### PR TITLE
Add generic evaluator repl component

### DIFF
--- a/src/components/EvaluatorRepl/EvaluatorRepl.css
+++ b/src/components/EvaluatorRepl/EvaluatorRepl.css
@@ -1,0 +1,60 @@
+.evaluator-repl {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  border-radius: 6px;
+  padding: 10px;
+  font-family: 'Courier New', 'Monaco', 'Menlo', monospace;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.evaluator-repl__output {
+  flex: 1;
+  overflow-y: auto;
+  border: 1px solid #333;
+  padding: 8px;
+  margin-bottom: 8px;
+  background: #252526;
+}
+
+.evaluator-repl__line.command {
+  color: #9cdcfe;
+}
+
+.evaluator-repl__line.result {
+  color: #ce9178;
+}
+
+.evaluator-repl__line.error {
+  color: #f48771;
+}
+
+.evaluator-repl__input {
+  display: flex;
+  gap: 8px;
+}
+
+.evaluator-repl__input textarea {
+  flex: 1;
+  resize: vertical;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  border: 1px solid #333;
+  padding: 6px;
+  border-radius: 4px;
+}
+
+.evaluator-repl__input button {
+  padding: 6px 12px;
+  background: #0e639c;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.evaluator-repl__input button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/src/components/EvaluatorRepl/EvaluatorRepl.tsx
+++ b/src/components/EvaluatorRepl/EvaluatorRepl.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useCallback, useRef } from 'react';
+import IEvaluator from '../../evaluators/interfaces';
+import './EvaluatorRepl.css';
+
+export interface EvaluatorReplProps {
+  /** Evaluator implementing the IEvaluator interface */
+  evaluator: IEvaluator;
+  /** Placeholder for the input box */
+  placeholder?: string;
+  /** Optional CSS class */
+  className?: string;
+  /** Optional style */
+  style?: React.CSSProperties;
+}
+
+interface ReplLine {
+  id: string;
+  type: 'command' | 'result' | 'error';
+  text: string;
+}
+
+export const EvaluatorRepl: React.FC<EvaluatorReplProps> = ({
+  evaluator,
+  placeholder = 'Enter expression and press Ctrl+Enter',
+  className = '',
+  style
+}) => {
+  const [input, setInput] = useState('');
+  const [lines, setLines] = useState<ReplLine[]>([]);
+  const outputRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollToBottom = () => {
+    const el = outputRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  };
+
+  const addLine = useCallback((line: Omit<ReplLine, 'id'>) => {
+    setLines(prev => [...prev, { ...line, id: `${Date.now()}-${Math.random()}` }]);
+    setTimeout(scrollToBottom, 0);
+  }, []);
+
+  const execute = useCallback(() => {
+    const expr = input.trim();
+    if (!expr) return;
+
+    addLine({ type: 'command', text: expr });
+    setInput('');
+
+    try {
+      const result = evaluator.evaluate(expr);
+      if (result.isError()) {
+        addLine({ type: 'error', text: result.prettyPrint() });
+      } else {
+        addLine({ type: 'result', text: result.prettyPrint() });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addLine({ type: 'error', text: msg });
+    }
+  }, [input, evaluator, addLine]);
+
+  const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      execute();
+    }
+  };
+
+  return (
+    <div className={`evaluator-repl ${className}`} style={style}>
+      <div className="evaluator-repl__output" ref={outputRef}>
+        {lines.map(l => (
+          <div key={l.id} className={`evaluator-repl__line ${l.type}`}>{l.text}</div>
+        ))}
+      </div>
+      <div className="evaluator-repl__input">
+        <textarea
+          value={input}
+          placeholder={placeholder}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKey}
+          rows={3}
+        />
+        <button onClick={execute} disabled={!input.trim()}>
+          Run
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EvaluatorRepl;

--- a/src/components/EvaluatorRepl/index.ts
+++ b/src/components/EvaluatorRepl/index.ts
@@ -1,0 +1,2 @@
+export { EvaluatorRepl } from './EvaluatorRepl';
+export type { EvaluatorReplProps } from './EvaluatorRepl';

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,10 @@ export type { CombinedInputConfig, CombinedInputProps } from './components/Combi
 export { mountCombinedInput, createCombinedInputSetup, setupCombinedInput } from './components/CombinedInput/mounting';
 export type { CombinedInputMountConfig } from './components/CombinedInput/mounting';
 
+// Export generic Evaluator REPL
+export { EvaluatorRepl } from './components/EvaluatorRepl';
+export type { EvaluatorReplProps } from './components/EvaluatorRepl';
+
 // Export REPL parsers
 export { PyretExpressionParser } from './components/ReplInterface/parsers/PyretExpressionParser';
 export type { PyretEvaluator, PyretEvaluationResult } from './components/ReplInterface/parsers/PyretExpressionParser';


### PR DESCRIPTION
## Summary
- add EvaluatorRepl component for evaluating expressions with any `IEvaluator`
- style EvaluatorRepl with basic CSS
- export EvaluatorRepl from library index

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817e7e09c4832cb1684c9d43a089c4