### PR TITLE
Node label background fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -2299,9 +2299,11 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       .attr("fill", (d: any) => {
         const isHidden = this.isHiddenNode(d);
         const hasIcon = !! d.icon;
+        const showLabels = d.showLabels;
         
-        const fill = isHidden || hasIcon ? "transparent" : "white";
-        //console.log(`Node ${d.id} - isHidden: ${isHidden}, hasIcon: ${hasIcon} ${d.icon}, fill: ${fill}`);
+        // Only make transparent if hidden OR (has icon AND not showing labels)
+        // When showLabels is true, keep white background even with icons
+        const fill = isHidden || (hasIcon && !showLabels) ? "transparent" : "white";
 
         return fill;
       });


### PR DESCRIPTION
When 'show labels' was true, the background of nodes was transparent. Fixing/defaulting to white.