### PR TITLE
Fix tsup config for browser platform

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
   clean: true,
   minify: false,
   target: 'es2020',
+  // Assume a browser environment so DOM globals like HTMLElement are available
+  platform: 'browser',
   outDir: 'dist',
   external: ['react', 'react-dom'],
   bundle: true,


### PR DESCRIPTION
## Summary
- configure the default build for a browser environment

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e98f8393c832c8299016239126b39