### PR TITLE
Hide alignment edge rendering

### DIFF
--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -1748,10 +1748,14 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         return "link";
       })
       .attr("data-link-id", (d: any) => d.id || "")
-      .attr("stroke", (d: any) => d.color)
+      .attr("stroke", (d: any) => this.isAlignmentEdge(d) ? "none" : d.color)
       .attr("fill", "none")
       // Use .style() for stroke-width so inline styles override CSS class rules (.link, .inferredLink)
-      .style("stroke-width", (d: any) => d.weight != null ? `${d.weight}px` : null)
+      .style("stroke-width", (d: any) => {
+        if (this.isAlignmentEdge(d)) return 0;
+        return d.weight != null ? `${d.weight}px` : null;
+      })
+      .style("opacity", (d: any) => this.isAlignmentEdge(d) ? 0 : null)
       .attr("stroke-dasharray", (d: any) => this.getEdgeDasharray(d.style))
       .attr("marker-end", (d: any) => {
         if (this.isAlignmentEdge(d)) return "none";


### PR DESCRIPTION
### Motivation
- Alignment constraint edges (those with ids/prefix `_alignment_`) were rendering visibly in the graph and should always be hidden so they don't distract from normal edges or block pointer events.

### Description
- In `src/translators/webcola/webcola-cnd-graph.ts` inside `setupLinkPaths`, alignment edges are forced to render invisibly by setting `stroke` to `none`, `stroke-width` to `0`, and `opacity` to `0` for alignment links while leaving other edge styling unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e8e993f8832ca31d30c64a19f1e5)