### PR TITLE
Add React Webcola widget

### DIFF
--- a/src/components/WebcolaWidget.tsx
+++ b/src/components/WebcolaWidget.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef } from 'react';
+import { parseLayoutSpec } from '../layout/layoutspec';
+import { LayoutInstance } from '../layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../evaluators/sgq-evaluator';
+import { IInputDataInstance } from '../data-instance/interfaces';
+
+export interface WebcolaWidgetProps {
+  /** Data instance to visualize */
+  dataInstance: IInputDataInstance;
+  /** CND layout specification in YAML */
+  cndSpec: string;
+  /** Width of the graph element */
+  width?: number;
+  /** Height of the graph element */
+  height?: number;
+  /** Layout format attribute for the custom element */
+  layoutFormat?: string;
+}
+
+/**
+ * React wrapper around the <webcola-cnd-graph> custom element.
+ * This component mirrors the demo pipeline: it parses the CND spec,
+ * runs the SGraphQueryEvaluator, generates the layout and renders
+ * using the WebCola custom element.
+ */
+export const WebcolaWidget: React.FC<WebcolaWidgetProps> = ({
+  dataInstance,
+  cndSpec,
+  width = 800,
+  height = 600,
+  layoutFormat = 'default'
+}) => {
+  const graphRef = useRef<any>(null);
+
+  useEffect(() => {
+    const element = graphRef.current as any;
+    if (!element) return;
+
+    try {
+      // Parse layout specification
+      const layoutSpec = parseLayoutSpec(cndSpec);
+
+      // Run evaluation pipeline using SGQ evaluator
+      const evaluator = new SGraphQueryEvaluator();
+      evaluator.initialize({ dataInstance });
+
+      const layoutInstance = new LayoutInstance(
+        layoutSpec,
+        evaluator,
+        0,
+        true
+      );
+
+      const { layout } = layoutInstance.generateLayout(dataInstance, {});
+      element.renderLayout(layout);
+    } catch (err) {
+      console.error('WebcolaWidget render failed:', err);
+    }
+  }, [dataInstance, cndSpec]);
+
+  return (
+    <webcola-cnd-graph
+      ref={graphRef}
+      width={width}
+      height={height}
+      layoutFormat={layoutFormat}
+    ></webcola-cnd-graph>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,3 +95,5 @@ export const version = '1.0.0';
 // Export React components
 export { InstanceBuilder } from './components/InstanceBuilder/InstanceBuilder';
 export type { InstanceBuilderProps } from './components/InstanceBuilder/InstanceBuilder';
+export { WebcolaWidget } from './components/WebcolaWidget';
+export type { WebcolaWidgetProps } from './components/WebcolaWidget';


### PR DESCRIPTION
## Summary
- add `WebcolaWidget` React component that wraps the `webcola-cnd-graph` custom element
- export the new component from the main entry

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing ESLint deps)*
- `npm run typecheck` *(fails: missing TypeScript deps)*

------
https://chatgpt.com/codex/tasks/task_e_6866fd67a894832c852105a7d073300c