### PR TITLE
bundle webcola vendor deps

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -6,8 +6,8 @@
 // Import the custom element class
 import { WebColaCnDGraph } from './translators/webcola/webcola-cnd-graph';
 // Import d3 and webcola to make them globally available
-import * as d3 from 'd3';
-import * as cola from 'webcola';
+import d3 from './vendor/d3.v4.min.js';
+import cola from './vendor/cola.js';
 
 // Make d3 and webcola available globally for WebCola d3adaptor
 if (typeof window !== 'undefined') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,8 @@ if (typeof window !== 'undefined') {
   import('./translators/webcola/webcola-cnd-graph').then(({ WebColaCnDGraph }) => {
     // Make d3 and webcola available globally for WebCola d3adaptor
     Promise.all([
-      import('d3'),
-      import('webcola')
+      import('./vendor/d3.v4.min.js'),
+      import('./vendor/cola.js')
     ]).then(([d3Module, colaModule]) => {
       (window as any).d3 = d3Module;
       (window as any).cola = colaModule;

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { EdgeWithMetadata, NodeWithMetadata, WebColaLayout, WebColaTranslator } from './webcolatranslator';
 import { InstanceLayout, isAlignmentConstraint, isLeftConstraint, isTopConstraint, LayoutNode } from '../../layout/interfaces';
-import { GridRouter, Group, Layout, Node, Link } from 'webcola';
+import type { GridRouter, Group, Layout, Node, Link } from 'webcola';
 
 // Import D3 v4 and WebCola from vendor files (bundled at build time)
 import d3 from '../../vendor/d3.v4.min.js';


### PR DESCRIPTION
## Summary
- use vendored d3 v4 and cola inside WebColaCnDGraph
- provide those vendored libs globally in browser entry points

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed4988220832cbc00bd35bec5d94c