### PR TITLE
Fix CnD graph viewport offset on fit-to-view

### DIFF
--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -731,11 +731,6 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    * Initialize the Shadow DOM structure
    */
   private initializeDOM(): void {
-    // Get actual container dimensions for responsive sizing
-    const containerRect = this.getBoundingClientRect();
-    const containerWidth = containerRect.width || 800;
-    const containerHeight = containerRect.height || 600;
-    
     this.shadowRoot!.innerHTML = `
       <style>
       ${this.getCSS()}
@@ -763,7 +758,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         <span class="loading-dot" aria-hidden="true"></span>
         <span id="loading-progress">Computing layout...</span>
       </div>
-      <svg id="svg" viewBox="0 0 ${containerWidth} ${containerHeight}" preserveAspectRatio="xMidYMid meet">
+      <svg id="svg">
         <defs>
         <marker id="end-arrow" markerWidth="15" markerHeight="10" refX="12" refY="5" orient="auto" markerUnits="userSpaceOnUse">
           <polygon points="0 0, 15 5, 0 10" fill="context-stroke" />


### PR DESCRIPTION
## Summary
- Removed `viewBox` and `preserveAspectRatio` attributes from the CnD graph SVG element
- The viewBox was initialized from the full web component dimensions (including toolbar), but D3 zoom operates in the SVG's pixel coordinate space (excluding toolbar). This mismatch, combined with `preserveAspectRatio="xMidYMid meet"`, created an implicit offset that shifted content to the right when using "fit to size"
- Without viewBox, D3 zoom manages all transforms directly in pixel space — the standard D3 zoom pattern — eliminating the coordinate system conflict

## Test plan
- [x] All 1011 existing tests pass
- [x] Build succeeds
- [ ] Load an example CnD graph and verify "fit to size" centers content correctly
- [ ] Verify pan/zoom still works normally
- [ ] Verify screenshot export still works (already handles missing viewBox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)