### PR TITLE
Improve grid routing stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",


### PR DESCRIPTION
### Motivation
- Grid routing was failing or producing incorrect paths when node/group bounds were missing or when edges lacked router nodes, causing runtime errors and poor label placement.
- Route/label updates assumed a 1:1 ordering between computed routes and original edges which could lead to mismatches and crashes.

### Description
- Add defensive bounds handling with `createFallbackBounds`, call `ensureNodeBounds()` before routing, and accept optional `nodes`/`groups` arrays in `route()` to avoid null inputs.
- Warn when group bounds are missing and build `gridRouterNodes` while filtering out entries without `routerNode` to prevent GridRouter node explosions.
- In `gridify()` early-return when there are no nodes/edges, filter to `routableEdges` (edges with `source.routerNode` and `target.routerNode`), and map routes by `edge.id` so routes stay associated with the correct edges.
- Update existing `.link-group` selections instead of blindly recreating DOM, compute path `d` from the GridRouter route or fall back to a straight line, and replace `gridUpdateLinkLabels()` with a version that looks up midpoints via `getGridRouteMidpoint()` using the `routesByEdgeId` map.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697678cf18bc832c8d7f880586cff7fe)