### PR TITLE
Add spytial-ts scaffold

### DIFF
--- a/spytial-ts/.gitignore
+++ b/spytial-ts/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/spytial-ts/README.md
+++ b/spytial-ts/README.md
@@ -1,0 +1,22 @@
+# spytial-ts
+
+TypeScript decorator-first helpers for SpyTial/Spytial Core.
+
+## Goals
+- Provide a decorator API that maps directly to SpyTial operators.
+- Keep runtime thin by delegating execution to `spytial-core`.
+- Offer non-decorator helpers for environments that cannot enable decorators.
+
+## Status
+Scaffolding only. Implementation will live in `src/` as the API is designed.
+
+## Development
+```bash
+npm install
+npm run build
+```
+
+## Roadmap
+- Define decorator contracts and core operator registry.
+- Add runtime adapters for diagram invocation.
+- Publish as a companion package to `spytial-core`.

--- a/spytial-ts/package.json
+++ b/spytial-ts/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "spytial-ts",
+  "version": "0.0.1",
+  "description": "Decorator-first TypeScript helpers for Spytial",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "spytial-core": "^1.8.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/spytial-ts/src/index.ts
+++ b/spytial-ts/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Public entry point for spytial-ts.
+ *
+ * This package will expose decorator helpers that map to Spytial operators.
+ * Implementation is intentionally left as a placeholder until the API is finalized.
+ */
+
+export type OperatorDecorator = (...args: unknown[]) => ClassDecorator | MethodDecorator | PropertyDecorator;
+
+export interface OperatorRegistry {
+  register: (name: string, decoratorFactory: OperatorDecorator) => void;
+  get: (name: string) => OperatorDecorator | undefined;
+}
+
+export const createOperatorRegistry = (): OperatorRegistry => {
+  const registry = new Map<string, OperatorDecorator>();
+
+  return {
+    register: (name, decoratorFactory) => {
+      registry.set(name, decoratorFactory);
+    },
+    get: (name) => registry.get(name),
+  };
+};

--- a/spytial-ts/tsconfig.json
+++ b/spytial-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Motivation
- Introduce a companion TypeScript package to host decorator-first helpers that map to Spytial operators and keep runtime behavior delegated to `spytial-core`.
- Provide a minimal scaffold so the API shape can be iterated on while keeping the runtime thin and implementation work isolated to `spytial-ts`.

### Description
- Add `spytial-ts` package directory with `README.md` documenting goals, status, and roadmap for decorator-based helpers.
- Add `package.json` with package metadata and `build`/`typecheck` scripts and `tsconfig.json` to configure TypeScript outputs to `dist`.
- Add `src/index.ts` exporting `OperatorDecorator` and an `OperatorRegistry` implementation via `createOperatorRegistry` as a placeholder API.
- Add `.gitignore` to ignore `node_modules/` and `dist/`.

### Testing
- No automated tests were run; this is scaffold-only and contains only initial files and API placeholders.
- `build` and `typecheck` scripts are provided in `package.json` for future CI validation but were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698345403b60832c9b154d5bae2c3168)