### PR TITLE
Deprecate Kiwi validator, make qualitative validator the default

### DIFF
--- a/src/layout/constraint-types.ts
+++ b/src/layout/constraint-types.ts
@@ -1,0 +1,204 @@
+import { InstanceLayout, LayoutNode, LayoutEdge, LayoutGroup, LayoutConstraint, isLeftConstraint, isTopConstraint, isAlignmentConstraint, isBoundingBoxConstraint, isGroupBoundaryConstraint, TopConstraint, LeftConstraint, AlignmentConstraint, BoundingBoxConstraint, GroupBoundaryConstraint, ImplicitConstraint } from './interfaces';
+import { RelativeOrientationConstraint, CyclicOrientationConstraint, AlignConstraint, GroupByField, GroupBySelector } from './layoutspec';
+
+
+export type SourceConstraint = RelativeOrientationConstraint | CyclicOrientationConstraint | AlignConstraint | ImplicitConstraint | GroupByField | GroupBySelector;
+
+export interface ErrorMessages {
+    conflictingConstraint: string;
+    conflictingSourceConstraint: string;
+    minimalConflictingConstraints: Map<string, string[]>;
+}
+
+/**
+ * Represents a constraint validation error with structured data
+ * Provides detailed information about constraint conflicts for programmatic handling
+ */
+export interface ConstraintError  extends Error {
+    /** Type of constraint error */
+    readonly type: 'group-overlap' | 'positional-conflict' | 'unknown-constraint' | 'hidden-node-conflict';
+
+    /** Human-readable error message */
+    readonly message: string;
+
+}
+
+export function isPositionalConstraintError(error: unknown): error is PositionalConstraintError {
+    return (error as PositionalConstraintError).type === 'positional-conflict';
+}
+
+export function isGroupOverlapError(error: unknown): error is GroupOverlapError {
+    return (error as GroupOverlapError).type === 'group-overlap';
+}
+
+export interface PositionalConstraintError extends ConstraintError {
+    type: 'positional-conflict';
+    conflictingConstraint: LayoutConstraint;
+    conflictingSourceConstraint: SourceConstraint;
+    minimalConflictingSet: Map<SourceConstraint, LayoutConstraint[]>;
+    maximalFeasibleSubset?: LayoutConstraint[];
+    errorMessages?: ErrorMessages;
+}
+
+export interface GroupOverlapError extends ConstraintError {
+    type: 'group-overlap';
+    group1: LayoutGroup;
+    group2: LayoutGroup;
+    overlappingNodes: LayoutNode[];
+}
+
+/**
+ * Error for when a hideAtom directive hides a node that is also referenced by layout constraints.
+ * Reported in a table format similar to IIS conflicts.
+ */
+export interface HiddenNodeConflictError extends ConstraintError {
+    type: 'hidden-node-conflict';
+    /** Map of hidden node ID → the hideAtom selector that hid it */
+    hiddenNodes: Map<string, string>;
+    /** Map of source constraint → list of pairwise descriptions that were dropped */
+    droppedConstraints: Map<string, string[]>;
+    /** Structured error messages for UI rendering (same format as positional errors) */
+    errorMessages: ErrorMessages;
+}
+
+export function isHiddenNodeConflictError(error: unknown): error is HiddenNodeConflictError {
+    return (error as HiddenNodeConflictError)?.type === 'hidden-node-conflict';
+}
+
+
+// Tooltip text explaining what node IDs are
+const ID_TOOLTIP_TEXT = "This is a unique identifier in the graph. Hover over graph nodes to see their IDs.";
+
+/**
+ * Escapes HTML special characters to prevent XSS attacks.
+ * @param str - String to escape
+ * @returns Escaped string safe for HTML insertion
+ */
+function escapeHtml(str: string): string {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+/**
+ * Formats a node label for display in error messages.
+ * Prioritizes showing attributes when available, with fallback to label and ID.
+ *
+ * @param node - The layout node to format
+ * @returns Formatted label string, potentially with HTML for tooltips
+ */
+export function formatNodeLabel(node: LayoutNode): string {
+    // Check if node has non-empty attributes with actual values
+    const hasAttributes = node.attributes &&
+        Object.entries(node.attributes).some(([_, values]) => values && values.length > 0);
+
+    if (hasAttributes) {
+        // Show attributes (truncated if needed) instead of ID
+        const attrs = node.attributes || {};
+        const attrEntries = Object.entries(attrs).sort(([a], [b]) => a.localeCompare(b));
+
+        // Format: label with key attributes shown
+        // For single attribute with single value: "label (key: value)"
+        // For multiple or complex: "label (key1: val1, key2: val2, ...)"
+        const attributeParts: string[] = [];
+        const maxAttributes = 2; // Show at most 2 attributes to avoid clutter
+        const maxValueLength = 20; // Truncate long values
+
+        for (let i = 0; i < Math.min(attrEntries.length, maxAttributes); i++) {
+            const [key, values] = attrEntries[i];
+            if (values && values.length > 0) {
+                // Take first value, truncate if too long
+                let value = values[0];
+                if (value.length > maxValueLength) {
+                    value = value.substring(0, maxValueLength) + '...';
+                }
+                // Escape HTML to prevent XSS
+                attributeParts.push(`${escapeHtml(key)}: ${escapeHtml(value)}`);
+            }
+        }
+
+        if (attrEntries.length > maxAttributes) {
+            attributeParts.push('...');
+        }
+
+        if (attributeParts.length > 0) {
+            // Escape label to prevent XSS
+            return `${escapeHtml(node.label)} (${attributeParts.join(', ')})`;
+        }
+    }
+
+    // No attributes present - show label with ID explanation
+    // Use HTML title attribute for hover tooltip explaining what the ID is
+    // Escape all user-provided values to prevent XSS
+    if (node.label && node.label !== node.id) {
+        // Format: label (id = X) where hovering explains the ID
+        return `<span title="${ID_TOOLTIP_TEXT}">${escapeHtml(node.label)} (id = ${escapeHtml(node.id)})</span>`;
+    }
+
+    // Only ID available (label same as ID or no label)
+    return `<span title="${ID_TOOLTIP_TEXT}">${escapeHtml(node.id)}</span>`;
+}
+
+// TODO:
+export function orientationConstraintToString(constraint: LayoutConstraint) {
+    const nodeLabel = formatNodeLabel;
+
+    if (isTopConstraint(constraint)) {
+        let tc = constraint as TopConstraint;
+        return `${nodeLabel(tc.top)} must be above ${nodeLabel(tc.bottom)}`;
+    }
+    else if (isLeftConstraint(constraint)) {
+        let lc = constraint as LeftConstraint;
+        return `${nodeLabel(lc.left)} must be to the left of  ${nodeLabel(lc.right)}`;
+    }
+    else if (isAlignmentConstraint(constraint)) {
+        let ac = constraint as AlignmentConstraint;
+        let axis = ac.axis;
+        let node1 = ac.node1;
+        let node2 = ac.node2;
+
+        if (axis === 'x') {
+            return `${nodeLabel(node1)} must be vertically aligned with ${nodeLabel(node2)}`;
+        }
+        else if (axis === 'y') {
+            return `${nodeLabel(node1)} must be horizontally aligned with ${nodeLabel(node2)}`;
+        }
+
+        return `${nodeLabel(node1)} must be aligned with ${nodeLabel(node2)} along the ${axis} axis`;
+    }
+    else if (isBoundingBoxConstraint(constraint)) {
+        let bc = constraint as BoundingBoxConstraint;
+        return `${nodeLabel(bc.node)} cannot be in group "${bc.group.name}".`;
+    }
+    else if (isGroupBoundaryConstraint(constraint)) {
+        let gc = constraint as GroupBoundaryConstraint;
+        const sideDescriptions: { [key: string]: string } = {
+            'left': 'to the left of',
+            'right': 'to the right of',
+            'top': 'above',
+            'bottom': 'below'
+        };
+        return `Group "${gc.groupA.name}" must be ${sideDescriptions[gc.side]} group "${gc.groupB.name}"`;
+    }
+    return `Unknown constraint type: ${constraint}`;
+}
+
+
+// ─── Validator Interface ────────────────────────────────────────────────────
+
+/**
+ * Common interface for all constraint validators.
+ * Both the deprecated Kiwi-based ConstraintValidator and the standard
+ * QualitativeConstraintValidator implement this interface.
+ */
+export interface IConstraintValidator {
+    horizontallyAligned: LayoutNode[][];
+    verticallyAligned: LayoutNode[][];
+    validateConstraints(): ConstraintError | null;
+    validatePositionalConstraints(): PositionalConstraintError | null;
+    validateGroupConstraints(): GroupOverlapError | null;
+    dispose(): void;
+}

--- a/src/layout/constraint-validator.ts
+++ b/src/layout/constraint-validator.ts
@@ -2,203 +2,31 @@ import { Solver, Variable, Expression, Strength, Operator, Constraint } from 'ki
 import { DisjunctiveConstraint, InstanceLayout, LayoutNode, LayoutEdge, LayoutGroup, LayoutConstraint, isLeftConstraint, isTopConstraint, isAlignmentConstraint, isBoundingBoxConstraint, TopConstraint, LeftConstraint, AlignmentConstraint, BoundingBoxConstraint, ImplicitConstraint, GroupBoundaryConstraint, isGroupBoundaryConstraint } from './interfaces';
 import { RelativeOrientationConstraint, CyclicOrientationConstraint, AlignConstraint, GroupByField, GroupBySelector } from './layoutspec';
 
+// Re-export all shared types from constraint-types.ts for backward compatibility
+export {
+    type SourceConstraint,
+    type ErrorMessages,
+    type ConstraintError,
+    type PositionalConstraintError,
+    type GroupOverlapError,
+    type HiddenNodeConflictError,
+    type IConstraintValidator,
+    isPositionalConstraintError,
+    isGroupOverlapError,
+    isHiddenNodeConflictError,
+    orientationConstraintToString,
+} from './constraint-types';
 
+import type { SourceConstraint, ConstraintError, PositionalConstraintError, GroupOverlapError, IConstraintValidator } from './constraint-types';
+import { orientationConstraintToString, formatNodeLabel } from './constraint-types';
 
-type SourceConstraint = RelativeOrientationConstraint | CyclicOrientationConstraint | AlignConstraint | ImplicitConstraint | GroupByField | GroupBySelector;
-
-export interface ErrorMessages {
-    conflictingConstraint: string;
-    conflictingSourceConstraint: string;
-    minimalConflictingConstraints: Map<string, string[]>;
-}
 
 /**
- * Represents a constraint validation error with structured data
- * Provides detailed information about constraint conflicts for programmatic handling
+ * @deprecated Use QualitativeConstraintValidator instead. This Kiwi/Cassowary-based
+ * validator will be removed in a future release. It is retained for backward
+ * compatibility and equivalence testing.
  */
-export interface ConstraintError  extends Error {
-    /** Type of constraint error */
-    readonly type: 'group-overlap' | 'positional-conflict' | 'unknown-constraint' | 'hidden-node-conflict';
-
-    /** Human-readable error message */
-    readonly message: string;
-
-}
-
-export function isPositionalConstraintError(error: unknown): error is PositionalConstraintError {
-    return (error as PositionalConstraintError).type === 'positional-conflict';
-}
-
-export function isGroupOverlapError(error: unknown): error is GroupOverlapError {
-    return (error as GroupOverlapError).type === 'group-overlap';
-}
-
-interface PositionalConstraintError extends ConstraintError {
-    type: 'positional-conflict';
-    conflictingConstraint: LayoutConstraint;
-    conflictingSourceConstraint: SourceConstraint;
-    minimalConflictingSet: Map<SourceConstraint, LayoutConstraint[]>;
-    maximalFeasibleSubset?: LayoutConstraint[];
-    errorMessages?: ErrorMessages;
-}
-
-interface GroupOverlapError extends ConstraintError {
-    type: 'group-overlap';
-    group1: LayoutGroup;
-    group2: LayoutGroup;
-    overlappingNodes: LayoutNode[];
-}
-
-/**
- * Error for when a hideAtom directive hides a node that is also referenced by layout constraints.
- * Reported in a table format similar to IIS conflicts.
- */
-interface HiddenNodeConflictError extends ConstraintError {
-    type: 'hidden-node-conflict';
-    /** Map of hidden node ID → the hideAtom selector that hid it */
-    hiddenNodes: Map<string, string>;
-    /** Map of source constraint → list of pairwise descriptions that were dropped */
-    droppedConstraints: Map<string, string[]>;
-    /** Structured error messages for UI rendering (same format as positional errors) */
-    errorMessages: ErrorMessages;
-}
-
-export function isHiddenNodeConflictError(error: unknown): error is HiddenNodeConflictError {
-    return (error as HiddenNodeConflictError)?.type === 'hidden-node-conflict';
-}
-
-export { type PositionalConstraintError, type GroupOverlapError, type HiddenNodeConflictError }
-
-
-// Tooltip text explaining what node IDs are
-const ID_TOOLTIP_TEXT = "This is a unique identifier in the graph. Hover over graph nodes to see their IDs.";
-
-/**
- * Escapes HTML special characters to prevent XSS attacks.
- * @param str - String to escape
- * @returns Escaped string safe for HTML insertion
- */
-function escapeHtml(str: string): string {
-    return str
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
-}
-
-/**
- * Formats a node label for display in error messages.
- * Prioritizes showing attributes when available, with fallback to label and ID.
- * 
- * @param node - The layout node to format
- * @returns Formatted label string, potentially with HTML for tooltips
- */
-function formatNodeLabel(node: LayoutNode): string {
-    // Check if node has non-empty attributes with actual values
-    const hasAttributes = node.attributes && 
-        Object.entries(node.attributes).some(([_, values]) => values && values.length > 0);
-    
-    if (hasAttributes) {
-        // Show attributes (truncated if needed) instead of ID
-        const attrs = node.attributes || {};
-        const attrEntries = Object.entries(attrs).sort(([a], [b]) => a.localeCompare(b));
-        
-        // Format: label with key attributes shown
-        // For single attribute with single value: "label (key: value)"
-        // For multiple or complex: "label (key1: val1, key2: val2, ...)"
-        const attributeParts: string[] = [];
-        const maxAttributes = 2; // Show at most 2 attributes to avoid clutter
-        const maxValueLength = 20; // Truncate long values
-        
-        for (let i = 0; i < Math.min(attrEntries.length, maxAttributes); i++) {
-            const [key, values] = attrEntries[i];
-            if (values && values.length > 0) {
-                // Take first value, truncate if too long
-                let value = values[0];
-                if (value.length > maxValueLength) {
-                    value = value.substring(0, maxValueLength) + '...';
-                }
-                // Escape HTML to prevent XSS
-                attributeParts.push(`${escapeHtml(key)}: ${escapeHtml(value)}`);
-            }
-        }
-        
-        if (attrEntries.length > maxAttributes) {
-            attributeParts.push('...');
-        }
-        
-        if (attributeParts.length > 0) {
-            // Escape label to prevent XSS
-            return `${escapeHtml(node.label)} (${attributeParts.join(', ')})`;
-        }
-    }
-    
-    // No attributes present - show label with ID explanation
-    // Use HTML title attribute for hover tooltip explaining what the ID is
-    // Escape all user-provided values to prevent XSS
-    if (node.label && node.label !== node.id) {
-        // Format: label (id = X) where hovering explains the ID
-        return `<span title="${ID_TOOLTIP_TEXT}">${escapeHtml(node.label)} (id = ${escapeHtml(node.id)})</span>`;
-    }
-    
-    // Only ID available (label same as ID or no label)
-    return `<span title="${ID_TOOLTIP_TEXT}">${escapeHtml(node.id)}</span>`;
-}
-
-// TODO: 
-export function orientationConstraintToString(constraint: LayoutConstraint) {
-    const nodeLabel = formatNodeLabel;
-
-    if (isTopConstraint(constraint)) {
-        let tc = constraint as TopConstraint;
-        return `${nodeLabel(tc.top)} must be above ${nodeLabel(tc.bottom)}`;
-    }
-    else if (isLeftConstraint(constraint)) {
-        let lc = constraint as LeftConstraint;
-        return `${nodeLabel(lc.left)} must be to the left of  ${nodeLabel(lc.right)}`;
-    }
-    else if (isAlignmentConstraint(constraint)) {
-        let ac = constraint as AlignmentConstraint;
-        let axis = ac.axis;
-        let node1 = ac.node1;
-        let node2 = ac.node2;
-
-        if (axis === 'x') {
-            return `${nodeLabel(node1)} must be vertically aligned with ${nodeLabel(node2)}`;
-        }
-        else if (axis === 'y') {
-            return `${nodeLabel(node1)} must be horizontally aligned with ${nodeLabel(node2)}`;
-        }
-
-        return `${nodeLabel(node1)} must be aligned with ${nodeLabel(node2)} along the ${axis} axis`;
-    }
-    else if (isBoundingBoxConstraint(constraint)) {
-        let bc = constraint as BoundingBoxConstraint;
-        // const sideDescriptions = {
-        //     'left': 'to the left of',
-        //     'right': 'to the right of',
-        //     'top': 'above',
-        //     'bottom': 'below'
-        // };
-        //return `${nodeLabel(bc.node)} must be ${sideDescriptions[bc.side]} group "${bc.group.name}"`;
-        return `${nodeLabel(bc.node)} cannot be in group "${bc.group.name}".`;
-    }
-    else if (isGroupBoundaryConstraint(constraint)) {
-        let gc = constraint as GroupBoundaryConstraint;
-        const sideDescriptions: { [key: string]: string } = {
-            'left': 'to the left of',
-            'right': 'to the right of',
-            'top': 'above',
-            'bottom': 'below'
-        };
-        return `Group "${gc.groupA.name}" must be ${sideDescriptions[gc.side]} group "${gc.groupB.name}"`;
-    }
-    return `Unknown constraint type: ${constraint}`;
-}
-
-
-class ConstraintValidator {
+class ConstraintValidator implements IConstraintValidator {
 
     private solver: Solver;
     private variables: { [key: string]: { x: Variable, y: Variable } };

--- a/src/layout/equivalence-checker.ts
+++ b/src/layout/equivalence-checker.ts
@@ -7,10 +7,10 @@ import {
     isLeftConstraint, isTopConstraint, isAlignmentConstraint,
 } from './interfaces';
 import {
-    ConstraintValidator,
     isPositionalConstraintError,
     type PositionalConstraintError,
-} from './constraint-validator';
+} from './constraint-types';
+import { QualitativeConstraintValidator } from './qualitative-constraint-validator';
 import { LayoutInstance } from './layoutinstance';
 
 // ---------------------------------------------------------------------------
@@ -285,7 +285,7 @@ function checkImplication(
             constraints: allConstraints,
             groups: [],
         };
-        const validator = new ConstraintValidator(merged);
+        const validator = new QualitativeConstraintValidator(merged);
         const error = validator.validatePositionalConstraints();
         if (!error) {
             // This negation alternative is satisfiable → extra is NOT implied.
@@ -420,7 +420,7 @@ function findDirectionalConflict(
         groups: [],
     };
 
-    const validator = new ConstraintValidator(merged);
+    const validator = new QualitativeConstraintValidator(merged);
     const error = validator.validatePositionalConstraints();
 
     if (error && isPositionalConstraintError(error)) {

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -7,6 +7,7 @@ export * from './interfaces';
 export * from './layoutspec';
 export * from './layoutinstance';
 export * from './colorpicker';
+export * from './constraint-types';
 export * from './constraint-validator';
 export * from './qualitative-constraint-validator';
 export * from './icon-registry';

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -1,6 +1,6 @@
 import { Graph, Edge } from 'graphlib';
 import { IAtom, IDataInstance } from '../data-instance/interfaces';
-import { PositionalConstraintError, GroupOverlapError, isPositionalConstraintError, isGroupOverlapError, isHiddenNodeConflictError, HiddenNodeConflictError } from './constraint-validator';
+import { type PositionalConstraintError, type GroupOverlapError, type HiddenNodeConflictError, type IConstraintValidator, isPositionalConstraintError, isGroupOverlapError, isHiddenNodeConflictError } from './constraint-types';
 import { EdgeStyle, normalizeEdgeStyle } from './edge-style';
 import { resolveIconPath } from './icon-registry';
 import type { SelectorErrorDetail } from '../components/ErrorMessageModal/ErrorStateManager';
@@ -84,18 +84,18 @@ export enum AlignmentEdgeStrategy {
 /**
  * Strategy for which constraint validator to use.
  *
- * - `kiwi` (default): The original Kiwi-based backtracking validator.
- *   Mature and battle-tested.
+ * - `qualitative` (default): CDCL-based validator that reasons over qualitative
+ *   partial-order constraints before handing off to Kiwi for coordinate
+ *   assignment. Faster on large/group-heavy instances with geometry-aware
+ *   pruning and clause learning.
  *
- * - `qualitative` (beta): CDCL-based validator that reasons purely over
- *   qualitative partial-order constraints before handing off to Kiwi for
- *   coordinate assignment. Faster on large/group-heavy instances but still
- *   under active development.
+ * - `kiwi` (deprecated): The original Kiwi-based backtracking validator.
+ *   Retained for backward compatibility and equivalence testing.
  */
 export enum ConstraintValidatorStrategy {
-    /** Original Kiwi-based backtracking validator (default, stable) */
+    /** @deprecated Use QUALITATIVE instead. Will be removed in a future release. */
     KIWI = 'kiwi',
-    /** CDCL-based qualitative validator (beta) */
+    /** CDCL-based qualitative validator (default) */
     QUALITATIVE = 'qualitative'
 }
 
@@ -349,7 +349,7 @@ export class LayoutInstance {
      * @param instNum - The instance number (default is 0), used to differentiate between multiple instances of the same layout.
      * @param addAlignmentEdges - Deprecated. Use alignmentEdgeStrategy instead. A boolean flag indicating whether alignment edges should be added (default is `true`, equivalent to 'connected' strategy).
      * @param alignmentEdgeStrategy - Strategy for adding alignment edges (default is `AlignmentEdgeStrategy.CONNECTED`). Takes precedence over addAlignmentEdges if provided.
-     * @param validatorStrategy - Which constraint validator to use (default is `ConstraintValidatorStrategy.KIWI`). Set to `QUALITATIVE` to use the beta CDCL-based validator.
+     * @param validatorStrategy - Which constraint validator to use (default is `ConstraintValidatorStrategy.QUALITATIVE`). Set to `KIWI` to use the deprecated Cassowary-based validator.
      *
      * The `LayoutInstance` class is responsible for generating a layout for a given data instance based on the provided layout specification.
      * It applies constraints, directives, and projections to produce a structured layout that can be rendered using a graph visualization library.
@@ -376,7 +376,7 @@ export class LayoutInstance {
                 : AlignmentEdgeStrategy.NEVER;
         }
 
-        this.validatorStrategy = validatorStrategy ?? ConstraintValidatorStrategy.KIWI;
+        this.validatorStrategy = validatorStrategy ?? ConstraintValidatorStrategy.QUALITATIVE;
     }
 
     get hideDisconnected(): boolean {
@@ -1237,7 +1237,7 @@ export class LayoutInstance {
         }
 
         // Validate all constraints (conjunctive + disjunctive) in one pass
-        const validator = this.validatorStrategy === ConstraintValidatorStrategy.QUALITATIVE
+        const validator: IConstraintValidator = this.validatorStrategy === ConstraintValidatorStrategy.QUALITATIVE
             ? new QualitativeConstraintValidator(layout)
             : new ConstraintValidator(layout);
         const constraintError = validator.validateConstraints();

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -71,52 +71,26 @@ import {
 import {
     type ConstraintError,
     type ErrorMessages,
+    type SourceConstraint,
+    type IConstraintValidator,
     orientationConstraintToString,
-} from './constraint-validator';
+} from './constraint-types';
 
 export {
     type ConstraintError,
     type ErrorMessages,
     orientationConstraintToString,
-} from './constraint-validator';
+} from './constraint-types';
 
-// ─── Source constraint type alias ────────────────────────────────────────────
+// Re-export error types and type guards from constraint-types
+export {
+    type PositionalConstraintError,
+    type GroupOverlapError,
+    isPositionalConstraintError,
+    isGroupOverlapError,
+} from './constraint-types';
 
-type SourceConstraint =
-    | RelativeOrientationConstraint
-    | CyclicOrientationConstraint
-    | AlignConstraint
-    | ImplicitConstraint
-    | GroupByField
-    | GroupBySelector;
-
-// ─── Error interfaces ────────────────────────────────────────────────────────
-
-interface PositionalConstraintError extends ConstraintError {
-    type: 'positional-conflict';
-    conflictingConstraint: LayoutConstraint;
-    conflictingSourceConstraint: SourceConstraint;
-    minimalConflictingSet: Map<SourceConstraint, LayoutConstraint[]>;
-    maximalFeasibleSubset?: LayoutConstraint[];
-    errorMessages?: ErrorMessages;
-}
-
-interface GroupOverlapError extends ConstraintError {
-    type: 'group-overlap';
-    group1: LayoutGroup;
-    group2: LayoutGroup;
-    overlappingNodes: LayoutNode[];
-}
-
-export function isPositionalConstraintError(error: unknown): error is PositionalConstraintError {
-    return (error as PositionalConstraintError)?.type === 'positional-conflict';
-}
-
-export function isGroupOverlapError(error: unknown): error is GroupOverlapError {
-    return (error as GroupOverlapError)?.type === 'group-overlap';
-}
-
-export { type PositionalConstraintError, type GroupOverlapError };
+import type { PositionalConstraintError, GroupOverlapError } from './constraint-types';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Constants
@@ -417,7 +391,7 @@ interface SolverCheckpoint {
 // QualitativeConstraintValidator
 // ═══════════════════════════════════════════════════════════════════════════════
 
-class QualitativeConstraintValidator {
+class QualitativeConstraintValidator implements IConstraintValidator {
     // ─── Input ───
     layout: InstanceLayout;
     nodes: LayoutNode[];
@@ -1175,6 +1149,18 @@ class QualitativeConstraintValidator {
                 if (!this.isBoundingBoxFeasible(bc)) return false;
             }
 
+            // AlignmentConstraint: aligning two nodes on the same axis is infeasible
+            // if they already have an ordering relationship on that axis.
+            if (isAlignmentConstraint(constraint)) {
+                const ac = constraint as AlignmentConstraint;
+                const graph = ac.axis === 'x' ? this.hGraph : this.vGraph;
+                // If either node is ordered before the other, alignment is impossible
+                if (graph.isOrdered(ac.node1.id, ac.node2.id) || graph.isOrdered(ac.node2.id, ac.node1.id)) {
+                    return false;
+                }
+                continue;
+            }
+
             const edge = this.constraintToEdge(constraint);
             if (!edge) continue;
             const graph = edge.axis === 'h' ? this.hGraph : this.vGraph;
@@ -1322,8 +1308,13 @@ class QualitativeConstraintValidator {
             let feasible = true;
             for (const constraint of disj.alternatives[i]) {
                 if (isAlignmentConstraint(constraint)) {
-                    // Alignment is never "contradicted" by existing state,
-                    // only ordering constraints can be.
+                    // Alignment is contradicted if the two nodes already have
+                    // an ordering relationship on the alignment axis.
+                    const ac = constraint as AlignmentConstraint;
+                    const graph = ac.axis === 'x' ? this.hGraph : this.vGraph;
+                    if (graph.isOrdered(ac.node1.id, ac.node2.id) || graph.isOrdered(ac.node2.id, ac.node1.id)) {
+                        feasible = false; break;
+                    }
                     continue;
                 }
                 const edge = this.constraintToEdge(constraint);

--- a/tests/constraint-validation-performance.test.ts
+++ b/tests/constraint-validation-performance.test.ts
@@ -1,3 +1,4 @@
+// Tests for deprecated ConstraintValidator (Kiwi). See qualitative-constraint-validator*.test.ts for current validator.
 import { describe, it, expect } from 'vitest';
 import { ConstraintValidator } from '../src/layout/constraint-validator';
 import { 

--- a/tests/disjunctive-constraint-validator.test.ts
+++ b/tests/disjunctive-constraint-validator.test.ts
@@ -1,3 +1,4 @@
+// Tests for deprecated ConstraintValidator (Kiwi). See qualitative-constraint-validator*.test.ts for current validator.
 import { describe, it, expect } from 'vitest';
 import { ConstraintValidator, PositionalConstraintError } from '../src/layout/constraint-validator';
 import { 

--- a/tests/iis-minimality.test.ts
+++ b/tests/iis-minimality.test.ts
@@ -1,3 +1,4 @@
+// Tests for deprecated ConstraintValidator (Kiwi). See qualitative-constraint-validator*.test.ts for current validator.
 import { describe, it, expect } from 'vitest';
 import { ConstraintValidator, PositionalConstraintError } from '../src/layout/constraint-validator';
 import { 

--- a/tests/negation-constraints.test.ts
+++ b/tests/negation-constraints.test.ts
@@ -1,3 +1,4 @@
+// Some tests in this file use the deprecated ConstraintValidator (Kiwi). See qualitative-constraint-validator*.test.ts for current validator.
 import { describe, it, expect } from 'vitest';
 import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
 import { parseLayoutSpec, RelativeOrientationConstraint, CyclicOrientationConstraint, AlignConstraint } from '../src/layout/layoutspec';


### PR DESCRIPTION
## Summary

- Extracts shared constraint types (`ConstraintError`, `PositionalConstraintError`, etc.) and a new `IConstraintValidator` interface into `constraint-types.ts`, decoupling them from the deprecated Kiwi-based validator
- Both `ConstraintValidator` and `QualitativeConstraintValidator` now implement `IConstraintValidator`
- Flips the default strategy from `KIWI` to `QUALITATIVE`; marks `KIWI` as `@deprecated`
- Fixes a correctness bug in the qualitative validator where `findSatisfyingAlternative` and `isAlternativeFeasible` did not check alignment alternatives against existing orderings — causing false-satisfiable results when a positive ordering conflicted with a negated orientation's alignment alternative

## Test plan

- [x] `npm run build:all` passes with no type errors
- [x] Full test suite passes (86 files, 1112 tests)
- [x] Denotation-diff entailment test now passes with qualitative validator as default (previously failed due to the alignment feasibility bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)