### PR TITLE
styling and EvaluatorREPL output fixes

### DIFF
--- a/src/components/EvaluatorRepl/EvaluatorRepl.css
+++ b/src/components/EvaluatorRepl/EvaluatorRepl.css
@@ -1,6 +1,14 @@
+.code-input {
+  font-family: monospace;
+}
+
 #repl-output {
   font-family: monospace; 
   white-space: pre-wrap; 
   max-height: 60vh; 
   overflow-y: auto;
+}
+
+#evaluator-input {
+  margin: 10px 0;
 }

--- a/src/components/EvaluatorRepl/EvaluatorRepl.tsx
+++ b/src/components/EvaluatorRepl/EvaluatorRepl.tsx
@@ -9,17 +9,18 @@ interface EvaluatorReplProps {
   instanceNumber: number
 }
 
-export const EvaluatorRepl: React.FC<EvaluatorReplProps> = ({ evaluator, instanceNumber }) => {
+type EvaluatorExecution = [string, string]
 
+export const EvaluatorRepl: React.FC<EvaluatorReplProps> = ({ evaluator, instanceNumber }) => {
   const [textInput, setTextInput] = React.useState('');
-  const [evaluatorOutput, setEvaluatorOutput] = React.useState<string[]>([]);
+  const [evaluatorOutput, setEvaluatorOutput] = React.useState<EvaluatorExecution[]>([]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault();
       // Evaluate the input expression
       const output = evaluator.evaluate(textInput, { instanceIndex: instanceNumber });
-      setEvaluatorOutput(prev => [output.prettyPrint(), ...prev]);
+      setEvaluatorOutput(prev => [[textInput, output.prettyPrint()], ...prev]);
       setTextInput(''); // Clear input after evaluation
     }
   }
@@ -27,6 +28,7 @@ export const EvaluatorRepl: React.FC<EvaluatorReplProps> = ({ evaluator, instanc
   return (
     <div id="evaluator-repl-container">
       <input 
+        className="code-input"
         id="evaluator-input" 
         type="text" 
         placeholder="Enter expression to evaluate..." 
@@ -35,8 +37,11 @@ export const EvaluatorRepl: React.FC<EvaluatorReplProps> = ({ evaluator, instanc
         onKeyDown={handleKeyDown}
       />
       <div id="repl-output">
-        {evaluatorOutput.map((line, index) => (
-          <p key={index} className="repl-output-line">{line}</p>
+        {evaluatorOutput.map(([textInput, output], index) => (
+          <React.Fragment key={index}>
+            <p className="repl-output-line">{`> ${textInput}`}</p>
+            <p className="repl-output-line">{output}</p>
+          </React.Fragment>
         ))}
       </div>
     </div>

--- a/src/components/NoCodeView/NoCodeView.css
+++ b/src/components/NoCodeView/NoCodeView.css
@@ -29,6 +29,10 @@
     background-color: transparent;
 }
 
+.code-input {
+    font-family: monospace;
+}
+
 /** Styles for informational labels */
 .infolabel {
     cursor: help; /* Changes the cursor to a question mark */

--- a/src/components/NoCodeView/Selectors/AttributeSelector.tsx
+++ b/src/components/NoCodeView/Selectors/AttributeSelector.tsx
@@ -45,7 +45,7 @@ export const AttributeSelector: React.FC<AttributeSelectorProps> = (props: Attri
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={props.directiveData.params.selector as string || ''}
           placeholder="Optional: target specific atoms (e.g., Person)"
           onChange={handleInputChange}

--- a/src/components/NoCodeView/Selectors/ColorAtomSelector.tsx
+++ b/src/components/NoCodeView/Selectors/ColorAtomSelector.tsx
@@ -35,7 +35,7 @@ export const ColorAtomSelector: React.FC<ColorAtomSelectorProps> = (props: Color
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           onChange={handleInputChange}
           required
         />

--- a/src/components/NoCodeView/Selectors/ColorEdgeSelector.tsx
+++ b/src/components/NoCodeView/Selectors/ColorEdgeSelector.tsx
@@ -42,7 +42,7 @@ export const ColorEdgeSelector: React.FC<ColorEdgeSelectorProps> = ({
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={selector}
           placeholder="Optional: target specific atoms (e.g., Person)"
           onChange={(e) => onUpdate({ params: { ...directiveData.params, selector: e.target.value || undefined } })}

--- a/src/components/NoCodeView/Selectors/CyclicSelector.tsx
+++ b/src/components/NoCodeView/Selectors/CyclicSelector.tsx
@@ -26,7 +26,7 @@ const CyclicSelector: React.FC<CyclicSelectorProps> = (props: CyclicSelectorProp
         <div className="input-group-prepend">
             <span className="input-group-text infolabel" title={TUPLE_SELECTOR_TEXT}>Selector</span>
         </div>
-        <input type="text" name="selector" className="form-control" required onChange={ handleParamsChange } value={props.constraintData.params.selector as string || ''}/>
+        <input type="text" name="selector" className="form-control code-input" required onChange={ handleParamsChange } value={props.constraintData.params.selector as string || ''}/>
     </div>
     <div className="input-group">
         <div className="input-group-prepend">

--- a/src/components/NoCodeView/Selectors/GroupByFieldSelector.tsx
+++ b/src/components/NoCodeView/Selectors/GroupByFieldSelector.tsx
@@ -44,7 +44,7 @@ export const GroupByFieldSelector: React.FC<GroupByFieldSelectorProps> = (props:
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={props.constraintData.params.selector as string || ''}
           placeholder="Optional: target specific atoms (e.g., Person)"
           onChange={handleInputChange}

--- a/src/components/NoCodeView/Selectors/GroupBySelectorSelector.tsx
+++ b/src/components/NoCodeView/Selectors/GroupBySelectorSelector.tsx
@@ -35,7 +35,7 @@ export const GroupBySelectorSelector: React.FC<GroupBySelectorSelectorProps> = (
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={props.constraintData.params.selector as string || ''}
           onChange={handleInputChange}
           required

--- a/src/components/NoCodeView/Selectors/HelperEdgeSelector.tsx
+++ b/src/components/NoCodeView/Selectors/HelperEdgeSelector.tsx
@@ -31,7 +31,7 @@ export const HelperEdgeSelector: React.FC<HelperEdgeSelectorProps> = ({
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={selector}
           onChange={(e) => onUpdate({ params: { ...directiveData.params, selector: e.target.value } })}
           required

--- a/src/components/NoCodeView/Selectors/HideAtomSelector.tsx
+++ b/src/components/NoCodeView/Selectors/HideAtomSelector.tsx
@@ -34,7 +34,7 @@ export const HideAtomSelector: React.FC<HideAtomSelectorProps> = (props: HideAto
       <input
         type="text"
         name="selector"
-        className="form-control"
+        className="form-control code-input"
         defaultValue={props.directiveData.params.selector as string || ''}
         onChange={handleInputChange}
         required

--- a/src/components/NoCodeView/Selectors/HideFieldSelector.tsx
+++ b/src/components/NoCodeView/Selectors/HideFieldSelector.tsx
@@ -45,7 +45,7 @@ export const HideFieldSelector: React.FC<HideFieldSelectorProps> = (props: HideF
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={props.directiveData.params.selector as string || ''}
           placeholder="Optional: target specific atoms (e.g., Person)"
           onChange={handleInputChange}

--- a/src/components/NoCodeView/Selectors/IconSelector.tsx
+++ b/src/components/NoCodeView/Selectors/IconSelector.tsx
@@ -31,7 +31,7 @@ export const IconSelector: React.FC<IconSelectorProps> = ({
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={selector}
           onChange={(e) => onUpdate({ params: { ...directiveData.params, selector: e.target.value } })}
           required

--- a/src/components/NoCodeView/Selectors/OrientationSelector.tsx
+++ b/src/components/NoCodeView/Selectors/OrientationSelector.tsx
@@ -46,7 +46,7 @@ export const OrientationSelector: React.FC<OrientationSelectorProps> = (props: O
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={props.constraintData.params.selector as string || ''}
           onChange={handleInputChange}
           required

--- a/src/components/NoCodeView/Selectors/SizeSelector.tsx
+++ b/src/components/NoCodeView/Selectors/SizeSelector.tsx
@@ -32,7 +32,7 @@ export const SizeSelector: React.FC<SizeSelectorProps> = ({
         <input
           type="text"
           name="selector"
-          className="form-control"
+          className="form-control code-input"
           defaultValue={selector}
           onChange={(e) => onUpdate({ params: { ...directiveData.params, selector: e.target.value } })}
           required

--- a/webcola-demo/react-component-integration.tsx
+++ b/webcola-demo/react-component-integration.tsx
@@ -1067,6 +1067,11 @@ export function mountEvaluatorRepl(containerId: string, evaluator: IEvaluator, i
     return false;
   }
 
+  if (!evaluator) {
+    console.error('Evaluator REPL: No evaluator provided');
+    return false;
+  }
+
   try {
     const root = createRoot(container);
     root.render(<EvaluatorRepl evaluator={evaluator} instanceNumber={instanceNumber}/>);


### PR DESCRIPTION
- Re-styled all text input elements (like the Evaluator REPL) to be in monospace font to have a consistency across all components. This meant modifying all the selector components in the No Code View.
- Changed the EvaluatorREPL to be a list of Tuples so ordering of output can be maintained.