### PR TITLE
Skip backtick prefix for built-in type atoms in reify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/data-instance/alloy-data-instance.ts
+++ b/src/data-instance/alloy-data-instance.ts
@@ -205,7 +205,9 @@ export class AlloyDataInstance implements IInputDataInstance {
     for (let typeId in instanceTypes) {
         let type = instanceTypes[typeId];
         let atoms = type.atoms;
-        typeAtoms[typeId] = atoms.map(atom => `\`${atom.id}`);
+        typeAtoms[typeId] = isBuiltin(type)
+            ? atoms.map(atom => atom.id)
+            : atoms.map(atom => `\`${atom.id}`);
     }
 
     // Then declare all the relations
@@ -216,7 +218,10 @@ export class AlloyDataInstance implements IInputDataInstance {
         let relation = instanceRelations[relationId];
         let tuples = relation.tuples;
         let tupleStrings = tuples.map(tuple => {
-            let tupleString = tuple.atoms.map(a => `\`${a}`).join("->");
+            let tupleString = tuple.atoms.map((a, i) => {
+                const atomType = instanceTypes[tuple.types[i]];
+                return atomType && isBuiltin(atomType) ? a : `\`${a}`;
+            }).join("->");
             return `(${tupleString})`;
         });
 


### PR DESCRIPTION
## Summary
- Built-in types (e.g. `Int`) now emit bare atom IDs in `reify()` output instead of backtick-prefixed ones
- Applies to both atom declarations (`Int = 0+1+2`) and tuple references (`rel = (0->``Foo0)`)
- Bumps version to 2.1.1

## Test plan
- [x] `npm run build:all` passes
- [ ] Verify reified output for instances containing Int atoms no longer has backtick-prefixed numeric IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)