### PR TITLE
Refine WebCola TLA demo pipeline

### DIFF
--- a/src/data-instance/tla/tla-data-instance.ts
+++ b/src/data-instance/tla/tla-data-instance.ts
@@ -1,0 +1,358 @@
+import { Graph } from 'graphlib';
+import type { IDataInstance, IAtom, IRelation, IType, ITuple } from '../interfaces';
+
+/**
+ * Normalized representation of a TLA+ value coming from a trace or state dump.
+ * The interface intentionally mirrors the minimal data commonly present in
+ * counterexample JSON emitted by tools like TLC/Apalache.
+ */
+export interface TlaValue {
+  /** Optional type label from the source tool (e.g., "Int", "Bool", "Set(Int)") */
+  readonly type?: string;
+  /** Raw value as emitted in the JSON trace */
+  readonly value: unknown;
+}
+
+/**
+ * A single state in a TLA+ execution trace.
+ */
+export interface TlaState {
+  /** Optional human friendly name (e.g., "Init", "Step 1") */
+  readonly name?: string;
+  /** Mapping of variable names to their values in this state */
+  readonly variables: Record<string, TlaValue | unknown>;
+}
+
+/**
+ * Top-level TLA+ datum describing a trace. Each state is converted into a
+ * `State` atom and each variable assignment becomes a relation tuple from the
+ * owning state atom to the atom representing the value.
+ */
+export interface TlaDatum {
+  readonly states: TlaState[];
+  /** Optional loop index (Apalache-style) to close the trace */
+  readonly loop?: number;
+}
+
+interface NormalizedTlaData {
+  atoms: IAtom[];
+  relations: IRelation[];
+  types: IType[];
+  builtinTypes: Set<string>;
+}
+
+/**
+ * IDataInstance implementation for TLA+ traces. The instance models:
+ * - `State` atoms for each step in the trace
+ * - Atoms for every variable value in each state
+ * - Variable-specific relations connecting states to their values
+ * - A `Next` relation connecting successive states (and the loop edge when present)
+ *
+ * Several TLA+ toolchains (e.g., TLC/Apalache) can emit DOT state graphs for
+ * debugging. The `State` atom + `Next` relation structure mirrors those exports
+ * so the generated graph can be visually compared against the DOT output using
+ * the existing DotDataInstance.
+ */
+export class TlaDataInstance implements IDataInstance {
+  private readonly atoms: IAtom[];
+  private readonly relations: IRelation[];
+  private readonly types: IType[];
+  private readonly builtinTypes: Set<string>;
+  private readonly datum: TlaDatum;
+
+  constructor(datum: TlaDatum, normalized?: NormalizedTlaData) {
+    this.datum = datum;
+
+    if (normalized) {
+      this.atoms = normalized.atoms;
+      this.relations = normalized.relations;
+      this.types = normalized.types;
+      this.builtinTypes = normalized.builtinTypes;
+    } else {
+      const processed = this.normalizeDatum(datum);
+      this.atoms = processed.atoms;
+      this.relations = processed.relations;
+      this.types = processed.types;
+      this.builtinTypes = processed.builtinTypes;
+    }
+  }
+
+  /** Get a type definition for a specific atom id. */
+  getAtomType(id: string): IType {
+    const atom = this.atoms.find(a => a.id === id);
+    if (!atom) {
+      throw new Error(`Atom with ID '${id}' not found in TLA+ datum.`);
+    }
+
+    const type = this.types.find(t => t.id === atom.type);
+    if (!type) {
+      throw new Error(`Type '${atom.type}' not found for atom '${id}'.`);
+    }
+
+    return type;
+  }
+
+  /** Return all known types. */
+  getTypes(): readonly IType[] {
+    return this.types;
+  }
+
+  /** Return all atoms. */
+  getAtoms(): readonly IAtom[] {
+    return this.atoms;
+  }
+
+  /** Return all relations. */
+  getRelations(): readonly IRelation[] {
+    return this.relations;
+  }
+
+  /** Create a projected instance containing only the requested atoms and their incident tuples. */
+  applyProjections(atomIds: string[]): IDataInstance {
+    const allowed = new Set(atomIds);
+    const atoms = this.atoms.filter(atom => allowed.has(atom.id));
+
+    const relations = this.relations
+      .map(relation => {
+        const tuples = relation.tuples.filter(tuple => tuple.atoms.every(atomId => allowed.has(atomId)));
+        if (tuples.length === 0) {
+          return null;
+        }
+        return { ...relation, tuples } as IRelation;
+      })
+      .filter((relation): relation is IRelation => relation !== null);
+
+    const types = this.rebuildTypes(atoms);
+
+    return new TlaDataInstance(this.datum, {
+      atoms,
+      relations,
+      types,
+      builtinTypes: new Set(this.builtinTypes),
+    });
+  }
+
+  /** Convert the instance into a graphlib Graph for layout algorithms. */
+  generateGraph(hideDisconnected: boolean = false, hideDisconnectedBuiltIns: boolean = false): Graph {
+    const graph = new Graph({ directed: true, multigraph: true });
+
+    this.atoms.forEach(atom => {
+      graph.setNode(atom.id, {
+        id: atom.id,
+        label: atom.label,
+        type: atom.type,
+        isBuiltin: this.isAtomBuiltin(atom),
+      });
+    });
+
+    this.relations.forEach(relation => {
+      relation.tuples.forEach((tuple, tupleIndex) => {
+        if (tuple.atoms.length >= 2) {
+          const sourceId = tuple.atoms[0];
+          const targetId = tuple.atoms[tuple.atoms.length - 1];
+          const edgeName = `${relation.id}_${tupleIndex}`;
+          graph.setEdge(sourceId, targetId, relation.name, edgeName);
+        } else if (tuple.atoms.length === 1) {
+          const atomId = tuple.atoms[0];
+          const edgeName = `${relation.id}_${tupleIndex}`;
+          graph.setEdge(atomId, atomId, relation.name, edgeName);
+        }
+      });
+    });
+
+    if (hideDisconnected || hideDisconnectedBuiltIns) {
+      const connectedNodes = new Set<string>();
+      graph.edges().forEach(edge => {
+        connectedNodes.add(edge.v);
+        connectedNodes.add(edge.w);
+      });
+
+      graph.nodes().forEach(node => {
+        const nodeData = graph.node(node) as { isBuiltin?: boolean } | undefined;
+        const isBuiltin = nodeData?.isBuiltin ?? false;
+        const shouldHide = hideDisconnected && !connectedNodes.has(node);
+        const shouldHideBuiltin = hideDisconnectedBuiltIns && isBuiltin && !connectedNodes.has(node);
+
+        if (shouldHide || shouldHideBuiltin) {
+          graph.removeNode(node);
+        }
+      });
+    }
+
+    return graph;
+  }
+
+  /** Normalize the raw datum into atoms, relations, and types. */
+  private normalizeDatum(datum: TlaDatum): NormalizedTlaData {
+    const atoms: IAtom[] = [];
+    const relationTuples = new Map<string, { name: string; types: string[]; tuples: ITuple[] }>();
+    const typeMap = new Map<string, IAtom[]>();
+    const builtinTypes = new Set<string>();
+
+    const registerType = (typeId: string, isBuiltin: boolean, atom: IAtom): void => {
+      if (!typeMap.has(typeId)) {
+        typeMap.set(typeId, []);
+      }
+      typeMap.get(typeId)!.push(atom);
+      if (isBuiltin) {
+        builtinTypes.add(typeId);
+      }
+    };
+
+    const stateType = 'State';
+
+    datum.states.forEach((state, index) => {
+      const stateId = `state_${index}`;
+      const stateAtom: IAtom = {
+        id: stateId,
+        type: stateType,
+        label: state.name ?? `State ${index + 1}`,
+      };
+      atoms.push(stateAtom);
+      registerType(stateType, true, stateAtom);
+
+      Object.entries(state.variables ?? {}).forEach(([varName, rawValue]) => {
+        const value = this.normalizeValue(rawValue);
+        const valueType = this.inferType(value);
+        const valueAtom: IAtom = {
+          id: `${stateId}.${varName}`,
+          type: valueType,
+          label: `${varName} = ${this.describeValue(value.value)}`,
+        };
+
+        atoms.push(valueAtom);
+        registerType(valueType, this.isBuiltinType(valueType), valueAtom);
+
+        const tuple: ITuple = {
+          atoms: [stateId, valueAtom.id],
+          types: [stateType, valueType],
+        };
+
+        if (!relationTuples.has(varName)) {
+          relationTuples.set(varName, {
+            name: varName,
+            types: [stateType, valueType],
+            tuples: [],
+          });
+        }
+
+        relationTuples.get(varName)!.tuples.push(tuple);
+      });
+    });
+
+    const relations: IRelation[] = Array.from(relationTuples.entries()).map(([id, relation]) => ({
+      id,
+      name: relation.name,
+      types: relation.types,
+      tuples: relation.tuples,
+    }));
+
+    const nextTuples: ITuple[] = [];
+    for (let i = 0; i < datum.states.length - 1; i++) {
+      nextTuples.push({ atoms: [`state_${i}`, `state_${i + 1}`], types: [stateType, stateType] });
+    }
+
+    if (datum.loop !== undefined && datum.loop >= 0 && datum.loop < datum.states.length) {
+      const lastIndex = datum.states.length - 1;
+      nextTuples.push({ atoms: [`state_${lastIndex}`, `state_${datum.loop}`], types: [stateType, stateType] });
+    }
+
+    if (nextTuples.length > 0) {
+      relations.push({ id: 'Next', name: 'Next', types: [stateType, stateType], tuples: nextTuples });
+    }
+
+    const types: IType[] = Array.from(typeMap.entries()).map(([typeId, atomsForType]) => ({
+      id: typeId,
+      types: [typeId],
+      atoms: atomsForType,
+      isBuiltin: builtinTypes.has(typeId),
+    }));
+
+    return { atoms, relations, types, builtinTypes };
+  }
+
+  private rebuildTypes(atoms: IAtom[]): IType[] {
+    const typeMap = new Map<string, IAtom[]>();
+
+    atoms.forEach(atom => {
+      if (!typeMap.has(atom.type)) {
+        typeMap.set(atom.type, []);
+      }
+      typeMap.get(atom.type)!.push(atom);
+    });
+
+    return Array.from(typeMap.entries()).map(([typeId, atomsForType]) => ({
+      id: typeId,
+      types: [typeId],
+      atoms: atomsForType,
+      isBuiltin: this.builtinTypes.has(typeId),
+    }));
+  }
+
+  private normalizeValue(raw: TlaValue | unknown): TlaValue {
+    if (raw && typeof raw === 'object' && 'value' in (raw as Record<string, unknown>)) {
+      return raw as TlaValue;
+    }
+    return { value: raw as unknown };
+  }
+
+  private inferType(value: TlaValue): string {
+    if (value.type && value.type.trim().length > 0) {
+      return value.type.trim();
+    }
+
+    const val = value.value;
+    if (Array.isArray(val)) {
+      return 'Seq';
+    }
+
+    switch (typeof val) {
+      case 'number':
+        return Number.isInteger(val) ? 'Int' : 'Real';
+      case 'boolean':
+        return 'Bool';
+      case 'string':
+        return 'String';
+      case 'object':
+        return val === null ? 'Null' : 'Record';
+      default:
+        return 'Unknown';
+    }
+  }
+
+  private describeValue(val: unknown): string {
+    if (typeof val === 'string') {
+      return val;
+    }
+    if (typeof val === 'number' || typeof val === 'boolean' || val === null) {
+      return String(val);
+    }
+    try {
+      return JSON.stringify(val);
+    } catch {
+      return String(val);
+    }
+  }
+
+  private isBuiltinType(typeId: string): boolean {
+    return ['State', 'Int', 'Real', 'Bool', 'String'].includes(typeId);
+  }
+
+  private isAtomBuiltin(atom: IAtom): boolean {
+    return this.builtinTypes.has(atom.type);
+  }
+}
+
+/**
+ * Factory to create an IDataInstance from a TLA+ datum.
+ */
+export function createTlaDataInstance(datum: TlaDatum): IDataInstance {
+  return new TlaDataInstance(datum);
+}
+
+/**
+ * Type guard for narrowing IDataInstance to TlaDataInstance.
+ */
+export function isTlaDataInstance(instance: IDataInstance): instance is TlaDataInstance {
+  return instance instanceof TlaDataInstance;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { AlloyDataInstance, createEmptyAlloyDataInstance } from './data-instance
 export { DotDataInstance } from './data-instance/dot/dot-data-instance';
 export { RacketGDataInstance } from './data-instance/racket/racket-g-data-instance';
 export { PyretDataInstance } from './data-instance/pyret/pyret-data-instance';
+export { TlaDataInstance, createTlaDataInstance, isTlaDataInstance } from './data-instance/tla/tla-data-instance';
 
 // Direct exports of key classes for convenience
 export { LayoutInstance } from './layout/layoutinstance';

--- a/webcola-demo/webcola-tla-demo.html
+++ b/webcola-demo/webcola-tla-demo.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebCola TLA+ Trace Demo</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+    .container {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+      margin-bottom: 18px;
+    }
+    textarea {
+      width: 100%;
+      min-height: 160px;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      font-size: 13px;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 12px;
+      box-sizing: border-box;
+      background: #fafafa;
+    }
+    button {
+      background: #007bff;
+      color: white;
+      border: none;
+      padding: 10px 16px;
+      border-radius: 4px;
+      cursor: pointer;
+      margin-right: 10px;
+    }
+    button:hover { background: #0056b3; }
+    .status {
+      margin-top: 10px;
+      padding: 10px 12px;
+      border-radius: 6px;
+      background: #e3f2fd;
+      color: #0d47a1;
+    }
+    #tla-demo-container {
+      height: 780px;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      margin-top: 16px;
+      background: white;
+    }
+    #graph-controls {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 10px;
+    }
+    #graph-controls select {
+      padding: 6px 8px;
+      border-radius: 4px;
+      border: 1px solid #ddd;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>WebCola TLA+ Trace Demo</h1>
+    <p>
+      Paste a TLA+ trace export (e.g., the JSON from Apalache/TLC) and a CnD layout
+      specification. The page runs the same Alloy-style pipeline: <code>TlaDataInstance</code>
+      → <code>SGraphQueryEvaluator</code> (SGQ) → <code>LayoutInstance</code> →
+      <code>&lt;webcola-cnd-graph&gt;</code>. No CombinedInput wrapper required.
+    </p>
+
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px;">
+      <div>
+        <h3>Trace JSON</h3>
+        <textarea id="tla-trace" aria-label="TLA+ trace JSON"></textarea>
+        <p style="margin-top: 6px; color: #555;">
+          Expect the standard <code>{ states: [...], loop?: number }</code> shape. Each state
+          maps variable names to values (optionally tagged with <code>type</code>), mirroring the
+          DOT-style state graphs most TLA+ tools export.
+        </p>
+      </div>
+      <div>
+        <h3>Layout Specification</h3>
+        <textarea id="tla-cnd" aria-label="CnD layout spec"></textarea>
+      </div>
+    </div>
+
+    <div style="margin-top: 12px; display: flex; align-items: center; gap: 12px;">
+      <button onclick="runTlaPipeline()">Apply Layout</button>
+      <button onclick="resetTlaInputs()" style="background:#6c757d;">Reset Sample</button>
+      <button onclick="clearTlaGraph()" style="background:#dc3545;">Clear Graph</button>
+      <div id="tla-status" class="status">Ready to load sample trace.</div>
+    </div>
+
+    <div id="graph-controls">
+      <label for="layoutFormat">Layout:</label>
+      <select id="layoutFormat" onchange="changeLayoutFormat()">
+        <option value="default" selected>Standard</option>
+        <option value="grid">Grid (beta)</option>
+      </select>
+    </div>
+
+    <div id="tla-demo-container">
+      <webcola-cnd-graph
+        id="tla-graph"
+        width="1000"
+        height="720"
+        layoutFormat="default"
+        aria-label="TLA+ graph">
+      </webcola-cnd-graph>
+    </div>
+
+    <div id="relation-highlighter-mount" class="container" style="margin-top: 12px;"></div>
+    <div id="error-messages"></div>
+
+    <div class="container" style="margin-top: 18px;">
+      <h3>SGQ REPL</h3>
+      <p class="text-muted" style="margin-top: -6px;">Runs Simple Graph Query expressions against the current TLA+ data instance.</p>
+      <div id="tla-repl"></div>
+    </div>
+  </div>
+
+  <!-- D3 v4 and WebCola - the working combination -->
+  <script src="https://d3js.org/d3.v4.min.js"></script>
+  <script src="../vendor/cola.js"></script>
+
+  <!-- Spytial Core Library (browser build) -->
+  <script src="../dist/browser/spytial-core-complete.global.js"></script>
+  <link rel="stylesheet" href="../dist/browser/spytial-core-complete.css">
+
+  <!-- React component helpers (REPL, highlighter, error modal) -->
+  <script src="../dist/components/react-component-integration.global.js"></script>
+  <link rel="stylesheet" href="../dist/components/react-component-integration.css">
+
+  <script>
+    const SAMPLE_TRACE = JSON.stringify({
+      states: [
+        {
+          name: 'Init',
+          variables: {
+            pc: { value: 'Init', type: 'Str' },
+            counter: { value: 0, type: 'Int' },
+            locked: { value: false, type: 'Bool' }
+          }
+        },
+        {
+          name: 'Tick',
+          variables: {
+            pc: { value: 'Step', type: 'Str' },
+            counter: { value: 1, type: 'Int' },
+            locked: { value: true, type: 'Bool' }
+          }
+        },
+        {
+          name: 'Loop',
+          variables: {
+            pc: { value: 'Step', type: 'Str' },
+            counter: { value: 2, type: 'Int' },
+            locked: { value: false, type: 'Bool' }
+          }
+        }
+      ],
+      loop: 1
+    }, null, 2);
+
+    const SAMPLE_CND = `constraints:\n  - orientation:\n      selector: Next\n      directions:\n        - right\ndirectives:\n  - flag: hideDisconnectedBuiltIns\n  - flag: hideDisconnected\n  - label:\n      selector: State\n      property: name`;
+
+    let tlaDataInstance = null;
+    let sgqEvaluator = null;
+    let layoutSpec = null;
+    let currentLayout = null;
+
+    /** Reset inputs back to the baked-in samples. */
+    function resetTlaInputs() {
+      document.getElementById('tla-trace').value = SAMPLE_TRACE;
+      document.getElementById('tla-cnd').value = SAMPLE_CND;
+      updateTlaStatus('Ready to load sample trace.', 'info');
+      clearTlaGraph();
+    }
+
+    /** Update the status banner. */
+    function updateTlaStatus(message, type = 'info') {
+      const statusEl = document.getElementById('tla-status');
+      statusEl.textContent = message;
+      statusEl.style.background = type === 'error' ? '#ffebee' : '#e3f2fd';
+      statusEl.style.color = type === 'error' ? '#c62828' : '#0d47a1';
+    }
+
+    /** Change the layout format on the fly. */
+    async function changeLayoutFormat() {
+      const graphElement = document.getElementById('tla-graph');
+      const layoutFormat = document.getElementById('layoutFormat').value;
+      graphElement.setAttribute('layoutFormat', layoutFormat);
+
+      if (currentLayout) {
+        await graphElement.renderLayout(currentLayout);
+      }
+    }
+
+    /** Clear the rendered graph. */
+    function clearTlaGraph() {
+      const graphElement = document.getElementById('tla-graph');
+      if (graphElement?.clear) {
+        graphElement.clear();
+      }
+      currentLayout = null;
+    }
+
+    /** Kick off the TLA+ pipeline without the CombinedInput wrapper. */
+    async function runTlaPipeline() {
+      try {
+        updateTlaStatus('Parsing TLA+ trace...', 'info');
+        const traceText = document.getElementById('tla-trace').value.trim();
+        const cndSpec = document.getElementById('tla-cnd').value.trim();
+
+        if (!traceText) {
+          throw new Error('Please paste a TLA+ trace JSON document.');
+        }
+        if (!cndSpec) {
+          throw new Error('Please provide a CnD layout specification.');
+        }
+
+        const trace = JSON.parse(traceText);
+        tlaDataInstance = new window.CndCore.TlaDataInstance(trace);
+
+        updateTlaStatus('Initializing SGQ evaluator...', 'info');
+        sgqEvaluator = new window.CndCore.SGraphQueryEvaluator();
+        sgqEvaluator.initialize({ sourceData: tlaDataInstance });
+
+        // Mount REPL to inspect selectors
+        if (window.mountEvaluatorRepl) {
+          window.mountEvaluatorRepl('tla-repl', sgqEvaluator, 0);
+        }
+
+        updateTlaStatus('Parsing layout specification...', 'info');
+        try {
+          layoutSpec = window.CndCore.parseLayoutSpec(cndSpec);
+          if (window.clearAllErrors) {
+            window.clearAllErrors();
+          }
+        } catch (error) {
+          if (window.showParseError) {
+            window.showParseError(error.message, 'Layout Specification');
+          }
+          throw error;
+        }
+
+        updateTlaStatus('Generating layout with SGQ evaluator...', 'info');
+        const layoutInstance = new window.CndCore.LayoutInstance(layoutSpec, sgqEvaluator, 0, true);
+        const layoutResult = layoutInstance.generateLayout(tlaDataInstance, {});
+
+        if (layoutResult.error) {
+          if (layoutResult.error.errorMessages && window.showPositionalError) {
+            window.showPositionalError(layoutResult.error.errorMessages);
+          } else if (layoutResult.error.overlappingNodes && window.showGroupOverlapError) {
+            window.showGroupOverlapError(layoutResult.error.message);
+          } else if (window.showGeneralError) {
+            window.showGeneralError(`Layout generation error: ${layoutResult.error.message}`);
+          }
+          throw new Error(layoutResult.error.message);
+        }
+
+        currentLayout = layoutResult.layout;
+
+        updateTlaStatus('Rendering WebCola graph...', 'info');
+        const graphElement = document.getElementById('tla-graph');
+        await graphElement.renderLayout(currentLayout);
+        updateTlaStatus('TLA+ graph rendered. Adjust the trace or layout spec to iterate.', 'success');
+      } catch (error) {
+        console.error('Failed to run TLA demo', error);
+        updateTlaStatus(`Error: ${error.message}`, 'error');
+      }
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+      resetTlaInputs();
+      if (window.mountRelationHighlighter) {
+        window.mountRelationHighlighter('relation-highlighter-mount', 'tla-graph');
+      }
+      if (window.mountErrorMessageModal) {
+        window.mountErrorMessageModal('error-messages');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redo the TLA+ WebCola demo to mirror the Alloy pipeline using TlaDataInstance, SGQ evaluator, and LayoutInstance
- include sample trace/layout inputs, status controls, layout switching, and SGQ REPL plus relation-highlighter/error mounts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931756f133c832ca90d5e8f89f6cf0b)