### PR TITLE
Add layout + translator tests and vitest Vite config

### DIFF
--- a/tests/layout-instance.test.ts
+++ b/tests/layout-instance.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../src/evaluators/sgq-evaluator';
+
+const jsonData: IJsonDataInstance = {
+  atoms: [
+    { id: 'A', type: 'Type1', label: 'A' },
+    { id: 'B', type: 'Type1', label: 'B' }
+  ],
+  relations: [
+    {
+      id: 'r',
+      name: 'r',
+      types: ['Type1', 'Type1'],
+      tuples: [ { atoms: ['A', 'B'], types: ['Type1', 'Type1'] } ]
+    }
+  ]
+};
+
+const layoutSpecStr = `
+constraints:
+  - orientation:
+      selector: r
+      directions:
+        - right
+`;
+
+const layoutSpec = parseLayoutSpec(layoutSpecStr);
+
+function createEvaluator(instance: JSONDataInstance) {
+  const evaluator = new SGraphQueryEvaluator();
+  evaluator.initialize({ sourceData: instance });
+  return evaluator;
+}
+
+describe('LayoutInstance', () => {
+  it('generates layout from data', () => {
+    const instance = new JSONDataInstance(jsonData);
+    const evaluator = createEvaluator(instance);
+
+    const layoutInstance = new LayoutInstance(layoutSpec, evaluator, 0, true);
+    const { layout } = layoutInstance.generateLayout(instance, {});
+
+    expect(layout.nodes).toHaveLength(2);
+    expect(layout.edges).toHaveLength(1);
+    expect(layout.constraints.length).toBeGreaterThan(0);
+  });
+});
+

--- a/tests/pyret-data-instance.test.ts
+++ b/tests/pyret-data-instance.test.ts
@@ -188,9 +188,6 @@ describe('PyretDataInstance', () => {
         expect(relationNames).toContain('right');
 
         const leftRelation = relations.find(relation => relation.name === 'left');
-
-
+        expect(leftRelation).toBeDefined();
     });
-
- 
 });

--- a/tests/webcola-translator.test.ts
+++ b/tests/webcola-translator.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../src/evaluators/sgq-evaluator';
+import { WebColaTranslator } from '../src/translators/webcola/webcolatranslator';
+
+const jsonData: IJsonDataInstance = {
+  atoms: [
+    { id: 'A', type: 'Type1', label: 'A' },
+    { id: 'B', type: 'Type1', label: 'B' }
+  ],
+  relations: [
+    {
+      id: 'r',
+      name: 'r',
+      types: ['Type1', 'Type1'],
+      tuples: [ { atoms: ['A', 'B'], types: ['Type1', 'Type1'] } ]
+    }
+  ]
+};
+
+const layoutSpecStr = `
+constraints:
+  - orientation:
+      selector: r
+      directions:
+        - right
+`;
+
+const layoutSpec = parseLayoutSpec(layoutSpecStr);
+
+function createEvaluator(instance: JSONDataInstance) {
+  const evaluator = new SGraphQueryEvaluator();
+  evaluator.initialize({ sourceData: instance });
+  return evaluator;
+}
+
+describe('WebColaTranslator', () => {
+  it('translates layout to webcola format', async () => {
+    const instance = new JSONDataInstance(jsonData);
+    const evaluator = createEvaluator(instance);
+
+    const layoutInstance = new LayoutInstance(layoutSpec, evaluator, 0, true);
+    const { layout } = layoutInstance.generateLayout(instance, {});
+
+    const translator = new WebColaTranslator();
+    const result = await translator.translate(layout);
+
+    expect(result.colaNodes).toHaveLength(2);
+    expect(result.colaEdges).toHaveLength(1);
+    expect(result.colaConstraints.length).toBeGreaterThan(0);
+  });
+});
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- include React plugin for vitest so Vite can process tests
- clean up `pyret-data-instance` test
- add unit tests for `LayoutInstance`
- add unit tests for translating to WebCola

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686eb170d3ec832c8dea5d772312d849