### PR TITLE
Enable minification for tsup builds

### DIFF
--- a/tsup.browser.config.ts
+++ b/tsup.browser.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: false, // Don't clean dist folder (preserve other builds)
-  minify: false, // Keep readable for debugging
+  minify: true, // Minify for production bundle size
   target: 'es2020',
   outDir: 'dist/browser',
   external: ['react', 'react-dom'], // Bundle everything, except React

--- a/tsup.components.config.ts
+++ b/tsup.components.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   globalName: 'IntegratedDemo',
   outDir: 'dist/components',
   clean: true,
-  minify: false, // Set to true for production
+  minify: true, // Minify for production bundle size
   sourcemap: true,
   // external: ['react', 'react-dom'], // Remove this line to bundle React
   target: 'es2020',

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,  // Enable sourcemaps for debugging
   clean: true,
-  minify: false,
+  minify: true,
   target: 'es2020',
   outDir: 'dist',
   external: ['react', 'react-dom'],


### PR DESCRIPTION
### Motivation
- Reduce production bundle size by enabling minification in tsup configs for core, browser, and demo component builds.

### Description
- Set `minify: true` in `tsup.config.ts`, `tsup.browser.config.ts`, and `tsup.components.config.ts` to enable minification for production bundles.

### Testing
- No automated tests were run for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697377cbdddc832cb9bba39f0122c724)