### PR TITLE
Clamp dense edge routing offsets and curvature

### DIFF
--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -3961,7 +3961,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     const dx = route[1].x - route[0].x;
     const dy = route[1].y - route[0].y;
     const angle = Math.atan2(dy, dx);
-    const distance = Math.sqrt(dx * dx + dy * dy);
+    const distance = this.getRouteLength(route);
 
     // Find edge index once and reuse for both offset and curvature
     const edgeIndex = allEdgesBetweenNodes.findIndex(edge => edge.id === edgeData.id);
@@ -4062,9 +4062,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    */
   private applyEdgeOffset(edgeData: any, route: Array<{ x: number; y: number }>, allEdges: any[], angle: number): Array<{ x: number; y: number }> {
     const edgeIndex = allEdges.findIndex(edge => edge.id === edgeData.id);
-    const dx = route[route.length - 1].x - route[0].x;
-    const dy = route[route.length - 1].y - route[0].y;
-    const distance = Math.sqrt(dx * dx + dy * dy);
+    const distance = this.getRouteLength(route);
     return this.applyEdgeOffsetWithIndex(edgeData, route, allEdges, angle, edgeIndex, distance);
   }
 
@@ -4112,6 +4110,22 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   private clampOffset(offset: number, distance: number): number {
     const maxOffset = Math.max(WebColaCnDGraph.MIN_EDGE_DISTANCE, distance * WebColaCnDGraph.MAX_EDGE_OFFSET_RATIO);
     return Math.max(-maxOffset, Math.min(maxOffset, offset));
+  }
+
+  /**
+   * Calculates total route length to avoid clamping based on a short first segment.
+   */
+  private getRouteLength(route: Array<{ x: number; y: number }>): number {
+    if (route.length < 2) {
+      return 0;
+    }
+
+    return route.slice(1).reduce((total, point, index) => {
+      const prev = route[index];
+      const dx = point.x - prev.x;
+      const dy = point.y - prev.y;
+      return total + Math.sqrt(dx * dx + dy * dy);
+    }, 0);
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Edge routing for graphs with many parallel edges produced excessively large offsets and curvatures that made bundled edges bulge far from nodes. 
- The change aims to limit offset and curvature magnitude based on route distance to keep dense bundles visually stable and avoid extreme arcs.

### Description
- Added new routing constants `MAX_EDGE_OFFSET_RATIO` and `MAX_EDGE_CURVATURE_RATIO` and helper clamp methods `clampOffset` and `clampCurvature` in `src/translators/webcola/webcola-cnd-graph.ts`.
- Updated `handleMultipleEdgeRouting` to compute route `distance` and pass it into `applyEdgeOffsetWithIndex`, and to apply a capped curvature via `clampCurvature` before calling `applyCurvatureToRoute`.
- Modified `applyEdgeOffset` / `applyEdgeOffsetWithIndex` to accept the route `distance` and use `clampOffset` so offsets are limited relative to the edge length.
- All changes are localized to `src/translators/webcola/webcola-cnd-graph.ts` and preserve the existing offset/curvature computation while capping extremes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e12a3a0f4832c9df17f1c7621d113)