### PR TITLE
Add "Holds never" toggle to structured constraint editor

### DIFF
--- a/src/components/NoCodeView/ConstraintCard.tsx
+++ b/src/components/NoCodeView/ConstraintCard.tsx
@@ -12,10 +12,15 @@ import { useHighlight } from './hooks';
 import { ConstraintType } from './types';
 import { ConstraintData, DirectiveData } from './interfaces';
 
+/** Constraint types that support the hold: never (negation) modifier */
+const NEGATABLE_TYPES: ReadonlySet<ConstraintType> = new Set([
+    'orientation', 'cyclic', 'align', 'groupfield', 'groupselector'
+]);
+
 /**
  * Configuration options for constraint card component
  * Designed for tree-shaking optimization and client-side performance
- * 
+ *
  * @public
  * @interface ConstraintCardProps
  */
@@ -79,6 +84,8 @@ const ConstraintCard = (props: ConstraintCardProps) => {
     const [isEditingComment, setIsEditingComment] = useState(false);
 
     const isCollapsed = props.constraintData.collapsed ?? false;
+    const isNegated = props.constraintData.params.hold === 'never';
+    const isNegatable = NEGATABLE_TYPES.has(props.constraintData.type);
 
     /**
      * Toggle collapsed state
@@ -93,6 +100,16 @@ const ConstraintCard = (props: ConstraintCardProps) => {
     const handleCommentChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         props.onUpdate({ comment: e.target.value });
     }, [props.onUpdate]);
+
+    const handleHoldToggle = useCallback(() => {
+        const newParams = { ...props.constraintData.params };
+        if (newParams.hold === 'never') {
+            delete newParams.hold;
+        } else {
+            newParams.hold = 'never';
+        }
+        props.onUpdate({ params: newParams });
+    }, [props.constraintData.params, props.onUpdate]);
 
     /**
      * Handle constraint type change with proper event typing
@@ -152,12 +169,25 @@ const ConstraintCard = (props: ConstraintCardProps) => {
                     <option value="size" title={SIZE_DESCRIPTION}>Size</option>
                     <option value="hideAtom" title={HIDEATOM_DESCRIPTION}>Hide Atom</option>
                 </select>
+                {isNegated && (
+                    <span className="negation-badge" title="This constraint holds never (negated)">NOT</span>
+                )}
             </div>
             {!isCollapsed && (
                 <>
                     <div className="params">
                         { renderSelectorComponent(props.constraintData.type, props.constraintData, props.onUpdate) }
                     </div>
+                    {isNegatable && (
+                        <label className="inline-checkbox" title="When checked, the layout will try to avoid satisfying this constraint.">
+                            <input
+                                type="checkbox"
+                                checked={isNegated}
+                                onChange={handleHoldToggle}
+                            />
+                            <span>Holds never</span>
+                        </label>
+                    )}
                     {/* Comment section */}
                     <div className="commentSection">
                         {isEditingComment || props.constraintData.comment ? (

--- a/src/components/NoCodeView/NoCodeView.css
+++ b/src/components/NoCodeView/NoCodeView.css
@@ -288,6 +288,22 @@
     accent-color: #0d6efd;
 }
 
+/* Negation badge for "holds never" constraints */
+.negation-badge {
+    display: inline-block;
+    font-size: 0.625rem;
+    font-weight: 700;
+    color: #dc3545;
+    background-color: #fee2e2;
+    border: 1px solid #fca5a5;
+    border-radius: 3px;
+    padding: 0.0625rem 0.375rem;
+    margin-left: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    vertical-align: middle;
+}
+
 /* Card header with collapse button and drag handle */
 .cardHeader {
     display: flex;


### PR DESCRIPTION
## Summary
- Adds an inline "Holds never" checkbox to constraint cards in the structured editor for all negatable types (orientation, cyclic, align, group-by-field, group-by-selector)
- Shows a red "NOT" badge next to the constraint type dropdown, visible even when the card is collapsed
- Reuses the existing `inline-checkbox` CSS pattern; no changes needed to the data model, parser, or serializer since `hold: 'never'` round-trips through `params` automatically

## Test plan
- [ ] `npm run build:all` passes
- [ ] `npm test` — all 1165 tests pass
- [ ] In the structured editor: add an orientation constraint, check "Holds never", switch to code view → confirm `hold: never` appears in YAML
- [ ] In code view: write `hold: never` on a constraint, switch to structured view → confirm checkbox is checked and NOT badge is visible
- [ ] Collapse a negated card → NOT badge remains visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)