### PR TITLE
Validate size constraints and align NoCode size defaults

### DIFF
--- a/src/components/NoCodeView/Selectors/SizeSelector.tsx
+++ b/src/components/NoCodeView/Selectors/SizeSelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UNARY_SELECTOR_TEXT } from '../constants';
+import { DEFAULT_NODE_HEIGHT, DEFAULT_NODE_WIDTH, UNARY_SELECTOR_TEXT } from '../constants';
 import { DirectiveData, ConstraintData } from '../interfaces';
 import { SelectorInput, SelectorChangeEvent } from './SelectorInput';
 
@@ -26,8 +26,8 @@ export const SizeSelector: React.FC<SizeSelectorProps> = ({
   }
   
   const selector = (data.params.selector as string) || '';
-  const width = (data.params.width as number) || 10;
-  const height = (data.params.height as number) || 10;
+  const width = typeof data.params.width === 'number' ? data.params.width : DEFAULT_NODE_WIDTH;
+  const height = typeof data.params.height === 'number' ? data.params.height : DEFAULT_NODE_HEIGHT;
 
   const handleSelectorChange = (event: SelectorChangeEvent) => {
     onUpdate({ params: { ...data.params, selector: event.target.value } });

--- a/src/components/NoCodeView/constants.ts
+++ b/src/components/NoCodeView/constants.ts
@@ -8,3 +8,5 @@ export const GROUPING_SELECTOR_DESCRIPTION = "Group elements based on a selector
 export const GROUPING_FIELD_DESCRIPTION = "Group elements based on a field."
 export const SIZE_DESCRIPTION = "Set the width and height of elements matching the selector."
 export const HIDEATOM_DESCRIPTION = "Hide elements matching the selector from the visualization."
+export const DEFAULT_NODE_WIDTH = 100;
+export const DEFAULT_NODE_HEIGHT = 60;

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -282,6 +282,21 @@ interface DirectivesBlock {
     hideDisconnectedBuiltIns : boolean;
 }
 
+function assertPositiveSizeDimension(value: unknown, label: string): void {
+    if (value === undefined || value === null) {
+        return;
+    }
+
+    if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {
+        throw new Error(`Size ${label} must be greater than 0`);
+    }
+}
+
+function assertValidSizeParams(size: Record<string, unknown>, context: string): void {
+    assertPositiveSizeDimension(size.width, `${context} width`);
+    assertPositiveSizeDimension(size.height, `${context} height`);
+}
+
 
 export interface LayoutSpec {
 
@@ -374,11 +389,14 @@ export function parseLayoutSpec(s: string): LayoutSpec {
           // Also extract size and hideAtom from constraints
           const typedConstraints = constraints as Record<string, any>[];
           sizesFromConstraints = typedConstraints.filter(c => c.size)
-            .map(c => ({
-                height: c.size.height,
-                width: c.size.width,
-                selector: c.size.selector
-            }));
+            .map(c => {
+                assertValidSizeParams(c.size, "constraint");
+                return {
+                    height: c.size.height,
+                    width: c.size.width,
+                    selector: c.size.selector
+                };
+            });
           
           hiddenAtomsFromConstraints = typedConstraints.filter(c => c.hideAtom)
             .map(c => ({
@@ -708,11 +726,12 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
 
     let sizes : AtomSizeDirective[] = typedDirectives.filter(d => d.size)
                 .map(d => {
+                    assertValidSizeParams(d.size, "directive");
                     return {
                         height: d.size.height,
                         width: d.size.width,
                         selector: d.size.selector
-                    }
+                    };
                 });
     
     let edgeColors : EdgeColorDirective[] = typedDirectives.filter(d => d.edgeColor)


### PR DESCRIPTION
### Motivation

- Prevent nonsensical size specs by rejecting width/height values that are not positive when parsing layout YAML via `parseLayoutSpec`.
- Keep the NoCode UI consistent with the runtime defaults by using the actual default node dimensions instead of the previous magic number defaults.

### Description

- Add `assertPositiveSizeDimension` and `assertValidSizeParams` helpers in `src/layout/layoutspec.ts` to validate size dimensions and raise `Error` for non-positive values.
- Invoke `assertValidSizeParams` when extracting sizes from both constraints and directives inside `parseLayoutSpec`/`parseDirectives` in `src/layout/layoutspec.ts` to enforce validation on parsed YAML sizes.
- Export `DEFAULT_NODE_WIDTH` and `DEFAULT_NODE_HEIGHT` from `src/components/NoCodeView/constants.ts` and update the NoCode size editor to use these constants in `src/components/NoCodeView/Selectors/SizeSelector.tsx` instead of the previous fallback of `10`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e631a26f0832c84e72adabf7f953e)