### PR TITLE
Add SpytialExplorer: Data Navigator + modal spatial navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "chroma-js": "^3.1.2",
         "d3": "^7.9.0",
         "dagre": "^0.8.5",
+        "data-navigator": "^2.4.1",
         "forge-expr-evaluator": "^1.1.0",
         "graphlib": "^2.1.8",
         "graphlib-dot": "^0.6.4",
@@ -4897,6 +4898,11 @@
         "graphlib": "^2.1.8",
         "lodash": "^4.17.15"
       }
+    },
+    "node_modules/data-navigator": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/data-navigator/-/data-navigator-2.4.1.tgz",
+      "integrity": "sha512-JYoSq2Wt1PTNuFRj+eUuUVfGTOOpc/XgJYiDMri+c35NRuCDDY/H+WeFr+SxZYmP6HlgV40VWXjBTVr1TFM0ww=="
     },
     "node_modules/data-urls": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "chroma-js": "^3.1.2",
     "d3": "^7.9.0",
     "dagre": "^0.8.5",
+    "data-navigator": "^2.4.1",
     "forge-expr-evaluator": "^1.1.0",
     "graphlib": "^2.1.8",
     "graphlib-dot": "^0.6.4",

--- a/src/components/spytial-explorer/explorer-styles.ts
+++ b/src/components/spytial-explorer/explorer-styles.ts
@@ -1,0 +1,554 @@
+/**
+ * CSS styles for the SpytialExplorer web component.
+ * Scoped to Shadow DOM — no global leakage.
+ */
+export function getExplorerCSS(): string {
+    return /* css */ `
+    :host {
+        display: block;
+        font-family: system-ui, -apple-system, sans-serif;
+        color: #333;
+        --accent: #5a3d8a;
+        --accent-light: #f0eef8;
+        --accent-border: #c4b8e0;
+        --focus-ring: #007acc;
+        --repl-bg: #1e1e1e;
+        --repl-fg: #d4d4d4;
+        --success: #2e7d32;
+        --error: #c62828;
+    }
+
+    /* ─── Layout ─────────────────────────────────────────────── */
+
+    .explorer-root {
+        max-width: 1400px;
+        margin: 0 auto;
+    }
+
+    .explorer-header {
+        padding: 16px 20px;
+        margin-bottom: 16px;
+    }
+
+    .explorer-header h1 {
+        font-size: 20px;
+        font-weight: 600;
+        margin: 0 0 8px 0;
+    }
+
+    .explorer-header p {
+        font-size: 14px;
+        color: #555;
+        margin: 0;
+        line-height: 1.5;
+    }
+
+    .explorer-header code {
+        background: var(--accent-light);
+        padding: 1px 5px;
+        border-radius: 3px;
+        font-size: 13px;
+        color: var(--accent);
+    }
+
+    /* Collapsible input */
+    details.input-panel {
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        margin-bottom: 16px;
+        padding: 0;
+    }
+
+    details.input-panel summary {
+        cursor: pointer;
+        padding: 12px 20px;
+        font-weight: 600;
+        font-size: 14px;
+        color: #555;
+        user-select: none;
+    }
+
+    details.input-panel summary:hover {
+        color: var(--accent);
+    }
+
+    details.input-panel .input-body {
+        padding: 0 20px 16px;
+    }
+
+    details.input-panel label {
+        font-weight: 600;
+        font-size: 13px;
+        display: block;
+        margin-bottom: 4px;
+        margin-top: 12px;
+    }
+
+    details.input-panel textarea {
+        width: 100%;
+        font-family: 'Courier New', monospace;
+        font-size: 12px;
+        padding: 10px;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        resize: vertical;
+        box-sizing: border-box;
+    }
+
+    .json-input { height: 180px; }
+    .cnd-input { height: 100px; }
+
+    /* ─── Main grid ──────────────────────────────────────────── */
+
+    .explorer-main {
+        display: flex;
+        gap: 16px;
+        align-items: stretch;
+    }
+
+    .left-panel {
+        flex: 2;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .right-panel {
+        flex: 1;
+        min-width: 320px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    @media (max-width: 900px) {
+        .explorer-main {
+            flex-direction: column;
+        }
+        .right-panel {
+            min-width: unset;
+        }
+    }
+
+    /* ─── Visual graph ───────────────────────────────────────── */
+
+    .graph-container {
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        overflow: hidden;
+        position: relative;
+    }
+
+    .graph-container webcola-cnd-graph {
+        display: block;
+    }
+
+    /* ─── Navigator (ARIA tree) ──────────────────────────────── */
+
+    .navigator-container {
+        background: #fff;
+        border: 2px solid var(--accent);
+        border-radius: 8px;
+        padding: 12px 16px;
+    }
+
+    .navigator-label {
+        font-weight: 600;
+        font-size: 13px;
+        color: var(--accent);
+        margin-bottom: 8px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .navigator-hint {
+        font-weight: 400;
+        font-size: 12px;
+        color: #888;
+    }
+
+    .navigator-output [role="graphics-document"] {
+        font-family: system-ui, sans-serif;
+    }
+
+    .navigator-output .diagram-overview {
+        font-size: 13px;
+        color: #555;
+        margin: 0 0 10px 0;
+        padding-bottom: 6px;
+        border-bottom: 1px solid #eee;
+    }
+
+    .navigator-output [role="treeitem"] {
+        padding: 6px 10px;
+        margin: 3px 0;
+        border-radius: 5px;
+        border: 1px solid #e8e8e8;
+        cursor: pointer;
+        outline: none;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 5px;
+        font-size: 14px;
+    }
+
+    .navigator-output [role="treeitem"]:hover {
+        background: #f5f5f5;
+    }
+
+    .navigator-output [role="treeitem"]:focus {
+        background: #e8f0fe;
+        box-shadow: 0 0 0 2px var(--focus-ring);
+        border-color: var(--focus-ring);
+    }
+
+    .navigator-output .node-label {
+        font-weight: 600;
+    }
+
+    .navigator-output .node-type {
+        font-size: 11px;
+        background: #e8e8e8;
+        color: #555;
+        padding: 1px 6px;
+        border-radius: 3px;
+        font-weight: 500;
+    }
+
+    .navigator-output .node-attrs {
+        display: flex;
+        gap: 3px;
+        flex-wrap: wrap;
+    }
+
+    .navigator-output .node-attr {
+        font-size: 11px;
+        background: #eef6ff;
+        color: #1a5276;
+        padding: 1px 6px;
+        border-radius: 3px;
+    }
+
+    .navigator-output .attr-key {
+        font-weight: 600;
+    }
+
+    .navigator-output .node-connections {
+        width: 100%;
+        display: flex;
+        gap: 3px;
+        flex-wrap: wrap;
+        margin-top: 2px;
+    }
+
+    .navigator-output .node-edge {
+        font-size: 10px;
+        padding: 1px 5px;
+        border-radius: 3px;
+    }
+
+    .navigator-output .node-edge-out {
+        background: #f0faf0;
+        color: #1e6e1e;
+    }
+
+    .navigator-output .node-edge-in {
+        background: #fef5e7;
+        color: #7d5a00;
+    }
+
+    .navigator-output .group-label {
+        font-weight: 600;
+    }
+
+    .navigator-output .node-count {
+        font-weight: 400;
+        color: #888;
+    }
+
+    .navigator-output [role="group"] {
+        padding-left: 14px;
+        border-left: 2px solid #ddd;
+        margin-left: 6px;
+        margin-top: 4px;
+    }
+
+    .navigator-output .diagram-relationships,
+    .navigator-output .diagram-spatial {
+        margin-top: 12px;
+    }
+
+    .navigator-output h3 {
+        font-size: 13px;
+        font-weight: 600;
+        margin: 0 0 6px 0;
+        color: #333;
+    }
+
+    .navigator-output table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+    }
+
+    .navigator-output th,
+    .navigator-output td {
+        border: 1px solid #e0e0e0;
+        padding: 4px 8px;
+        text-align: left;
+    }
+
+    .navigator-output th {
+        background: #f5f5f5;
+        font-weight: 600;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: #666;
+    }
+
+    .navigator-output .diagram-spatial ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .navigator-output .diagram-spatial li {
+        padding: 3px 0;
+        font-size: 12px;
+        color: #444;
+    }
+
+    .navigator-output .diagram-spatial em {
+        color: var(--accent);
+        font-style: normal;
+        font-weight: 500;
+    }
+
+    /* ─── Context panel ──────────────────────────────────────── */
+
+    .context-panel {
+        background: var(--accent-light);
+        border: 1px solid var(--accent-border);
+        border-radius: 6px;
+        padding: 12px 16px;
+    }
+
+    .context-panel-label {
+        font-weight: 600;
+        font-size: 13px;
+        color: var(--accent);
+        margin-bottom: 6px;
+    }
+
+    .context-content {
+        font-size: 13px;
+        line-height: 1.5;
+    }
+
+    .context-direction {
+        display: inline-block;
+        background: #e8e0f5;
+        padding: 1px 8px;
+        border-radius: 3px;
+        margin: 2px 4px 2px 0;
+        font-size: 12px;
+    }
+
+    .context-group {
+        display: inline-block;
+        background: #e0f0e0;
+        padding: 1px 8px;
+        border-radius: 3px;
+        margin: 2px 4px 2px 0;
+        font-size: 12px;
+    }
+
+    .context-group kbd {
+        font-size: 10px;
+        background: #c0d8c0;
+        padding: 0 4px;
+        border-radius: 2px;
+        margin-left: 4px;
+    }
+
+    /* ─── Modality badges ───────────────────────────────────── */
+
+    .modality-badge {
+        display: inline-block;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        padding: 0 5px;
+        border-radius: 3px;
+        vertical-align: middle;
+    }
+
+    .modality-must {
+        background: #c8e6c9;
+        color: #2e7d32;
+    }
+
+    .modality-can {
+        background: #fff3e0;
+        color: #e65100;
+    }
+
+    .modality-unconstrained {
+        background: #e0e0e0;
+        color: #616161;
+    }
+
+    /* ─── REPL shared ────────────────────────────────────────── */
+
+    .repl-section {
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 12px 16px;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .repl-label {
+        font-weight: 600;
+        font-size: 13px;
+        color: #333;
+        margin-bottom: 2px;
+    }
+
+    .repl-hint {
+        font-size: 12px;
+        color: #888;
+        margin-bottom: 8px;
+    }
+
+    .repl-input-row {
+        display: flex;
+        gap: 6px;
+        margin-bottom: 8px;
+    }
+
+    .repl-input {
+        flex: 1;
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        padding: 6px 10px;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        outline: none;
+    }
+
+    .repl-input:focus {
+        border-color: var(--focus-ring);
+        box-shadow: 0 0 0 1px var(--focus-ring);
+    }
+
+    .repl-button {
+        background-color: var(--focus-ring);
+        color: white;
+        border: none;
+        padding: 6px 14px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 13px;
+        font-weight: 500;
+    }
+
+    .repl-button:hover { background-color: #005a9e; }
+    .repl-button:disabled { background-color: #ccc; cursor: not-allowed; }
+
+    .repl-output {
+        font-family: 'Courier New', monospace;
+        font-size: 12px;
+        background: var(--repl-bg);
+        color: var(--repl-fg);
+        padding: 12px;
+        border-radius: 6px;
+        flex: 1;
+        min-height: 80px;
+        max-height: 300px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+    }
+
+    /* ─── Query result atoms ─────────────────────────────────── */
+
+    .query-result-atom {
+        cursor: pointer;
+        text-decoration: underline;
+        text-decoration-style: dotted;
+        color: #ce9178;
+    }
+
+    .query-result-atom:hover,
+    .query-result-atom:focus {
+        text-decoration-style: solid;
+        color: #4ec9b0;
+        outline: 1px solid #4ec9b0;
+        outline-offset: 1px;
+        border-radius: 2px;
+    }
+
+    .result-error { color: #f44336; }
+    .result-empty { color: #888; }
+    .result-brace { color: #9cdcfe; }
+    .result-count { color: #666; }
+    .result-query { color: #4ec9b0; }
+    .result-prompt { color: #888; }
+
+    /* ─── Status ─────────────────────────────────────────────── */
+
+    .status-bar {
+        padding: 8px 12px;
+        border-radius: 4px;
+        font-size: 13px;
+        margin-top: 8px;
+    }
+
+    .status-bar.info { background: #e3f2fd; color: #1976d2; }
+    .status-bar.success { background: #e8f5e8; color: var(--success); }
+    .status-bar.error { background: #ffebee; color: var(--error); }
+
+    /* ─── Translate button ───────────────────────────────────── */
+
+    .translate-button {
+        background-color: var(--accent);
+        color: white;
+        border: none;
+        padding: 8px 16px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 500;
+        margin-top: 8px;
+    }
+
+    .translate-button:hover { background-color: #4a2d7a; }
+
+    /* ─── Utility ────────────────────────────────────────────── */
+
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0,0,0,0);
+        border: 0;
+    }
+
+    .highlight-flash {
+        outline: 3px solid #4ec9b0 !important;
+    }
+    `;
+}

--- a/src/components/spytial-explorer/index.ts
+++ b/src/components/spytial-explorer/index.ts
@@ -1,0 +1,1 @@
+export { SpytialExplorer } from './spytial-explorer';

--- a/src/components/spytial-explorer/spytial-explorer.ts
+++ b/src/components/spytial-explorer/spytial-explorer.ts
@@ -1,0 +1,1036 @@
+/**
+ * SpytialExplorer — extends WebColaCnDGraph with Data Navigator integration.
+ *
+ * Drop-in replacement for <webcola-cnd-graph> that adds:
+ *   - Data Navigator overlay on SVG nodes (keyboard-navigable, screen-reader-announced)
+ *   - Modal spatial annotations (must/can on every neighbor relationship)
+ *   - Group navigation (Enter to drill into a group, Esc to leave)
+ *   - Spatial context panel (live-updates on node focus with constraint-derived neighbors)
+ *   - Spatial REPL (must/can/cannot modal queries — replaces drag-to-explore)
+ *   - Datum REPL (data instance queries)
+ *
+ * Usage:
+ *   <spytial-explorer width="800" height="600"></spytial-explorer>
+ *   <script>
+ *     const explorer = document.querySelector('spytial-explorer');
+ *     // Same API as webcola-cnd-graph:
+ *     explorer.renderLayout(instanceLayout);
+ *     // Plus: set up accessibility from layout + validator
+ *     explorer.enableAccessibility(instanceLayout, validator, dataEvaluator);
+ *   </script>
+ */
+
+import { WebColaCnDGraph } from '../../translators/webcola/webcola-cnd-graph';
+import { AccessibleTranslator } from '../../translators/accessible/accessible-translator';
+import { LayoutEvaluator } from '../../evaluators/layout/layout-evaluator';
+import { getExplorerCSS } from './explorer-styles';
+import type { AccessibleLayout, SpatialNeighbors } from '../../translators/accessible/accessible-translator';
+import type { InstanceLayout, LayoutGroup } from '../../layout/interfaces';
+import type { QualitativeConstraintValidator } from '../../layout/qualitative-constraint-validator';
+import type { SGraphQueryEvaluator } from '../../evaluators/data/sgq-evaluator';
+// Data Navigator — structure and input modules (rendering done manually for Shadow DOM compat)
+import dataNavigator from 'data-navigator';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+type Modality = 'must' | 'can' | 'unconstrained';
+
+/** Direction names as used by the QualitativeConstraintValidator API */
+type ValidatorDirection = 'leftOf' | 'rightOf' | 'above' | 'below';
+
+/** Spatial direction as used internally (arrow keys / nav map) */
+type SpatialDir = 'left' | 'right' | 'up' | 'down';
+
+interface AnnotatedNeighbor {
+    nodeId: string;
+    direction: SpatialDir;
+    modality: Modality;
+}
+
+interface QueryHistoryEntry {
+    expr: string;
+    html: string;
+    srText: string;
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────
+
+export class SpytialExplorer extends WebColaCnDGraph {
+    // Accessibility state
+    private accessibleLayout: AccessibleLayout | null = null;
+    private layoutEvaluator: LayoutEvaluator | null = null;
+    private constraintValidator: QualitativeConstraintValidator | null = null;
+    private dataEvaluator: SGraphQueryEvaluator | null = null;
+    private currentInstanceLayout: InstanceLayout | null = null;
+
+    // Data Navigator state
+    private dnInputHandler: any = null;
+    private dnCurrentFocusId: string | null = null;
+    private dnOverlayContainer: HTMLElement | null = null;
+
+    // Group navigation state
+    private groupStack: string[] = [];          // stack of group names we've entered
+    private groupMemberMap: Map<string, string[]> = new Map(); // groupName → nodeIds
+    private nodeGroupMap: Map<string, string[]> = new Map();   // nodeId → groupNames
+
+    // Query histories
+    private spatialHistory: QueryHistoryEntry[] = [];
+    private datumHistory: QueryHistoryEntry[] = [];
+
+    // DOM references within shadow root
+    private explorerPanel: HTMLElement | null = null;
+
+    constructor() {
+        super();
+        this.appendExplorerDOM();
+        this.wireExplorerEvents();
+    }
+
+    // ─── Public API ────────────────────────────────────────────────────
+
+    /**
+     * Enable accessibility features after a layout has been rendered.
+     * Call this after renderLayout() with the validator and evaluator
+     * from the layout pipeline.
+     */
+    public enableAccessibility(
+        layout: InstanceLayout,
+        validator: QualitativeConstraintValidator | null,
+        dataEvaluator?: SGraphQueryEvaluator,
+    ): void {
+        this.currentInstanceLayout = layout;
+        this.constraintValidator = validator;
+
+        // Build accessible representation
+        const translator = new AccessibleTranslator();
+        this.accessibleLayout = translator.translate(layout);
+
+        // Layout evaluator for spatial REPL
+        this.layoutEvaluator = validator
+            ? new LayoutEvaluator(validator, layout)
+            : null;
+
+        // Datum evaluator for data REPL
+        if (dataEvaluator) this.dataEvaluator = dataEvaluator;
+
+        // Build group maps
+        this.buildGroupMaps(layout.groups);
+
+        // Enable REPL buttons
+        this.enableREPLs();
+
+        // Set up Data Navigator after the layout simulation settles
+        // (zoom-to-fit must complete before we can read SVG positions)
+        this.addEventListener('layout-complete', () => {
+            // Extra frame to ensure the zoom transform is applied to the DOM
+            requestAnimationFrame(() => this.setupDataNavigator());
+        }, { once: true });
+
+        // If layout already completed (e.g., enableAccessibility called late),
+        // set up immediately
+        if (this.getNodePositions().length > 0) {
+            const g = this.shadowRoot!.querySelector('svg > g');
+            const transform = g?.getAttribute('transform') ?? '';
+            if (transform.includes('scale') && !transform.includes('scale(1)')) {
+                // Transform already applied — set up now
+                requestAnimationFrame(() => this.setupDataNavigator());
+            }
+        }
+    }
+
+    /**
+     * Override renderLayout to stash the instance layout for later use.
+     */
+    public async renderLayout(instanceLayout: InstanceLayout, options?: any): Promise<void> {
+        this.currentInstanceLayout = instanceLayout;
+        return super.renderLayout(instanceLayout, options);
+    }
+
+    // ─── Group Maps ───────────────────────────────────────────────────
+
+    private buildGroupMaps(groups: LayoutGroup[]): void {
+        this.groupMemberMap.clear();
+        this.nodeGroupMap.clear();
+
+        for (const group of groups) {
+            if (group.negated) continue;
+            this.groupMemberMap.set(group.name, [...group.nodeIds]);
+            for (const nodeId of group.nodeIds) {
+                if (!this.nodeGroupMap.has(nodeId)) this.nodeGroupMap.set(nodeId, []);
+                this.nodeGroupMap.get(nodeId)!.push(group.name);
+            }
+        }
+    }
+
+    // ─── Modality ─────────────────────────────────────────────────────
+
+    /**
+     * Determine whether a neighbor relationship is must, can, or unconstrained.
+     *
+     * For example, if Node1 is the left neighbor of Node0 in the current layout,
+     * this checks: is Node1 in validator.getMust(Node0, 'leftOf')?
+     *   - yes → 'must'  (in ALL valid layouts, Node1 is left of Node0)
+     *   - no  → 'can'   (in THIS layout it is, but other valid layouts may differ)
+     * If no validator is available, returns 'unconstrained'.
+     */
+    private getModality(
+        fromNodeId: string,
+        direction: SpatialDir,
+        toNodeId: string,
+    ): Modality {
+        if (!this.constraintValidator) return 'unconstrained';
+
+        const validatorDir = this.spatialDirToValidatorDir(direction);
+        try {
+            const mustSet = this.constraintValidator.getMust(fromNodeId, validatorDir);
+            if (mustSet.has(toNodeId)) return 'must';
+            return 'can';
+        } catch {
+            return 'unconstrained';
+        }
+    }
+
+    /**
+     * Map our spatial direction names to the validator's relation names.
+     * "left neighbor" = "that node is leftOf this node"
+     */
+    private spatialDirToValidatorDir(dir: SpatialDir): ValidatorDirection {
+        switch (dir) {
+            case 'left': return 'leftOf';
+            case 'right': return 'rightOf';
+            case 'up': return 'above';
+            case 'down': return 'below';
+        }
+    }
+
+    /**
+     * Get all annotated neighbors for a node — each neighbor tagged with its modality.
+     */
+    private getAnnotatedNeighbors(nodeId: string): AnnotatedNeighbor[] {
+        if (!this.accessibleLayout) return [];
+
+        const nav = this.accessibleLayout.navigation;
+        const nb = nav.getNeighbors(nodeId);
+        if (!nb) return [];
+
+        const result: AnnotatedNeighbor[] = [];
+        const pairs: Array<[SpatialDir, string | null]> = [
+            ['left', nb.left],
+            ['right', nb.right],
+            ['up', nb.above],
+            ['down', nb.below],
+        ];
+
+        for (const [dir, targetId] of pairs) {
+            if (!targetId) continue;
+            result.push({
+                nodeId: targetId,
+                direction: dir,
+                modality: this.getModality(nodeId, dir, targetId),
+            });
+        }
+
+        return result;
+    }
+
+    // ─── Shadow DOM Extension ──────────────────────────────────────────
+
+    /**
+     * Append the explorer panel (context + REPLs) and DN overlay container
+     * to the shadow root created by WebColaCnDGraph.
+     */
+    private appendExplorerDOM(): void {
+        const shadow = this.shadowRoot!;
+
+        // Add explorer CSS
+        const style = document.createElement('style');
+        style.textContent = getExplorerCSS();
+        shadow.appendChild(style);
+
+        // Data Navigator overlay container — positioned over the SVG
+        this.dnOverlayContainer = document.createElement('div');
+        this.dnOverlayContainer.id = 'dn-overlay-root';
+        this.dnOverlayContainer.setAttribute('role', 'application');
+        this.dnOverlayContainer.setAttribute('aria-label', 'Diagram navigation. Arrow keys move between nodes. Shift plus arrow restricts to must relationships. Enter to go into a group. Escape to leave.');
+        this.dnOverlayContainer.style.cssText = 'position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none;';
+
+        // Insert into the svg-container (which has position: relative)
+        const svgContainer = shadow.querySelector('#svg-container');
+        if (svgContainer) {
+            (svgContainer as HTMLElement).style.position = 'relative';
+            svgContainer.appendChild(this.dnOverlayContainer);
+        }
+
+        // Screen-reader live region for spatial announcements
+        const liveRegion = document.createElement('div');
+        liveRegion.id = 'se-live-region';
+        liveRegion.setAttribute('aria-live', 'polite');
+        liveRegion.setAttribute('aria-atomic', 'true');
+        liveRegion.className = 'sr-only';
+        shadow.appendChild(liveRegion);
+
+        // Explorer panel below the graph
+        this.explorerPanel = document.createElement('div');
+        this.explorerPanel.id = 'se-explorer-panel';
+        this.explorerPanel.innerHTML = `
+            <!-- Spatial context -->
+            <div class="context-panel" role="region" aria-label="Spatial context for focused node">
+                <div class="context-panel-label">Spatial Context</div>
+                <div class="context-content" id="se-context">
+                    Navigate to a node to see its spatial context.
+                </div>
+            </div>
+
+            <!-- Spatial REPL -->
+            <div class="repl-section" role="region" aria-label="Spatial query REPL">
+                <div class="repl-label">Spatial Queries</div>
+                <div class="repl-hint">
+                    <code>must.rightOf(Node0)</code> &middot;
+                    <code>can.leftOf(Node1)</code> &middot;
+                    <code>cannot.above(Node2)</code>
+                </div>
+                <div class="repl-input-row">
+                    <label for="se-spatial-input" class="sr-only">Spatial query expression</label>
+                    <input type="text" id="se-spatial-input" class="repl-input"
+                           placeholder="must.rightOf(Node0)"
+                           aria-describedby="se-spatial-hint">
+                    <span id="se-spatial-hint" class="sr-only">
+                        Enter a spatial query like must.rightOf(Node0) and press Enter.
+                        Results are clickable — activate a result to navigate to that node.
+                    </span>
+                    <button class="repl-button" id="se-spatial-btn" disabled>Query</button>
+                </div>
+                <div class="repl-output" id="se-spatial-output"
+                     role="log" aria-label="Spatial query results" aria-live="polite">
+<span class="result-prompt">//</span> Run enableAccessibility() first, then enter a spatial query.
+<span class="result-prompt">//</span>
+<span class="result-prompt">//</span> <strong>must</strong>  — true in ALL valid layouts
+<span class="result-prompt">//</span> <strong>can</strong>   — true in SOME valid layout
+<span class="result-prompt">//</span> <strong>cannot</strong> — true in NO valid layout
+                </div>
+            </div>
+
+            <!-- Datum REPL -->
+            <div class="repl-section" role="region" aria-label="Data query REPL">
+                <div class="repl-label">Data Queries</div>
+                <div class="repl-hint">
+                    <code>Node</code> &middot;
+                    <code>Node.left</code> &middot;
+                    <code>Node.left.val</code>
+                </div>
+                <div class="repl-input-row">
+                    <label for="se-datum-input" class="sr-only">Data query expression</label>
+                    <input type="text" id="se-datum-input" class="repl-input"
+                           placeholder="Node.left.val"
+                           aria-describedby="se-datum-hint">
+                    <span id="se-datum-hint" class="sr-only">
+                        Enter a data query like Node.left.val and press Enter.
+                    </span>
+                    <button class="repl-button" id="se-datum-btn" disabled>Query</button>
+                </div>
+                <div class="repl-output" id="se-datum-output"
+                     role="log" aria-label="Data query results" aria-live="polite">
+<span class="result-prompt">//</span> Run enableAccessibility() first, then enter a data query.
+                </div>
+            </div>
+        `;
+        shadow.appendChild(this.explorerPanel);
+    }
+
+    // ─── Event Wiring ──────────────────────────────────────────────────
+
+    private wireExplorerEvents(): void {
+        const shadow = this.shadowRoot!;
+
+        // Spatial REPL
+        shadow.addEventListener('click', (e) => {
+            const target = e.target as HTMLElement;
+            if (target.id === 'se-spatial-btn') this.executeSpatialQuery();
+            if (target.id === 'se-datum-btn') this.executeDatumQuery();
+            if (target.classList.contains('query-result-atom')) {
+                this.navigateToNode(target.dataset.nodeId!);
+            }
+        });
+
+        shadow.addEventListener('keydown', (e) => {
+            const target = e.target as HTMLElement;
+            if (target.id === 'se-spatial-input' && e.key === 'Enter') this.executeSpatialQuery();
+            if (target.id === 'se-datum-input' && e.key === 'Enter') this.executeDatumQuery();
+            if (target.classList.contains('query-result-atom') && e.key === 'Enter') {
+                this.navigateToNode(target.dataset.nodeId!);
+            }
+        });
+    }
+
+    // ─── Data Navigator Integration ────────────────────────────────────
+
+    /**
+     * Build a Data Navigator structure from the spatial navigation map
+     * and overlay focusable elements on the SVG.
+     */
+    /**
+     * Extract the current SVG pan/zoom transform so overlay elements
+     * can be positioned in container-pixel coordinates.
+     */
+    private getSVGTransform(): { tx: number; ty: number; scale: number } {
+        const shadow = this.shadowRoot!;
+        const g = shadow.querySelector('svg > g');
+        if (!g) return { tx: 0, ty: 0, scale: 1 };
+
+        const transformAttr = g.getAttribute('transform') ?? '';
+        const translateMatch = transformAttr.match(/translate\(\s*([-\d.]+)[,\s]+([-\d.]+)\s*\)/);
+        const scaleMatch = transformAttr.match(/scale\(\s*([-\d.]+)\s*\)/);
+
+        return {
+            tx: translateMatch ? parseFloat(translateMatch[1]) : 0,
+            ty: translateMatch ? parseFloat(translateMatch[2]) : 0,
+            scale: scaleMatch ? parseFloat(scaleMatch[1]) : 1,
+        };
+    }
+
+    private setupDataNavigator(): void {
+        if (!this.accessibleLayout || !this.currentInstanceLayout) return;
+
+        const nav = this.accessibleLayout.navigation;
+        const nodeDescs = this.accessibleLayout.description.nodes;
+        const positions = this.getNodePositions();
+        const layoutNodes = this.currentInstanceLayout.nodes;
+
+        if (positions.length === 0) return;
+
+        // Get SVG transform for coordinate conversion
+        const svgTransform = this.getSVGTransform();
+
+        // Build position + size lookup
+        const posMap = new Map(positions.map(p => [p.id, p]));
+        const sizeMap = new Map(layoutNodes.map(n => [
+            n.id,
+            { width: (n as any).visualWidth ?? n.width ?? 50, height: (n as any).visualHeight ?? n.height ?? 30 },
+        ]));
+        const descMap = new Map(nodeDescs.map(d => [d.id, d]));
+
+        // ─── Build DN structure manually ───────────────────────────────
+        // We build the Structure object directly rather than using DN's
+        // structure() function, because our navigation graph comes from
+        // the constraint solver, not from raw data dimensions.
+
+        const dnNodes: Record<string, any> = {};
+        const dnEdges: Record<string, any> = {};
+        const dnElementData: Record<string, any> = {};
+        let edgeCounter = 0;
+
+        for (const [nodeId, neighbors] of nav.entries()) {
+            const pos = posMap.get(nodeId);
+            const size = sizeMap.get(nodeId);
+            const desc = descMap.get(nodeId);
+            if (!pos || !size) continue;
+
+            const renderId = `dn-node-${this.sanitizeId(nodeId)}`;
+            const nodeEdges: string[] = [];
+
+            // Create edges for each spatial direction
+            const directions: Array<[SpatialDir, string | null]> = [
+                ['left', neighbors.left],
+                ['right', neighbors.right],
+                ['up', neighbors.above],
+                ['down', neighbors.below],
+            ];
+
+            for (const [dir, targetId] of directions) {
+                if (!targetId) continue;
+                const edgeId = `e${edgeCounter++}`;
+                dnEdges[edgeId] = {
+                    source: nodeId,
+                    target: targetId,
+                    navigationRules: [dir],
+                };
+                nodeEdges.push(edgeId);
+            }
+
+            dnNodes[nodeId] = {
+                id: nodeId,
+                edges: nodeEdges,
+                renderId,
+                label: desc?.label ?? nodeId,
+                type: desc?.mostSpecificType ?? '',
+            };
+
+            // Element data for rendering — convert SVG coords to container pixels
+            // Enforce a minimum clickable size so nodes remain interactive at low zoom
+            const MIN_NODE_SIZE = 24;
+            const pixelX = pos.x * svgTransform.scale + svgTransform.tx;
+            const pixelY = pos.y * svgTransform.scale + svgTransform.ty;
+            const rawW = size.width * svgTransform.scale;
+            const rawH = size.height * svgTransform.scale;
+            const pixelW = Math.max(rawW, MIN_NODE_SIZE);
+            const pixelH = Math.max(rawH, MIN_NODE_SIZE);
+
+            dnElementData[renderId] = {
+                spatialProperties: {
+                    x: pixelX - pixelW / 2,
+                    y: pixelY - pixelH / 2,
+                    width: pixelW,
+                    height: pixelH,
+                },
+                semantics: {
+                    label: () => this.buildNodeAnnouncement(nodeId),
+                    role: 'button',
+                },
+                cssClass: 'dn-spatial-node',
+            };
+        }
+
+        const dnStructure = {
+            nodes: dnNodes,
+            edges: dnEdges,
+            navigationRules: {
+                left: { key: 'ArrowLeft', direction: 'target' as const },
+                right: { key: 'ArrowRight', direction: 'target' as const },
+                up: { key: 'ArrowUp', direction: 'target' as const },
+                down: { key: 'ArrowDown', direction: 'target' as const },
+            },
+            elementData: dnElementData,
+        };
+
+        // ─── Build DN input handler ────────────────────────────────────
+
+        this.dnInputHandler = dataNavigator.input({
+            structure: dnStructure,
+            navigationRules: dnStructure.navigationRules,
+            entryPoint: nav.nodeOrder[0],
+        });
+
+        // ─── Render DN overlay nodes ───────────────────────────────────
+        // We render manually instead of using DN's rendering module because
+        // we're inside a Shadow DOM and DN's renderer uses document.getElementById.
+
+        this.renderDNOverlay(dnStructure, dnElementData);
+
+        // ─── Wire keyboard navigation on the overlay ───────────────────
+
+        this.wireDNKeyboard(dnStructure);
+    }
+
+    /**
+     * Render focusable overlay elements on top of the SVG nodes.
+     * These are what Data Navigator users interact with.
+     */
+    private renderDNOverlay(
+        structure: any,
+        elementData: Record<string, any>,
+    ): void {
+        if (!this.dnOverlayContainer) return;
+
+        // Clear previous overlay
+        this.dnOverlayContainer.innerHTML = '';
+
+        // Entry button
+        const entryBtn = document.createElement('button');
+        entryBtn.className = 'dn-entry-button';
+        entryBtn.textContent = 'Enter diagram navigation';
+        entryBtn.style.cssText = 'pointer-events: auto; margin: 4px;';
+        entryBtn.addEventListener('click', () => {
+            const firstNodeId = this.accessibleLayout?.navigation.nodeOrder[0];
+            if (firstNodeId) this.navigateToNode(firstNodeId);
+        });
+        this.dnOverlayContainer.appendChild(entryBtn);
+
+        // Create a focusable element for each node
+        for (const [nodeId, node] of Object.entries(structure.nodes) as any[]) {
+            const renderId = node.renderId;
+            const data = elementData[renderId];
+            if (!data) continue;
+
+            const sp = data.spatialProperties;
+            const el = document.createElement('div');
+            el.id = renderId;
+            el.className = `dn-spatial-node ${data.cssClass || ''}`;
+            el.setAttribute('role', 'button');
+            el.setAttribute('tabindex', '-1');
+            el.setAttribute('aria-label', typeof data.semantics?.label === 'function'
+                ? data.semantics.label()
+                : (data.semantics?.label || nodeId));
+            el.dataset.nodeId = nodeId;
+
+            // Tag with groups for group navigation
+            const groups = this.nodeGroupMap.get(nodeId);
+            if (groups && groups.length > 0) {
+                el.dataset.groups = groups.join(',');
+            }
+
+            el.style.cssText = `
+                position: absolute;
+                left: ${sp.x}px;
+                top: ${sp.y}px;
+                width: ${sp.width}px;
+                height: ${sp.height}px;
+                pointer-events: auto;
+                cursor: pointer;
+                border-radius: 4px;
+                outline-offset: 2px;
+            `;
+
+            // Focus handler — update context panel
+            el.addEventListener('focus', () => {
+                this.dnCurrentFocusId = nodeId;
+                this.onDNNodeFocused(nodeId);
+            });
+
+            this.dnOverlayContainer!.appendChild(el);
+        }
+    }
+
+    /**
+     * Wire keyboard navigation on the DN overlay.
+     *
+     * - Arrow keys: navigate to nearest neighbor in that direction (current layout)
+     * - Shift+Arrow: navigate only along MUST relationships (guaranteed in all valid layouts)
+     * - Enter: drill into a group
+     * - Esc: leave a group (or exit navigation)
+     */
+    private wireDNKeyboard(_structure: any): void {
+        if (!this.dnOverlayContainer || !this.dnInputHandler) return;
+
+        this.dnOverlayContainer.addEventListener('keydown', (e) => {
+            if (!this.dnCurrentFocusId || !this.dnInputHandler) return;
+
+            // ─── Group navigation ─────────────────────────────────
+            if (e.key === 'Enter') {
+                this.handleGroupEnter();
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+            }
+
+            if (e.key === 'Escape') {
+                if (this.groupStack.length > 0) {
+                    this.handleGroupEscape();
+                } else {
+                    // Exit navigation entirely
+                    (this.shadowRoot!.activeElement as HTMLElement)?.blur();
+                    this.dnCurrentFocusId = null;
+                }
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+            }
+
+            // ─── Spatial navigation ───────────────────────────────
+            const direction = this.dnInputHandler.keydownValidator(e);
+            if (!direction) return;
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            const mustOnly = e.shiftKey;
+            const nextNode = this.dnInputHandler.move(this.dnCurrentFocusId, direction);
+
+            if (!nextNode) return;
+
+            // If Shift is held, only allow must relationships
+            if (mustOnly) {
+                const modality = this.getModality(
+                    this.dnCurrentFocusId,
+                    direction as SpatialDir,
+                    nextNode.id,
+                );
+                if (modality !== 'must') {
+                    this.announce(`No must-${direction} neighbor. This is a can relationship.`);
+                    return;
+                }
+            }
+
+            // If we're inside a group, only navigate to group members
+            if (this.groupStack.length > 0) {
+                const currentGroup = this.groupStack[this.groupStack.length - 1];
+                const members = this.groupMemberMap.get(currentGroup);
+                if (members && !members.includes(nextNode.id)) {
+                    this.announce(`Edge of group ${currentGroup}. Press Escape to leave group.`);
+                    return;
+                }
+            }
+
+            this.dnCurrentFocusId = nextNode.id;
+            const renderId = nextNode.renderId;
+            const el = this.shadowRoot!.getElementById(renderId);
+            if (el) {
+                el.focus();
+                this.highlightNodes([nextNode.id]);
+            }
+        });
+    }
+
+    // ─── Group Navigation ─────────────────────────────────────────────
+
+    /**
+     * Enter pressed on a node: if the node belongs to a group,
+     * drill into that group. Navigation is then confined to group members.
+     */
+    private handleGroupEnter(): void {
+        if (!this.dnCurrentFocusId) return;
+
+        const groups = this.nodeGroupMap.get(this.dnCurrentFocusId);
+        if (!groups || groups.length === 0) {
+            this.announce('This node is not in a group.');
+            return;
+        }
+
+        // If in a group already, try to enter a nested group (if any).
+        // Otherwise enter the first available group.
+        let targetGroup: string | null = null;
+        if (this.groupStack.length > 0) {
+            // Look for a group this node belongs to that's NOT the current group
+            const current = this.groupStack[this.groupStack.length - 1];
+            targetGroup = groups.find(g => g !== current) ?? null;
+            if (!targetGroup) {
+                this.announce(`Already inside group ${current}. No nested groups.`);
+                return;
+            }
+        } else {
+            targetGroup = groups[0];
+        }
+
+        this.groupStack.push(targetGroup);
+        const members = this.groupMemberMap.get(targetGroup) ?? [];
+
+        // Highlight all group members
+        this.highlightNodes(members);
+
+        this.announce(`Entered group ${targetGroup}, ${members.length} members. Arrow keys navigate within group. Escape to leave.`);
+    }
+
+    /**
+     * Escape pressed while inside a group: pop the group stack
+     * and return to unconstrained navigation.
+     */
+    private handleGroupEscape(): void {
+        const leftGroup = this.groupStack.pop();
+
+        if (this.groupStack.length > 0) {
+            const parentGroup = this.groupStack[this.groupStack.length - 1];
+            const members = this.groupMemberMap.get(parentGroup) ?? [];
+            this.highlightNodes(members);
+            this.announce(`Left group ${leftGroup}. Now in group ${parentGroup}.`);
+        } else {
+            // Highlight just the focused node
+            if (this.dnCurrentFocusId) this.highlightNodes([this.dnCurrentFocusId]);
+            this.announce(`Left group ${leftGroup}. Free navigation.`);
+        }
+    }
+
+    // ─── Spatial Context ───────────────────────────────────────────────
+
+    /**
+     * Called when a DN overlay node receives focus.
+     * Updates the context panel and live region with modal annotations.
+     */
+    private onDNNodeFocused(nodeId: string): void {
+        if (!this.accessibleLayout) return;
+
+        const nav = this.accessibleLayout.navigation;
+        const nb = nav.getNeighbors(nodeId);
+        if (!nb) return;
+
+        const desc = this.accessibleLayout.description.nodes.find(n => n.id === nodeId);
+        const label = desc?.label ?? nodeId;
+        const type = desc?.mostSpecificType ?? '';
+        const annotated = this.getAnnotatedNeighbors(nodeId);
+
+        this.updateContextPanel(label, type, nb, annotated);
+        this.highlightNodes([nodeId]);
+
+        // Dispatch event for external consumers
+        this.dispatchEvent(new CustomEvent('node-focused', {
+            detail: { nodeId, label, neighbors: nb, annotatedNeighbors: annotated },
+            bubbles: true,
+        }));
+    }
+
+    /**
+     * Build a screen-reader announcement string for a node,
+     * including modal spatial context from the constraint graph.
+     */
+    private buildNodeAnnouncement(nodeId: string): string {
+        if (!this.accessibleLayout) return nodeId;
+
+        const desc = this.accessibleLayout.description.nodes.find(n => n.id === nodeId);
+        if (!desc) return nodeId;
+
+        const parts = [desc.label];
+        if (desc.mostSpecificType) parts.push(desc.mostSpecificType);
+
+        const annotated = this.getAnnotatedNeighbors(nodeId);
+        if (annotated.length > 0) {
+            const spatial = annotated.map(a => {
+                const dirLabel = a.direction === 'up' ? 'above' : a.direction === 'down' ? 'below' : `${a.direction} of`;
+                const modal = a.modality !== 'unconstrained' ? `${a.modality} ` : '';
+                return `${modal}${dirLabel} ${this.getNodeLabel(a.nodeId)}`;
+            });
+            parts.push(spatial.join(', '));
+        }
+
+        const groups = this.nodeGroupMap.get(nodeId);
+        if (groups && groups.length > 0) parts.push(`in group ${groups.join(', ')}`);
+
+        // Group navigation hint
+        if (groups && groups.length > 0 && this.groupStack.length === 0) {
+            parts.push('press Enter to navigate within group');
+        }
+
+        return parts.join('. ') + '.';
+    }
+
+    private updateContextPanel(
+        label: string,
+        type: string,
+        nb: SpatialNeighbors,
+        annotated: AnnotatedNeighbor[],
+    ): void {
+        const shadow = this.shadowRoot!;
+        const contextEl = shadow.getElementById('se-context');
+        const liveEl = shadow.getElementById('se-live-region');
+        if (!contextEl || !liveEl) return;
+
+        // Build header
+        let html = `<strong>${this.escapeHtml(label)}</strong>`;
+        if (type) html += ` <span class="context-direction">${this.escapeHtml(type)}</span>`;
+
+        // Group breadcrumb
+        if (this.groupStack.length > 0) {
+            html += ` <span class="context-group">In: ${this.groupStack.map(g => this.escapeHtml(g)).join(' &rsaquo; ')}</span>`;
+        }
+        html += '<br>';
+
+        // Annotated neighbor chips with modality badges
+        if (annotated.length > 0) {
+            html += annotated.map(a => {
+                const dirName = a.direction === 'up' ? 'Above'
+                    : a.direction === 'down' ? 'Below'
+                    : a.direction === 'left' ? 'Left'
+                    : 'Right';
+                const modalClass = a.modality === 'must' ? 'modality-must'
+                    : a.modality === 'can' ? 'modality-can'
+                    : 'modality-unconstrained';
+                const modalBadge = a.modality !== 'unconstrained'
+                    ? `<span class="modality-badge ${modalClass}">${a.modality}</span> `
+                    : '';
+                return `<span class="context-direction">${modalBadge}${dirName}: <strong>${this.escapeHtml(this.getNodeLabel(a.nodeId))}</strong></span>`;
+            }).join(' ');
+        } else {
+            html += '<span style="color:#888">No spatial neighbors (unconstrained)</span>';
+        }
+
+        // Group membership
+        const groups = nb.containingGroups;
+        if (groups.length > 0 && this.groupStack.length === 0) {
+            html += '<br>' + groups.map(g =>
+                `<span class="context-group">Group: ${this.escapeHtml(g)} <kbd>Enter</kbd></span>`,
+            ).join(' ');
+        }
+
+        contextEl.innerHTML = html;
+
+        // Screen reader announcement with modality
+        const srParts: string[] = [];
+        for (const a of annotated) {
+            const dirLabel = a.direction === 'up' ? 'above' : a.direction === 'down' ? 'below' : `${a.direction} of`;
+            const modal = a.modality !== 'unconstrained' ? `${a.modality} ` : '';
+            srParts.push(`${modal}${dirLabel} ${this.getNodeLabel(a.nodeId)}`);
+        }
+
+        let srText = label;
+        if (srParts.length > 0) srText += '. ' + srParts.join(', ') + '.';
+        if (groups.length > 0) srText += ` In group ${groups.join(', ')}. Press Enter to navigate within group.`;
+        if (this.groupStack.length > 0) {
+            srText += ` Inside group ${this.groupStack[this.groupStack.length - 1]}. Press Escape to leave.`;
+        }
+
+        liveEl.textContent = srText;
+    }
+
+    // ─── Spatial REPL ──────────────────────────────────────────────────
+
+    private executeSpatialQuery(): void {
+        const shadow = this.shadowRoot!;
+        const input = shadow.getElementById('se-spatial-input') as HTMLInputElement | null;
+        if (!input) return;
+
+        const expr = input.value.trim();
+        if (!expr) return;
+
+        if (!this.layoutEvaluator) {
+            this.spatialHistory.push({
+                expr,
+                html: '<span class="result-error">Error: No layout evaluator. Call enableAccessibility() first.</span>',
+                srText: 'Error: No layout evaluator.',
+            });
+            this.renderSpatialHistory();
+            return;
+        }
+
+        const result = this.layoutEvaluator.evaluate(expr);
+
+        if (result.isError()) {
+            this.spatialHistory.push({
+                expr,
+                html: `<span class="result-error">Error: ${this.escapeHtml(result.prettyPrint())}</span>`,
+                srText: `Error: ${result.prettyPrint()}`,
+            });
+        } else if (result.noResult()) {
+            this.spatialHistory.push({
+                expr,
+                html: '<span class="result-empty">(empty set — no results)</span>',
+                srText: 'Empty set, no results.',
+            });
+        } else {
+            const atoms = result.selectedAtoms();
+            const atomHtml = atoms.map(a => {
+                const safeId = this.sanitizeId(a);
+                return `<span class="query-result-atom" role="link" tabindex="0" data-node-id="${this.escapeHtml(safeId)}">${this.escapeHtml(a)}</span>`;
+            }).join(', ');
+
+            this.spatialHistory.push({
+                expr,
+                html: `<span class="result-brace">{</span> ${atomHtml} <span class="result-brace">}</span> ` +
+                      `<span class="result-count">(${atoms.length} result${atoms.length !== 1 ? 's' : ''} — click to navigate)</span>`,
+                srText: `${atoms.length} result${atoms.length !== 1 ? 's' : ''}: ${atoms.join(', ')}. Activate a result to navigate to it.`,
+            });
+
+            // Highlight results in SVG
+            this.highlightNodes(atoms);
+        }
+
+        this.renderSpatialHistory();
+        this.dispatchEvent(new CustomEvent('query-executed', {
+            detail: { type: 'spatial', expr, result: result.prettyPrint() },
+            bubbles: true,
+        }));
+
+        input.value = '';
+        input.focus();
+    }
+
+    private renderSpatialHistory(): void {
+        const output = this.shadowRoot!.getElementById('se-spatial-output');
+        if (!output) return;
+
+        output.innerHTML = this.spatialHistory.map(h =>
+            `<span class="result-prompt">&gt;</span> <span class="result-query">${this.escapeHtml(h.expr)}</span>\n  ${h.html}`,
+        ).join('\n\n');
+        output.scrollTop = output.scrollHeight;
+    }
+
+    // ─── Datum REPL ────────────────────────────────────────────────────
+
+    private executeDatumQuery(): void {
+        const shadow = this.shadowRoot!;
+        const input = shadow.getElementById('se-datum-input') as HTMLInputElement | null;
+        if (!input) return;
+
+        const expr = input.value.trim();
+        if (!expr) return;
+
+        if (!this.dataEvaluator) {
+            this.datumHistory.push({
+                expr,
+                html: '<span class="result-error">Error: No data evaluator. Call enableAccessibility() with a data evaluator.</span>',
+                srText: 'Error: No data evaluator.',
+            });
+            this.renderDatumHistory();
+            return;
+        }
+
+        const result = this.dataEvaluator.evaluate(expr);
+
+        if (result.isError()) {
+            this.datumHistory.push({
+                expr,
+                html: `<span class="result-error">Error: ${this.escapeHtml(result.prettyPrint())}</span>`,
+                srText: `Error: ${result.prettyPrint()}`,
+            });
+        } else if (result.noResult()) {
+            this.datumHistory.push({
+                expr,
+                html: '<span class="result-empty">(empty set — no results)</span>',
+                srText: 'Empty set, no results.',
+            });
+        } else {
+            this.datumHistory.push({
+                expr,
+                html: `<span style="color:#ce9178">${this.escapeHtml(result.prettyPrint())}</span>`,
+                srText: result.prettyPrint(),
+            });
+        }
+
+        this.renderDatumHistory();
+        input.value = '';
+        input.focus();
+    }
+
+    private renderDatumHistory(): void {
+        const output = this.shadowRoot!.getElementById('se-datum-output');
+        if (!output) return;
+
+        output.innerHTML = this.datumHistory.map(h =>
+            `<span class="result-prompt">&gt;</span> <span class="result-query">${this.escapeHtml(h.expr)}</span>\n  ${h.html}`,
+        ).join('\n\n');
+        output.scrollTop = output.scrollHeight;
+    }
+
+    // ─── Focus Coordination ────────────────────────────────────────────
+
+    /**
+     * Navigate to a node by ID — focuses the DN overlay element,
+     * highlights the SVG node, and updates the context panel.
+     */
+    private navigateToNode(nodeId: string): void {
+        const shadow = this.shadowRoot!;
+        const renderId = `dn-node-${this.sanitizeId(nodeId)}`;
+        const el = shadow.getElementById(renderId);
+
+        if (el) {
+            el.focus();
+            this.highlightNodes([nodeId]);
+        }
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────
+
+    /** Push text to the live region for screen reader announcement. */
+    private announce(text: string): void {
+        const liveEl = this.shadowRoot!.getElementById('se-live-region');
+        if (liveEl) liveEl.textContent = text;
+    }
+
+    private enableREPLs(): void {
+        const shadow = this.shadowRoot!;
+        const spatialBtn = shadow.getElementById('se-spatial-btn') as HTMLButtonElement | null;
+        const datumBtn = shadow.getElementById('se-datum-btn') as HTMLButtonElement | null;
+        if (spatialBtn) spatialBtn.disabled = !this.layoutEvaluator;
+        if (datumBtn) datumBtn.disabled = !!this.dataEvaluator === false;
+
+        if (this.layoutEvaluator && this.currentInstanceLayout?.nodes?.[0]) {
+            const firstName = this.currentInstanceLayout.nodes[0].name || this.currentInstanceLayout.nodes[0].id;
+            const spatialInput = shadow.getElementById('se-spatial-input') as HTMLInputElement | null;
+            if (spatialInput) spatialInput.placeholder = `must.rightOf(${firstName})`;
+        }
+    }
+
+    private getNodeLabel(nodeId: string): string {
+        if (!this.accessibleLayout) return nodeId;
+        const desc = this.accessibleLayout.description.nodes.find(
+            n => n.id === nodeId,
+        );
+        return desc ? desc.label : nodeId;
+    }
+
+    private sanitizeId(raw: string): string {
+        return raw.replace(/[^a-zA-Z0-9_-]/g, '_');
+    }
+
+    private escapeHtml(str: string): string {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export { ForgeEvaluator, WrappedForgeEvaluator } from './evaluators/data/forge-e
 export { SQLEvaluator } from './evaluators/data/sql-evaluator';
 export { WebColaTranslator } from './translators';
 export { AccessibleTranslator, buildSpatialNavigationMap } from './translators';
+export { SpytialExplorer } from './components/spytial-explorer';
 export { StructuredInputGraph } from './translators';
 export {
   ignoreHistory,
@@ -104,6 +105,13 @@ if (typeof window !== 'undefined') {
         if (typeof customElements !== 'undefined' && !customElements.get('structured-input-graph')) {
           customElements.define('structured-input-graph', StructuredInputGraph as any);
           //console.log('✅ Structured Input Graph custom element registered');
+        }
+      }).catch(console.error);
+
+      // Register spytial-explorer
+      import('./components/spytial-explorer/spytial-explorer').then(({ SpytialExplorer }) => {
+        if (typeof customElements !== 'undefined' && !customElements.get('spytial-explorer')) {
+          customElements.define('spytial-explorer', SpytialExplorer as any);
         }
       }).catch(console.error);
     }).catch(console.error);

--- a/webcola-demo/accessible-demo.html
+++ b/webcola-demo/accessible-demo.html
@@ -3,285 +3,212 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Spatial Queries as Accessible Affordances</title>
-
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Spatial Explorer — Accessible Diagram Navigation</title>
     <style>
-        * { box-sizing: border-box; }
         body {
-            font-family: Arial, sans-serif;
-            max-width: 95vw;
-            margin: 0 auto;
-            padding: 16px;
-            background-color: #f5f5f5;
-        }
-        .panel {
-            background: white;
-            padding: 16px;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-        button {
-            background-color: #007acc;
-            color: white;
-            border: none;
-            padding: 8px 14px;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 14px;
-        }
-        button:hover { background-color: #005a9e; }
-        button:disabled { background-color: #ccc; cursor: not-allowed; }
-        textarea {
-            width: 100%;
-            font-family: 'Courier New', monospace;
-            font-size: 12px;
-            padding: 8px;
-            border: 1px solid #ddd;
-            border-radius: 4px;
-            resize: vertical;
-            box-sizing: border-box;
-        }
-        #json-input { height: 180px; }
-        #cnd-input { height: 120px; }
-        .status {
-            margin: 8px 0;
-            padding: 8px;
-            border-radius: 4px;
-            font-size: 13px;
-        }
-        .status.info { background: #e3f2fd; color: #1976d2; }
-        .status.success { background: #e8f5e8; color: #2e7d32; }
-        .status.error { background: #ffebee; color: #c62828; }
-
-        /* ─── Main layout: graph+navigator left, REPLs right ─── */
-        #main-area {
-            display: flex;
-            gap: 16px;
-            margin-top: 16px;
-        }
-        #graph-panel {
-            flex: 3;
-            min-width: 500px;
-            display: flex;
-            flex-direction: column;
-            gap: 12px;
-        }
-        #repl-panel {
-            flex: 2;
-            min-width: 350px;
-            display: flex;
-            flex-direction: column;
-            gap: 12px;
-        }
-
-        /* ─── Navigator layer (ARIA tree) ─── */
-        #accessible-html-output {
-            border: 2px solid #5a3d8a;
-            border-radius: 8px;
-            padding: 16px;
-            min-height: 120px;
-            background: #faf8ff;
-        }
-        #accessible-html-output [role="graphics-document"] {
+            margin: 0;
+            padding: 20px;
+            background: #f5f5f5;
             font-family: system-ui, sans-serif;
         }
-        #accessible-html-output .diagram-overview {
-            font-size: 14px;
-            color: #555;
-            margin: 0 0 12px 0;
-            padding-bottom: 8px;
-            border-bottom: 1px solid #eee;
+        .demo-header {
+            max-width: 1400px;
+            margin: 0 auto 16px;
         }
-        #accessible-html-output [role="treeitem"] {
-            padding: 8px 12px;
-            margin: 4px 0;
-            border-radius: 6px;
-            border: 1px solid #e8e8e8;
-            cursor: pointer;
-            outline: none;
-            display: flex;
-            flex-wrap: wrap;
-            align-items: baseline;
-            gap: 6px;
+        .demo-header h1 { font-size: 22px; margin: 0 0 8px; }
+        .demo-header p { font-size: 14px; color: #555; margin: 0 0 8px; line-height: 1.6; }
+        .demo-header code {
+            background: #f0eef8; padding: 1px 5px; border-radius: 3px;
+            font-size: 13px; color: #5a3d8a;
         }
-        #accessible-html-output [role="treeitem"]:hover { background: #f5f5f5; }
-        #accessible-html-output [role="treeitem"]:focus {
-            background: #e8f0fe;
-            box-shadow: 0 0 0 2px #007acc;
-            border-color: #007acc;
+        .usage-guide {
+            max-width: 1400px;
+            margin: 24px auto 0;
+            background: white;
+            border-radius: 8px;
+            padding: 20px 24px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
         }
-        #accessible-html-output .node-label { font-weight: 600; font-size: 15px; }
-        #accessible-html-output .node-type {
-            font-size: 11px; background: #e8e8e8; color: #555;
-            padding: 1px 6px; border-radius: 3px; font-weight: 500;
+        .usage-guide h2 { font-size: 16px; margin: 0 0 12px; }
+        .usage-guide h3 { font-size: 14px; margin: 16px 0 6px; color: #333; }
+        .usage-guide p, .usage-guide li { font-size: 13px; color: #555; line-height: 1.6; }
+        .usage-guide ul { padding-left: 20px; margin: 4px 0; }
+        .usage-guide kbd {
+            background: #eee; border: 1px solid #ccc; border-radius: 3px;
+            padding: 1px 5px; font-size: 12px; font-family: monospace;
         }
-        #accessible-html-output .node-attrs { display: flex; gap: 4px; flex-wrap: wrap; }
-        #accessible-html-output .node-attr {
-            font-size: 12px; background: #eef6ff; color: #1a5276;
-            padding: 1px 6px; border-radius: 3px;
+        .usage-guide pre {
+            background: #1e1e2e; color: #cdd6f4; padding: 14px 16px;
+            border-radius: 6px; font-size: 12.5px; line-height: 1.5;
+            overflow-x: auto; margin: 8px 0;
         }
-        #accessible-html-output .attr-key { font-weight: 600; }
-        #accessible-html-output .node-connections {
-            width: 100%; display: flex; gap: 4px; flex-wrap: wrap; margin-top: 2px;
+        .usage-guide .comment { color: #6c7086; }
+        .usage-guide .keyword { color: #cba6f7; }
+        .usage-guide .string { color: #a6e3a1; }
+        .usage-guide .fn { color: #89b4fa; }
+        .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+        @media (max-width: 800px) { .two-col { grid-template-columns: 1fr; } }
+        .thesis-box {
+            background: #f8f6ff; border-left: 3px solid #5a3d8a; padding: 10px 14px;
+            border-radius: 0 6px 6px 0; margin: 8px 0;
         }
-        #accessible-html-output .node-edge {
-            font-size: 11px; padding: 1px 6px; border-radius: 3px;
-        }
-        #accessible-html-output .node-edge-out { background: #f0faf0; color: #1e6e1e; }
-        #accessible-html-output .node-edge-in { background: #fef5e7; color: #7d5a00; }
-        #accessible-html-output .group-label { font-weight: 600; }
-        #accessible-html-output .node-count { font-weight: 400; color: #888; }
-        #accessible-html-output [role="group"] {
-            padding-left: 16px; border-left: 2px solid #ddd;
-            margin-left: 8px; margin-top: 4px;
-        }
-        #accessible-html-output .diagram-relationships,
-        #accessible-html-output .diagram-spatial { margin-top: 16px; }
-        #accessible-html-output h3 {
-            font-size: 14px; font-weight: 600; margin: 0 0 8px 0; color: #333;
-        }
-        #accessible-html-output table {
-            width: 100%; border-collapse: collapse; font-size: 13px;
-        }
-        #accessible-html-output th, #accessible-html-output td {
-            border: 1px solid #e0e0e0; padding: 5px 10px; text-align: left;
-        }
-        #accessible-html-output th {
-            background: #f5f5f5; font-weight: 600; font-size: 12px;
-            text-transform: uppercase; letter-spacing: 0.5px; color: #666;
-        }
-        #accessible-html-output .diagram-spatial ul { list-style: none; padding: 0; margin: 0; }
-        #accessible-html-output .diagram-spatial li { padding: 4px 0; font-size: 13px; color: #444; }
-        #accessible-html-output .diagram-spatial em { color: #5a3d8a; font-style: normal; font-weight: 500; }
-
-        .sr-only {
-            position: absolute; width: 1px; height: 1px; padding: 0;
-            margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0;
-        }
-
-        /* ─── Spatial context panel ─── */
-        #spatial-context-panel {
-            background: #f0eef8; border: 1px solid #c4b8e0; border-radius: 6px;
-            padding: 12px 16px; font-size: 13px; line-height: 1.5; color: #333;
-        }
-        #spatial-context-panel .context-label { font-weight: 600; color: #5a3d8a; margin-bottom: 4px; }
-        #spatial-context-panel .context-direction {
-            display: inline-block; background: #e8e0f5; padding: 1px 8px;
-            border-radius: 3px; margin: 2px 4px 2px 0; font-size: 12px;
-        }
-        #spatial-context-panel .context-group {
-            display: inline-block; background: #e0f0e0; padding: 1px 8px;
-            border-radius: 3px; margin: 2px 4px 2px 0; font-size: 12px;
-        }
-
-        /* ─── REPL styling ─── */
-        .repl-section { margin-bottom: 0; }
-        .repl-section h3 { font-size: 14px; font-weight: 600; margin: 0 0 6px 0; color: #333; }
-        .repl-output {
-            font-family: 'Courier New', monospace; font-size: 13px;
-            background: #1e1e1e; color: #d4d4d4; padding: 12px;
-            border-radius: 6px; max-height: 250px; overflow-y: auto; white-space: pre-wrap;
-        }
-        .query-result-atom {
-            cursor: pointer; text-decoration: underline; text-decoration-style: dotted;
-        }
-        .query-result-atom:hover { text-decoration-style: solid; color: #4ec9b0; }
-
-        /* ─── Input details ─── */
-        #input-details summary {
-            cursor: pointer; font-weight: 600; padding: 8px 0; color: #555;
-        }
-        #input-details[open] summary { margin-bottom: 8px; }
-
-        @media (max-width: 900px) {
-            #main-area { flex-direction: column; }
-            #graph-panel, #repl-panel { min-width: unset; }
-        }
+        .thesis-box p { color: #3a2a5a; margin: 0; }
     </style>
 </head>
 <body>
-
-    <!-- ─── Header ─── -->
-    <div class="panel border" style="margin-bottom: 0;">
-        <h1 class="h4" style="margin-bottom: 8px;">Spatial Queries as Accessible Affordances</h1>
-        <p class="text-muted small" style="margin-bottom: 4px;">
-            In visual tools, <strong>dragging</strong> reveals what spatial arrangements are possible.
-            The spatial REPL provides the same exploration non-visually:
-            <code>must.leftOf(Node0)</code> answers "what <em>must</em> always be to the left?"
-            &mdash; information locked behind drag interaction in existing tools.
+    <div class="demo-header">
+        <h1>Spatial Explorer</h1>
+        <p>
+            <code>&lt;spytial-explorer&gt;</code> is a drop-in replacement for
+            <code>&lt;webcola-cnd-graph&gt;</code> that integrates
+            <a href="https://github.com/cmudig/data-navigator">Data Navigator</a>
+            with Spytial's constraint-derived spatial model. The result: keyboard navigation
+            and spatial queries that <em>no</em> existing tool can derive from pixels alone.
         </p>
-        <p class="text-muted small" style="margin-bottom: 0;">
-            <strong>Graph</strong> (what sighted users see) &rarr;
-            <strong>Navigator</strong> (non-visual traversal via constraints) &rarr;
-            <strong>REPLs</strong> (non-visual exploration &mdash; replaces drag).
-        </p>
+        <div class="thesis-box">
+            <p><strong>Key insight:</strong> The REPL replaces <em>drag-to-explore</em> as an
+            interaction primitive. Instead of visually scanning a diagram to answer
+            "what is to the right of this node?", a screen reader user can type
+            <code>must.rightOf(Node0)</code> and get a provably correct answer
+            &mdash; grounded in the constraint graph, not pixel coordinates.</p>
+        </div>
     </div>
 
-    <!-- ─── Collapsible input ─── -->
-    <details id="input-details" class="panel border" style="margin-top: 8px;">
-        <summary>Data &amp; Layout Specification (click to edit)</summary>
-        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
-            <div style="flex: 1; min-width: 300px;">
-                <label for="json-input" style="font-weight: bold; display: block; margin-bottom: 4px;">JSON Data Instance:</label>
-                <textarea id="json-input">{
-  "atoms": [
-    { "id": "Node0", "type": "Node", "label": "Node (10)" },
-    { "id": "Node1", "type": "Node", "label": "Node (5)" },
-    { "id": "Node2", "type": "Node", "label": "Node (15)" },
-    { "id": "Node3", "type": "Node", "label": "Node (3)" },
-    { "id": "Node4", "type": "Node", "label": "Node (7)" },
-    { "id": "Node5", "type": "Node", "label": "Node (12)" },
-    { "id": "Node6", "type": "Node", "label": "Node (18)" },
-    { "id": "Int0", "type": "Int", "label": "10" },
-    { "id": "Int1", "type": "Int", "label": "5" },
-    { "id": "Int2", "type": "Int", "label": "15" },
-    { "id": "Int3", "type": "Int", "label": "3" },
-    { "id": "Int4", "type": "Int", "label": "7" },
-    { "id": "Int5", "type": "Int", "label": "12" },
-    { "id": "Int6", "type": "Int", "label": "18" }
-  ],
-  "relations": [
-    {
-      "id": "Node&lt;:left",
-      "name": "left",
-      "types": ["Node", "Node"],
-      "tuples": [
-        { "atoms": ["Node0", "Node1"], "types": ["Node", "Node"] },
-        { "atoms": ["Node1", "Node3"], "types": ["Node", "Node"] },
-        { "atoms": ["Node2", "Node5"], "types": ["Node", "Node"] }
-      ]
-    },
-    {
-      "id": "Node&lt;:right",
-      "name": "right",
-      "types": ["Node", "Node"],
-      "tuples": [
-        { "atoms": ["Node0", "Node2"], "types": ["Node", "Node"] },
-        { "atoms": ["Node1", "Node4"], "types": ["Node", "Node"] },
-        { "atoms": ["Node2", "Node6"], "types": ["Node", "Node"] }
-      ]
-    },
-    {
-      "id": "Node&lt;:val",
-      "name": "val",
-      "types": ["Node", "Int"],
-      "tuples": [
-        { "atoms": ["Node0", "Int0"], "types": ["Node", "Int"] },
-        { "atoms": ["Node1", "Int1"], "types": ["Node", "Int"] },
-        { "atoms": ["Node2", "Int2"], "types": ["Node", "Int"] },
-        { "atoms": ["Node3", "Int3"], "types": ["Node", "Int"] },
-        { "atoms": ["Node4", "Int4"], "types": ["Node", "Int"] },
-        { "atoms": ["Node5", "Int5"], "types": ["Node", "Int"] },
-        { "atoms": ["Node6", "Int6"], "types": ["Node", "Int"] }
-      ]
-    }
-  ]
-}</textarea>
+    <spytial-explorer id="explorer" width="900" height="500"></spytial-explorer>
+
+    <!-- ─── Usage Guide ─────────────────────────────────────────────── -->
+    <div class="usage-guide">
+        <h2>How to Use This Demo</h2>
+
+        <div class="two-col">
+            <div>
+                <h3>Keyboard Navigation (Data Navigator)</h3>
+                <ul>
+                    <li>Click <strong>"Enter diagram navigation"</strong> (or <kbd>Tab</kbd> to it) to start</li>
+                    <li><kbd>&larr;</kbd> <kbd>&rarr;</kbd> <kbd>&uarr;</kbd> <kbd>&darr;</kbd> &mdash; move between nodes spatially (current layout)</li>
+                    <li><kbd>Shift</kbd>+<kbd>&larr;</kbd> etc. &mdash; move only along <strong>must</strong> relationships (guaranteed in ALL valid layouts)</li>
+                    <li><kbd>Enter</kbd> &mdash; drill into a group (navigate among group members)</li>
+                    <li><kbd>Esc</kbd> &mdash; leave group, or exit diagram navigation</li>
+                    <li>The <strong>Spatial Context</strong> panel updates live with modality badges (<span style="background:#c8e6c9;padding:0 4px;border-radius:2px;font-size:11px;font-weight:700">MUST</span> / <span style="background:#fff3e0;padding:0 4px;border-radius:2px;font-size:11px;font-weight:700">CAN</span>)</li>
+                </ul>
+
+                <h3>Spatial Queries (REPL)</h3>
+                <ul>
+                    <li><code>must.rightOf(Node0)</code> &mdash; nodes that <em>must</em> be right of Node0 in <strong>all</strong> valid layouts</li>
+                    <li><code>can.leftOf(Node1)</code> &mdash; nodes that <em>can</em> be left of Node1 in <strong>some</strong> valid layout</li>
+                    <li><code>cannot.above(Node2)</code> &mdash; nodes that <em>cannot</em> be above Node2 in <strong>any</strong> valid layout</li>
+                    <li>Results are clickable &mdash; click a result atom to navigate to that node</li>
+                </ul>
             </div>
-            <div style="flex: 0 0 280px;">
-                <label for="cnd-input" style="font-weight: bold; display: block; margin-bottom: 4px;">Layout Specification (CND):</label>
-                <textarea id="cnd-input">constraints:
+            <div>
+                <h3>Data Queries (REPL)</h3>
+                <ul>
+                    <li><code>Node</code> &mdash; all atoms of type Node</li>
+                    <li><code>Node.left</code> &mdash; follow the <em>left</em> relation from all Nodes</li>
+                    <li><code>Node.left.val</code> &mdash; chain relations: left children's values</li>
+                </ul>
+
+                <h3>Why This Matters</h3>
+                <p>
+                    Traditional diagram accessibility tools (alt text, ARIA trees) describe
+                    <em>what</em> is in a diagram. Spytial answers <em>why</em>: the spatial
+                    layout is derived from constraints, not arbitrary positioning. This means:
+                </p>
+                <ul>
+                    <li><strong>must</strong> queries give guarantees &mdash; true regardless of layout variation</li>
+                    <li><strong>can/cannot</strong> queries reveal structural degrees of freedom</li>
+                    <li>Data Navigator gets <em>spatial semantics it can't derive on its own</em> from the constraint graph</li>
+                </ul>
+            </div>
+        </div>
+
+        <h3>Using <code>&lt;spytial-explorer&gt;</code> in Your Own Page</h3>
+<pre><span class="comment">&lt;!-- 1. Include dependencies --&gt;</span>
+&lt;script src=<span class="string">"d3.v4.min.js"</span>&gt;&lt;/script&gt;
+&lt;script src=<span class="string">"cola.js"</span>&gt;&lt;/script&gt;
+&lt;script src=<span class="string">"spytial-core-complete.global.js"</span>&gt;&lt;/script&gt;
+
+<span class="comment">&lt;!-- 2. Drop in the element (same attributes as webcola-cnd-graph) --&gt;</span>
+&lt;spytial-explorer id=<span class="string">"explorer"</span> width=<span class="string">"800"</span> height=<span class="string">"500"</span>&gt;&lt;/spytial-explorer&gt;
+
+&lt;script&gt;
+  <span class="comment">// 3. Run the standard layout pipeline</span>
+  <span class="keyword">const</span> instance  = <span class="keyword">new</span> spytialcore.<span class="fn">JSONDataInstance</span>(jsonText);
+  <span class="keyword">const</span> evaluator = <span class="keyword">new</span> spytialcore.<span class="fn">SGraphQueryEvaluator</span>();
+  evaluator.<span class="fn">initialize</span>({ sourceData: instance });
+  <span class="keyword">const</span> layoutSpec = spytialcore.<span class="fn">parseLayoutSpec</span>(cndYaml);
+  <span class="keyword">const</span> li = <span class="keyword">new</span> spytialcore.<span class="fn">LayoutInstance</span>(layoutSpec, evaluator, 0, <span class="keyword">true</span>);
+  <span class="keyword">const</span> result = li.<span class="fn">generateLayout</span>(instance);
+
+  <span class="comment">// 4. Render (inherited from WebColaCnDGraph)</span>
+  <span class="keyword">await</span> explorer.<span class="fn">renderLayout</span>(result.layout);
+
+  <span class="comment">// 5. One call enables all a11y features:</span>
+  <span class="comment">//    Data Navigator overlay, spatial context, spatial + datum REPLs</span>
+  explorer.<span class="fn">enableAccessibility</span>(result.layout, result.validator, evaluator);
+&lt;/script&gt;</pre>
+    </div>
+
+    <!-- Load the library bundle (registers <spytial-explorer> automatically) -->
+    <script src="https://d3js.org/d3.v4.min.js"></script>
+    <script src="../vendor/cola.js"></script>
+    <script src="../dist/browser/spytial-core-complete.global.js"></script>
+
+    <script>
+        // BST example data
+        const BST_JSON = {
+            atoms: [
+                { id: "Node0", type: "Node", label: "Node (10)" },
+                { id: "Node1", type: "Node", label: "Node (5)" },
+                { id: "Node2", type: "Node", label: "Node (15)" },
+                { id: "Node3", type: "Node", label: "Node (3)" },
+                { id: "Node4", type: "Node", label: "Node (7)" },
+                { id: "Node5", type: "Node", label: "Node (12)" },
+                { id: "Node6", type: "Node", label: "Node (18)" },
+                { id: "Int0", type: "Int", label: "10" },
+                { id: "Int1", type: "Int", label: "5" },
+                { id: "Int2", type: "Int", label: "15" },
+                { id: "Int3", type: "Int", label: "3" },
+                { id: "Int4", type: "Int", label: "7" },
+                { id: "Int5", type: "Int", label: "12" },
+                { id: "Int6", type: "Int", label: "18" }
+            ],
+            relations: [
+                {
+                    id: "Node<:left", name: "left",
+                    types: ["Node", "Node"],
+                    tuples: [
+                        { atoms: ["Node0", "Node1"], types: ["Node", "Node"] },
+                        { atoms: ["Node1", "Node3"], types: ["Node", "Node"] },
+                        { atoms: ["Node2", "Node5"], types: ["Node", "Node"] }
+                    ]
+                },
+                {
+                    id: "Node<:right", name: "right",
+                    types: ["Node", "Node"],
+                    tuples: [
+                        { atoms: ["Node0", "Node2"], types: ["Node", "Node"] },
+                        { atoms: ["Node1", "Node4"], types: ["Node", "Node"] },
+                        { atoms: ["Node2", "Node6"], types: ["Node", "Node"] }
+                    ]
+                },
+                {
+                    id: "Node<:val", name: "val",
+                    types: ["Node", "Int"],
+                    tuples: [
+                        { atoms: ["Node0", "Int0"], types: ["Node", "Int"] },
+                        { atoms: ["Node1", "Int1"], types: ["Node", "Int"] },
+                        { atoms: ["Node2", "Int2"], types: ["Node", "Int"] },
+                        { atoms: ["Node3", "Int3"], types: ["Node", "Int"] },
+                        { atoms: ["Node4", "Int4"], types: ["Node", "Int"] },
+                        { atoms: ["Node5", "Int5"], types: ["Node", "Int"] },
+                        { atoms: ["Node6", "Int6"], types: ["Node", "Int"] }
+                    ]
+                }
+            ]
+        };
+
+        const BST_CND = `constraints:
   - orientation:
       selector: left
       directions:
@@ -290,495 +217,57 @@
 directives:
   - attribute:
       field: val
-  - flag: hideDisconnectedBuiltIns</textarea>
-                <button id="translateButton" onclick="runTranslation()" style="margin-top: 8px;">Re-translate</button>
-                <div id="status" class="status info">Loading...</div>
-            </div>
-        </div>
-    </details>
+  - flag: hideDisconnectedBuiltIns`;
 
-    <!-- ─── Main area: graph+navigator | REPLs ─── -->
-    <div id="main-area">
+        // ─── Pipeline ─────────────────────────────────────────────────
+        async function init() {
+            // Wait for custom elements to be defined
+            await customElements.whenDefined('spytial-explorer');
 
-        <!-- Left: Graph + Navigator layer -->
-        <div id="graph-panel" class="panel border">
-            <!-- Visual graph -->
-            <div>
-                <h2 class="h6" style="margin: 0 0 8px 0;">Visual Graph</h2>
-                <webcola-cnd-graph
-                    id="graph-container"
-                    width="600"
-                    height="400"
-                    layoutFormat="default"
-                    aria-label="Visual graph rendering">
-                </webcola-cnd-graph>
-            </div>
+            const explorer = document.getElementById('explorer');
 
-            <!-- Data Navigator layer -->
-            <div>
-                <h2 class="h6" style="margin: 0 0 4px 0;">Navigator</h2>
-                <p class="text-muted small" style="margin-bottom: 8px;">
-                    Use <kbd>Tab</kbd> to enter. <kbd>Alt</kbd>+Arrow keys navigate
-                    spatially (constraint-derived). Plain arrows use tree navigation.
-                </p>
-                <div id="accessible-html-output">
-                    <p class="text-muted">Loading...</p>
-                </div>
-            </div>
-        </div>
-
-        <!-- Right: Context + REPLs -->
-        <div id="repl-panel">
-
-            <!-- Spatial context — live updates on node focus -->
-            <div class="panel border">
-                <div id="spatial-context-panel" role="region" aria-label="Spatial context for focused node">
-                    <div class="context-label">Spatial Context</div>
-                    <div id="spatial-context-content">Navigate to a node to see its spatial context.</div>
-                </div>
-                <!-- Screen-reader-only live region -->
-                <div id="spatial-live-region" aria-live="polite" aria-atomic="true" class="sr-only"></div>
-            </div>
-
-            <!-- Spatial REPL -->
-            <div class="panel border repl-section">
-                <h3>Spatial Queries <span class="text-muted" style="font-weight:normal; font-size:12px;">(diagram)</span></h3>
-                <p class="text-muted small" style="margin-bottom: 6px;">
-                    Query what <em>must</em>, <em>can</em>, or <em>cannot</em> hold spatially.
-                    These answer questions locked behind drag interaction in visual tools.
-                </p>
-                <div style="display: flex; gap: 8px; margin-bottom: 8px;">
-                    <label for="query-input" class="sr-only">Spatial query expression</label>
-                    <input type="text" id="query-input" placeholder="must.rightOf(Node0)"
-                           aria-describedby="query-input-hint"
-                           style="flex: 1; font-family: 'Courier New', monospace; font-size: 14px; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px;"
-                           onkeydown="if(event.key==='Enter') runQuery()">
-                    <span id="query-input-hint" class="sr-only">Enter a spatial query like must.rightOf(Node0) and press Enter. Click results to navigate to them.</span>
-                    <button onclick="runQuery()" id="query-button" disabled>Query</button>
-                </div>
-                <div id="query-output" role="log" aria-label="Spatial query results" aria-live="polite" class="repl-output">
-<span style="color:#9cdcfe">Modalities:</span>
-  <span style="color:#ce9178">must</span>  &mdash; true in ALL valid layouts
-  <span style="color:#ce9178">can</span>   &mdash; true in SOME valid layout
-  <span style="color:#ce9178">cannot</span> &mdash; true in NO valid layout
-
-<span style="color:#9cdcfe">Try:</span>
-  <span style="color:#4ec9b0">must.rightOf(Node0)</span>   <span style="color:#4ec9b0">can.leftOf(Node1)</span>
-  <span style="color:#4ec9b0">cannot.above(Node2)</span>   <span style="color:#4ec9b0">must.aligned.x(Node0)</span>
-  <span style="color:#4ec9b0">grouped(Node0)</span>        <span style="color:#4ec9b0">contains(G1)</span></div>
-            </div>
-
-            <!-- Datum REPL -->
-            <div class="panel border repl-section">
-                <h3>Data Queries <span class="text-muted" style="font-weight:normal; font-size:12px;">(datum)</span></h3>
-                <p class="text-muted small" style="margin-bottom: 6px;">
-                    Query the underlying data instance. Navigate relations with dot notation.
-                </p>
-                <div style="display: flex; gap: 8px; margin-bottom: 8px;">
-                    <label for="datum-input" class="sr-only">Data query expression</label>
-                    <input type="text" id="datum-input" placeholder="Node.left.val"
-                           aria-describedby="datum-input-hint"
-                           style="flex: 1; font-family: 'Courier New', monospace; font-size: 14px; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px;"
-                           onkeydown="if(event.key==='Enter') runDatumQuery()">
-                    <span id="datum-input-hint" class="sr-only">Enter a data query like Node.left.val and press Enter</span>
-                    <button onclick="runDatumQuery()" id="datum-button" disabled>Query</button>
-                </div>
-                <div id="datum-output" role="log" aria-label="Data query results" aria-live="polite" class="repl-output">
-<span style="color:#9cdcfe">Try:</span>
-  <span style="color:#4ec9b0">Node</span>              <span style="color:#4ec9b0">left</span>
-  <span style="color:#4ec9b0">Node.left</span>         <span style="color:#4ec9b0">Node.val</span>
-  <span style="color:#4ec9b0">Node.left.val</span>     <span style="color:#4ec9b0">Node.right.val</span></div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Scripts -->
-    <script src="https://d3js.org/d3.v4.min.js"></script>
-    <script src="../vendor/cola.js"></script>
-    <script src="../dist/browser/spytial-core-complete.global.js"></script>
-    <script>
-        const CndCore = spytialcore;
-
-        // ─── State ─────────────────────────────────────────────────────────
-        let currentAccessibleLayout = null;
-        let currentLayoutEvaluator = null;
-        let currentDataEvaluator = null;
-        let queryHistory = [];
-        let datumQueryHistory = [];
-
-        // ─── Status ────────────────────────────────────────────────────────
-        function updateStatus(message, type) {
-            const el = document.getElementById('status');
-            el.textContent = message;
-            el.className = 'status ' + type;
-        }
-
-        // ─── Main Pipeline ─────────────────────────────────────────────────
-        async function runTranslation() {
             try {
-                updateStatus('Processing...', 'info');
+                // 1. Parse JSON data
+                const instance = new spytialcore.JSONDataInstance(JSON.stringify(BST_JSON));
 
-                const jsonText = document.getElementById('json-input').value;
-                if (!jsonText.trim()) throw new Error('Please enter JSON data.');
-
-                const instance = new CndCore.JSONDataInstance(jsonText);
-
-                const evaluator = new CndCore.SGraphQueryEvaluator();
+                // 2. Create data evaluator
+                const evaluator = new spytialcore.SGraphQueryEvaluator();
                 evaluator.initialize({ sourceData: instance });
-                currentDataEvaluator = evaluator;
 
-                const cndSpec = document.getElementById('cnd-input').value || '';
-                const layoutSpec = CndCore.parseLayoutSpec(cndSpec);
+                // 3. Parse layout spec
+                const layoutSpec = spytialcore.parseLayoutSpec(BST_CND);
 
-                const layoutInstance = new CndCore.LayoutInstance(layoutSpec, evaluator, 0, true);
+                // 4. Generate InstanceLayout
+                const layoutInstance = new spytialcore.LayoutInstance(layoutSpec, evaluator, 0, true);
                 const layoutResult = layoutInstance.generateLayout(instance);
 
-                if (layoutResult.selectorErrors?.length > 0) {
-                    console.warn('Selector errors:', layoutResult.selectorErrors);
-                }
                 if (layoutResult.error) {
                     console.warn('Layout error (continuing):', layoutResult.error.message);
                 }
 
-                // Accessible translation
-                const translator = new CndCore.AccessibleTranslator();
-                currentAccessibleLayout = translator.translate(layoutResult.layout);
+                // 5. Render the graph (inherited from WebColaCnDGraph)
+                await explorer.renderLayout(layoutResult.layout);
 
-                // Layout evaluator for spatial REPL
-                currentLayoutEvaluator = null;
-                if (layoutResult.validator) {
-                    currentLayoutEvaluator = new CndCore.LayoutEvaluator(
-                        layoutResult.validator, layoutResult.layout
-                    );
-                    document.getElementById('query-button').disabled = false;
-                    document.getElementById('query-input').placeholder = 'must.rightOf(' +
-                        (layoutResult.layout.nodes?.[0]?.name || layoutResult.layout.nodes?.[0]?.id || 'Node0') + ')';
-                } else {
-                    document.getElementById('query-button').disabled = true;
-                }
+                // 6. Enable accessibility: Data Navigator overlay + context + REPLs
+                explorer.enableAccessibility(
+                    layoutResult.layout,
+                    layoutResult.validator || null,
+                    evaluator
+                );
 
-                document.getElementById('datum-button').disabled = false;
-
-                // Render navigator layer
-                renderNavigator(currentAccessibleLayout);
-
-                // Render visual graph
-                renderVisualGraph(layoutResult.layout);
-
-                updateStatus('Ready. Navigate the tree or query the REPLs.', 'success');
+                console.log('Spatial Explorer initialized with BST example');
 
             } catch (error) {
-                console.error('Translation failed:', error);
-                updateStatus('Error: ' + error.message, 'error');
-                currentDataEvaluator = null;
-                currentLayoutEvaluator = null;
-                document.getElementById('datum-button').disabled = true;
-                document.getElementById('query-button').disabled = true;
+                console.error('Pipeline failed:', error);
             }
         }
 
-        // ─── Navigator Renderer ────────────────────────────────────────────
-
-        function renderNavigator(accessible) {
-            const container = document.getElementById('accessible-html-output');
-            container.innerHTML = accessible.toHTML();
-            wireUpKeyboardNavigation(container);
+        // Run after DOM + scripts are loaded
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
         }
-
-        // ─── Keyboard Navigation ───────────────────────────────────────────
-
-        function wireUpKeyboardNavigation(container) {
-            const treeItems = container.querySelectorAll('[role="treeitem"]');
-            if (treeItems.length === 0) return;
-
-            treeItems[0].setAttribute('tabindex', '0');
-
-            // Use event delegation on the persistent container for focusin
-            container.addEventListener('focusin', (e) => {
-                const node = e.target.closest('[role="treeitem"]');
-                if (node) updateSpatialContext(node);
-            });
-
-            container.addEventListener('keydown', (e) => {
-                const current = document.activeElement;
-                if (!current || current.getAttribute('role') !== 'treeitem') return;
-
-                // Alt+Arrow = spatial navigation (constraint-based)
-                if (e.altKey) {
-                    let targetId = null;
-                    switch (e.key) {
-                        case 'ArrowUp': targetId = current.getAttribute('data-nav-above'); break;
-                        case 'ArrowDown': targetId = current.getAttribute('data-nav-below'); break;
-                        case 'ArrowLeft': targetId = current.getAttribute('data-nav-left'); break;
-                        case 'ArrowRight': targetId = current.getAttribute('data-nav-right'); break;
-                        default: return;
-                    }
-                    if (targetId) {
-                        e.preventDefault();
-                        focusNodeById(container, current, targetId);
-                    }
-                    return;
-                }
-
-                // Standard WAI-ARIA tree navigation
-                const allItems = Array.from(container.querySelectorAll('[role="treeitem"]'));
-                const idx = allItems.indexOf(current);
-
-                switch (e.key) {
-                    case 'ArrowUp':
-                        if (idx > 0) { e.preventDefault(); focusNode(current, allItems[idx - 1]); }
-                        break;
-                    case 'ArrowDown':
-                        if (idx < allItems.length - 1) { e.preventDefault(); focusNode(current, allItems[idx + 1]); }
-                        break;
-                    case 'ArrowLeft':
-                        if (current.getAttribute('aria-expanded') === 'true') {
-                            e.preventDefault();
-                            current.setAttribute('aria-expanded', 'false');
-                            const group = current.querySelector('[role="group"]');
-                            if (group) group.hidden = true;
-                        } else {
-                            const parentGroup = current.closest('[role="group"]');
-                            if (parentGroup) {
-                                const parentItem = parentGroup.closest('[role="treeitem"]');
-                                if (parentItem) { e.preventDefault(); focusNode(current, parentItem); }
-                            }
-                        }
-                        break;
-                    case 'ArrowRight':
-                        if (current.getAttribute('aria-expanded') === 'false') {
-                            e.preventDefault();
-                            current.setAttribute('aria-expanded', 'true');
-                            const group = current.querySelector('[role="group"]');
-                            if (group) group.hidden = false;
-                        } else if (current.getAttribute('aria-expanded') === 'true') {
-                            const firstChild = current.querySelector('[role="group"] > [role="treeitem"]');
-                            if (firstChild) { e.preventDefault(); focusNode(current, firstChild); }
-                        }
-                        break;
-                }
-            });
-        }
-
-        function focusNode(from, to) {
-            from.setAttribute('tabindex', '-1');
-            to.setAttribute('tabindex', '0');
-            to.focus();
-        }
-
-        function focusNodeById(container, from, targetId) {
-            const target = container.querySelector('#' + targetId);
-            if (target) focusNode(from, target);
-        }
-
-        // ─── Spatial Context ───────────────────────────────────────────────
-
-        function updateSpatialContext(nodeElement) {
-            if (!currentAccessibleLayout) return;
-
-            const elementId = nodeElement.id;
-            if (!elementId || !elementId.startsWith('node-')) return;
-
-            const nodeId = elementId.replace('node-', '');
-            const nb = currentAccessibleLayout.navigation.getNeighbors(nodeId);
-            if (!nb) return;
-
-            const nodeDesc = currentAccessibleLayout.description.nodes.find(n =>
-                sanitizeIdJS(n.id) === nodeId
-            );
-
-            const contextEl = document.getElementById('spatial-context-content');
-            const liveEl = document.getElementById('spatial-live-region');
-            if (!contextEl || !liveEl) return;
-
-            const label = nodeDesc ? nodeDesc.label : nodeId;
-            const type = nodeDesc ? nodeDesc.mostSpecificType : '';
-
-            const directions = [];
-            if (nb.above) directions.push({ dir: 'Above', label: getNodeLabel(nb.above) });
-            if (nb.below) directions.push({ dir: 'Below', label: getNodeLabel(nb.below) });
-            if (nb.left) directions.push({ dir: 'Left', label: getNodeLabel(nb.left) });
-            if (nb.right) directions.push({ dir: 'Right', label: getNodeLabel(nb.right) });
-
-            // Visual panel
-            let html = `<strong>${esc(label)}</strong>`;
-            if (type) html += ` <span class="context-direction">${esc(type)}</span>`;
-            html += '<br>';
-
-            if (directions.length > 0) {
-                html += directions.map(d =>
-                    `<span class="context-direction">${d.dir}: <strong>${esc(d.label)}</strong></span>`
-                ).join(' ');
-            } else {
-                html += '<span style="color:#888">No spatial neighbors (unconstrained)</span>';
-            }
-
-            if (nb.containingGroups.length > 0) {
-                html += '<br>' + nb.containingGroups.map(g =>
-                    `<span class="context-group">In: ${esc(g)}</span>`
-                ).join(' ');
-            }
-
-            contextEl.innerHTML = html;
-
-            // Screen-reader announcement
-            const srParts = [];
-            if (nb.above) srParts.push(`above ${getNodeLabel(nb.above)}`);
-            if (nb.below) srParts.push(`below ${getNodeLabel(nb.below)}`);
-            if (nb.left) srParts.push(`left of ${getNodeLabel(nb.left)}`);
-            if (nb.right) srParts.push(`right of ${getNodeLabel(nb.right)}`);
-
-            let srText = label;
-            if (srParts.length > 0) srText += '. ' + srParts.join(', ') + '.';
-            if (nb.containingGroups.length > 0) {
-                srText += ' In group ' + nb.containingGroups.join(', ') + '.';
-            }
-            liveEl.textContent = srText;
-        }
-
-        function getNodeLabel(nodeId) {
-            if (!currentAccessibleLayout) return nodeId;
-            const desc = currentAccessibleLayout.description.nodes.find(n =>
-                sanitizeIdJS(n.id) === nodeId || n.id === nodeId
-            );
-            return desc ? desc.label : nodeId;
-        }
-
-        function sanitizeIdJS(raw) {
-            return raw.replace(/[^a-zA-Z0-9_-]/g, '_');
-        }
-
-        // ─── Visual Graph ──────────────────────────────────────────────────
-
-        async function renderVisualGraph(layout) {
-            try {
-                const graph = document.getElementById('graph-container');
-                if (graph && graph.renderLayout) await graph.renderLayout(layout);
-            } catch (e) {
-                console.warn('Visual render failed:', e);
-            }
-        }
-
-        // ─── Spatial Query REPL ────────────────────────────────────────────
-
-        function runQuery() {
-            const input = document.getElementById('query-input');
-            const output = document.getElementById('query-output');
-            const expr = input.value.trim();
-            if (!expr) return;
-
-            if (!currentLayoutEvaluator) {
-                output.innerHTML = '<span style="color:#f44336" role="alert">Error: No layout evaluator available.</span>';
-                return;
-            }
-
-            const result = currentLayoutEvaluator.evaluate(expr);
-
-            if (result.isError()) {
-                queryHistory.push({
-                    expr,
-                    html: `<span style="color:#f44336">Error: ${esc(result.prettyPrint())}</span>`,
-                });
-            } else if (result.noResult()) {
-                queryHistory.push({
-                    expr,
-                    html: `<span style="color:#888">(empty set &mdash; no results)</span>`,
-                });
-            } else {
-                const atoms = result.selectedAtoms();
-                const atomHtml = atoms.map(a =>
-                    `<span class="query-result-atom" role="link" tabindex="0" data-node-id="${esc(sanitizeIdJS(a))}" onclick="focusNodeFromQuery(this)" onkeydown="if(event.key==='Enter')focusNodeFromQuery(this)" style="color:#ce9178">${esc(a)}</span>`
-                ).join(', ');
-                queryHistory.push({
-                    expr,
-                    html: `<span style="color:#9cdcfe">{</span> ${atomHtml} <span style="color:#9cdcfe">}</span>  <span style="color:#666">(${atoms.length} result${atoms.length !== 1 ? 's' : ''})</span>`,
-                });
-            }
-
-            const historyLines = queryHistory.map(h =>
-                `<span style="color:#888">&gt;</span> <span style="color:#4ec9b0">${esc(h.expr)}</span>\n  ${h.html}`
-            );
-            output.innerHTML = historyLines.join('\n\n');
-            output.scrollTop = output.scrollHeight;
-            input.value = '';
-            input.focus();
-        }
-
-        function focusNodeFromQuery(element) {
-            const nodeId = element.getAttribute('data-node-id');
-            if (!nodeId) return;
-
-            const container = document.getElementById('accessible-html-output');
-            const target = container.querySelector('#node-' + nodeId);
-            if (target) {
-                container.querySelectorAll('[role="treeitem"][tabindex="0"]').forEach(el => {
-                    el.setAttribute('tabindex', '-1');
-                });
-                target.setAttribute('tabindex', '0');
-                target.focus();
-                target.style.outline = '3px solid #4ec9b0';
-                setTimeout(() => { target.style.outline = ''; }, 1500);
-            }
-        }
-
-        // ─── Data Query REPL ───────────────────────────────────────────────
-
-        function runDatumQuery() {
-            const input = document.getElementById('datum-input');
-            const output = document.getElementById('datum-output');
-            const expr = input.value.trim();
-            if (!expr) return;
-
-            if (!currentDataEvaluator) {
-                output.innerHTML = '<span style="color:#f44336" role="alert">Error: No data evaluator available.</span>';
-                return;
-            }
-
-            const result = currentDataEvaluator.evaluate(expr);
-
-            if (result.isError()) {
-                datumQueryHistory.push({
-                    expr,
-                    html: `<span style="color:#f44336">Error: ${esc(result.prettyPrint())}</span>`,
-                });
-            } else if (result.noResult()) {
-                datumQueryHistory.push({
-                    expr,
-                    html: `<span style="color:#888">(empty set &mdash; no results)</span>`,
-                });
-            } else {
-                datumQueryHistory.push({
-                    expr,
-                    html: `<span style="color:#ce9178">${esc(result.prettyPrint())}</span>`,
-                });
-            }
-
-            const historyLines = datumQueryHistory.map(h =>
-                `<span style="color:#888">&gt;</span> <span style="color:#4ec9b0">${esc(h.expr)}</span>\n  ${h.html}`
-            );
-            output.innerHTML = historyLines.join('\n\n');
-            output.scrollTop = output.scrollHeight;
-            input.value = '';
-            input.focus();
-        }
-
-        // ─── Utilities ─────────────────────────────────────────────────────
-
-        function esc(str) {
-            const div = document.createElement('div');
-            div.textContent = str;
-            return div.innerHTML;
-        }
-
-        // ─── Init: auto-translate on load ──────────────────────────────────
-
-        window.addEventListener('load', () => {
-            if (typeof CndCore !== 'undefined' && CndCore.AccessibleTranslator) {
-                runTranslation();
-            } else {
-                updateStatus('Error: CndCore bundle not loaded.', 'error');
-            }
-        });
     </script>
 </body>
 </html>

--- a/webcola-demo/accessible-demo.html
+++ b/webcola-demo/accessible-demo.html
@@ -3,46 +3,32 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Accessible Layout Translator Demo</title>
+    <title>Spatial Queries as Accessible Affordances</title>
 
-    <!-- Bootstrap CSS for component styling -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
+        * { box-sizing: border-box; }
         body {
-            display: flex;
             font-family: Arial, sans-serif;
-            max-width: 90vw;
+            max-width: 95vw;
             margin: 0 auto;
-            padding: 20px;
+            padding: 16px;
             background-color: #f5f5f5;
-            gap: 20px;
         }
         .panel {
             background: white;
-            padding: 20px;
+            padding: 16px;
             border-radius: 8px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-        #input-panel {
-            flex: 1;
-            min-width: 400px;
-        }
-        #output-panel {
-            flex: 2;
-            min-width: 500px;
-            display: flex;
-            flex-direction: column;
-            gap: 16px;
         }
         button {
             background-color: #007acc;
             color: white;
             border: none;
-            padding: 10px 15px;
+            padding: 8px 14px;
             border-radius: 4px;
             cursor: pointer;
             font-size: 14px;
-            margin: 5px 0;
         }
         button:hover { background-color: #005a9e; }
         button:disabled { background-color: #ccc; cursor: not-allowed; }
@@ -50,34 +36,51 @@
             width: 100%;
             font-family: 'Courier New', monospace;
             font-size: 12px;
-            padding: 10px;
+            padding: 8px;
             border: 1px solid #ddd;
             border-radius: 4px;
             resize: vertical;
             box-sizing: border-box;
         }
-        #json-input { height: 220px; }
-        #cnd-input { height: 140px; }
-        label {
-            font-weight: bold;
-            display: block;
-            margin-bottom: 5px;
-        }
+        #json-input { height: 180px; }
+        #cnd-input { height: 120px; }
         .status {
-            margin: 10px 0;
-            padding: 10px;
+            margin: 8px 0;
+            padding: 8px;
             border-radius: 4px;
+            font-size: 13px;
         }
         .status.info { background: #e3f2fd; color: #1976d2; }
         .status.success { background: #e8f5e8; color: #2e7d32; }
         .status.error { background: #ffebee; color: #c62828; }
 
-        /* Accessible output styling */
+        /* ─── Main layout: graph+navigator left, REPLs right ─── */
+        #main-area {
+            display: flex;
+            gap: 16px;
+            margin-top: 16px;
+        }
+        #graph-panel {
+            flex: 3;
+            min-width: 500px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        #repl-panel {
+            flex: 2;
+            min-width: 350px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        /* ─── Navigator layer (ARIA tree) ─── */
         #accessible-html-output {
             border: 2px solid #5a3d8a;
             border-radius: 8px;
             padding: 16px;
-            min-height: 200px;
+            min-height: 120px;
             background: #faf8ff;
         }
         #accessible-html-output [role="graphics-document"] {
@@ -102,201 +105,126 @@
             align-items: baseline;
             gap: 6px;
         }
-        #accessible-html-output [role="treeitem"]:hover {
-            background: #f5f5f5;
-        }
+        #accessible-html-output [role="treeitem"]:hover { background: #f5f5f5; }
         #accessible-html-output [role="treeitem"]:focus {
             background: #e8f0fe;
             box-shadow: 0 0 0 2px #007acc;
             border-color: #007acc;
         }
-        #accessible-html-output .node-label {
-            font-weight: 600;
-            font-size: 15px;
-        }
+        #accessible-html-output .node-label { font-weight: 600; font-size: 15px; }
         #accessible-html-output .node-type {
-            font-size: 11px;
-            background: #e8e8e8;
-            color: #555;
-            padding: 1px 6px;
-            border-radius: 3px;
-            font-weight: 500;
+            font-size: 11px; background: #e8e8e8; color: #555;
+            padding: 1px 6px; border-radius: 3px; font-weight: 500;
         }
-        #accessible-html-output .node-attrs {
-            display: flex;
-            gap: 4px;
-            flex-wrap: wrap;
-        }
+        #accessible-html-output .node-attrs { display: flex; gap: 4px; flex-wrap: wrap; }
         #accessible-html-output .node-attr {
-            font-size: 12px;
-            background: #eef6ff;
-            color: #1a5276;
-            padding: 1px 6px;
-            border-radius: 3px;
+            font-size: 12px; background: #eef6ff; color: #1a5276;
+            padding: 1px 6px; border-radius: 3px;
         }
-        #accessible-html-output .attr-key {
-            font-weight: 600;
-        }
+        #accessible-html-output .attr-key { font-weight: 600; }
         #accessible-html-output .node-connections {
-            width: 100%;
-            display: flex;
-            gap: 4px;
-            flex-wrap: wrap;
-            margin-top: 2px;
+            width: 100%; display: flex; gap: 4px; flex-wrap: wrap; margin-top: 2px;
         }
         #accessible-html-output .node-edge {
-            font-size: 11px;
-            padding: 1px 6px;
-            border-radius: 3px;
+            font-size: 11px; padding: 1px 6px; border-radius: 3px;
         }
-        #accessible-html-output .node-edge-out {
-            background: #f0faf0;
-            color: #1e6e1e;
-        }
-        #accessible-html-output .node-edge-in {
-            background: #fef5e7;
-            color: #7d5a00;
-        }
-        #accessible-html-output .group-label {
-            font-weight: 600;
-        }
-        #accessible-html-output .node-count {
-            font-weight: 400;
-            color: #888;
-        }
+        #accessible-html-output .node-edge-out { background: #f0faf0; color: #1e6e1e; }
+        #accessible-html-output .node-edge-in { background: #fef5e7; color: #7d5a00; }
+        #accessible-html-output .group-label { font-weight: 600; }
+        #accessible-html-output .node-count { font-weight: 400; color: #888; }
         #accessible-html-output [role="group"] {
-            padding-left: 16px;
-            border-left: 2px solid #ddd;
-            margin-left: 8px;
-            margin-top: 4px;
+            padding-left: 16px; border-left: 2px solid #ddd;
+            margin-left: 8px; margin-top: 4px;
         }
         #accessible-html-output .diagram-relationships,
-        #accessible-html-output .diagram-spatial {
-            margin-top: 16px;
-        }
+        #accessible-html-output .diagram-spatial { margin-top: 16px; }
         #accessible-html-output h3 {
-            font-size: 14px;
-            font-weight: 600;
-            margin: 0 0 8px 0;
-            color: #333;
+            font-size: 14px; font-weight: 600; margin: 0 0 8px 0; color: #333;
         }
         #accessible-html-output table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 13px;
+            width: 100%; border-collapse: collapse; font-size: 13px;
         }
         #accessible-html-output th, #accessible-html-output td {
-            border: 1px solid #e0e0e0;
-            padding: 5px 10px;
-            text-align: left;
+            border: 1px solid #e0e0e0; padding: 5px 10px; text-align: left;
         }
         #accessible-html-output th {
-            background: #f5f5f5;
-            font-weight: 600;
-            font-size: 12px;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            color: #666;
+            background: #f5f5f5; font-weight: 600; font-size: 12px;
+            text-transform: uppercase; letter-spacing: 0.5px; color: #666;
         }
-        #accessible-html-output .diagram-spatial ul {
-            list-style: none;
-            padding: 0;
-            margin: 0;
-        }
-        #accessible-html-output .diagram-spatial li {
-            padding: 4px 0;
-            font-size: 13px;
-            color: #444;
-        }
-        #accessible-html-output .diagram-spatial em {
-            color: #5a3d8a;
-            font-style: normal;
-            font-weight: 500;
-        }
+        #accessible-html-output .diagram-spatial ul { list-style: none; padding: 0; margin: 0; }
+        #accessible-html-output .diagram-spatial li { padding: 4px 0; font-size: 13px; color: #444; }
+        #accessible-html-output .diagram-spatial em { color: #5a3d8a; font-style: normal; font-weight: 500; }
+
         .sr-only {
-            position: absolute;
-            width: 1px;
-            height: 1px;
-            padding: 0;
-            margin: -1px;
-            overflow: hidden;
-            clip: rect(0,0,0,0);
-            border: 0;
+            position: absolute; width: 1px; height: 1px; padding: 0;
+            margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0;
         }
 
-        /* Alt text output */
-        #alt-text-output {
-            font-family: system-ui, sans-serif;
-            font-size: 14px;
-            line-height: 1.6;
-            padding: 16px;
-            background: #fffef5;
-            border: 1px solid #e0d8a8;
-            border-radius: 8px;
+        /* ─── Spatial context panel ─── */
+        #spatial-context-panel {
+            background: #f0eef8; border: 1px solid #c4b8e0; border-radius: 6px;
+            padding: 12px 16px; font-size: 13px; line-height: 1.5; color: #333;
+        }
+        #spatial-context-panel .context-label { font-weight: 600; color: #5a3d8a; margin-bottom: 4px; }
+        #spatial-context-panel .context-direction {
+            display: inline-block; background: #e8e0f5; padding: 1px 8px;
+            border-radius: 3px; margin: 2px 4px 2px 0; font-size: 12px;
+        }
+        #spatial-context-panel .context-group {
+            display: inline-block; background: #e0f0e0; padding: 1px 8px;
+            border-radius: 3px; margin: 2px 4px 2px 0; font-size: 12px;
         }
 
-        /* Tab styling */
-        .output-tabs {
-            display: flex;
-            gap: 0;
-            border-bottom: 2px solid #ddd;
+        /* ─── REPL styling ─── */
+        .repl-section { margin-bottom: 0; }
+        .repl-section h3 { font-size: 14px; font-weight: 600; margin: 0 0 6px 0; color: #333; }
+        .repl-output {
+            font-family: 'Courier New', monospace; font-size: 13px;
+            background: #1e1e1e; color: #d4d4d4; padding: 12px;
+            border-radius: 6px; max-height: 250px; overflow-y: auto; white-space: pre-wrap;
         }
-        .output-tab {
-            padding: 8px 16px;
-            background: #f0f0f0;
-            border: 1px solid #ddd;
-            border-bottom: none;
-            border-radius: 4px 4px 0 0;
-            cursor: pointer;
-            font-size: 14px;
-            font-weight: 500;
-            color: #555;
-            margin: 0;
+        .query-result-atom {
+            cursor: pointer; text-decoration: underline; text-decoration-style: dotted;
         }
-        .output-tab.active {
-            background: white;
-            color: #007acc;
-            border-bottom: 2px solid white;
-            margin-bottom: -2px;
-        }
-        .output-tab:hover:not(.active) { background: #e8e8e8; }
-        .tab-content { display: none; padding-top: 16px; }
-        .tab-content.active { display: block; }
+        .query-result-atom:hover { text-decoration-style: solid; color: #4ec9b0; }
 
-        /* Description tree styling */
-        #description-tree details {
-            margin-left: 16px;
-            margin-bottom: 4px;
+        /* ─── Input details ─── */
+        #input-details summary {
+            cursor: pointer; font-weight: 600; padding: 8px 0; color: #555;
         }
-        #description-tree summary {
-            cursor: pointer;
-            padding: 4px 8px;
-            border-radius: 4px;
-            font-weight: 500;
-        }
-        #description-tree summary:hover { background: #f0f0f0; }
-        #description-tree .desc-section { font-weight: 600; color: #333; }
-        #description-tree .desc-item { font-weight: normal; color: #555; }
-        #description-tree .desc-detail { color: #777; font-size: 13px; padding: 4px 8px; }
+        #input-details[open] summary { margin-bottom: 8px; }
 
-        @media (max-width: 768px) {
-            body { flex-direction: column; }
-            #input-panel, #output-panel { min-width: unset; }
+        @media (max-width: 900px) {
+            #main-area { flex-direction: column; }
+            #graph-panel, #repl-panel { min-width: unset; }
         }
     </style>
 </head>
 <body>
-    <!-- Input Panel -->
-    <div class="panel border" id="input-panel">
-        <h1 class="h4">Accessible Translator Demo</h1>
-        <p class="text-muted small">
-            Spatial &ne; Visual. This demo compiles an <code>InstanceLayout</code> to an accessible representation:
-            spatial navigation, semantic HTML, and structured descriptions.
-        </p>
 
-        <div class="mb-3">
-            <label for="json-input">JSON Data Instance:</label>
-            <textarea id="json-input">{
+    <!-- ─── Header ─── -->
+    <div class="panel border" style="margin-bottom: 0;">
+        <h1 class="h4" style="margin-bottom: 8px;">Spatial Queries as Accessible Affordances</h1>
+        <p class="text-muted small" style="margin-bottom: 4px;">
+            In visual tools, <strong>dragging</strong> reveals what spatial arrangements are possible.
+            The spatial REPL provides the same exploration non-visually:
+            <code>must.leftOf(Node0)</code> answers "what <em>must</em> always be to the left?"
+            &mdash; information locked behind drag interaction in existing tools.
+        </p>
+        <p class="text-muted small" style="margin-bottom: 0;">
+            <strong>Graph</strong> (what sighted users see) &rarr;
+            <strong>Navigator</strong> (non-visual traversal via constraints) &rarr;
+            <strong>REPLs</strong> (non-visual exploration &mdash; replaces drag).
+        </p>
+    </div>
+
+    <!-- ─── Collapsible input ─── -->
+    <details id="input-details" class="panel border" style="margin-top: 8px;">
+        <summary>Data &amp; Layout Specification (click to edit)</summary>
+        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+            <div style="flex: 1; min-width: 300px;">
+                <label for="json-input" style="font-weight: bold; display: block; margin-bottom: 4px;">JSON Data Instance:</label>
+                <textarea id="json-input">{
   "atoms": [
     { "id": "Node0", "type": "Node", "label": "Node (10)" },
     { "id": "Node1", "type": "Node", "label": "Node (5)" },
@@ -350,11 +278,10 @@
     }
   ]
 }</textarea>
-        </div>
-
-        <div class="mb-3">
-            <label for="cnd-input">Layout Specification (CND):</label>
-            <textarea id="cnd-input">constraints:
+            </div>
+            <div style="flex: 0 0 280px;">
+                <label for="cnd-input" style="font-weight: bold; display: block; margin-bottom: 4px;">Layout Specification (CND):</label>
+                <textarea id="cnd-input">constraints:
   - orientation:
       selector: left
       directions:
@@ -364,127 +291,104 @@ directives:
   - attribute:
       field: val
   - flag: hideDisconnectedBuiltIns</textarea>
+                <button id="translateButton" onclick="runTranslation()" style="margin-top: 8px;">Re-translate</button>
+                <div id="status" class="status info">Loading...</div>
+            </div>
         </div>
+    </details>
 
-        <button id="translateButton" onclick="runTranslation()">Translate to Accessible</button>
+    <!-- ─── Main area: graph+navigator | REPLs ─── -->
+    <div id="main-area">
 
-        <div id="status" class="status info">Ready. Enter JSON data and a layout spec, then click Translate.</div>
-
-        <!-- Visual rendering -->
-        <div class="mt-3">
-            <label>Visual Rendering</label>
-            <div style="position: relative; margin-top: 8px;">
+        <!-- Left: Graph + Navigator layer -->
+        <div id="graph-panel" class="panel border">
+            <!-- Visual graph -->
+            <div>
+                <h2 class="h6" style="margin: 0 0 8px 0;">Visual Graph</h2>
                 <webcola-cnd-graph
                     id="graph-container"
                     width="600"
-                    height="450"
+                    height="400"
                     layoutFormat="default"
                     aria-label="Visual graph rendering">
                 </webcola-cnd-graph>
             </div>
-        </div>
-    </div>
 
-    <!-- Output Panel -->
-    <div class="panel border" id="output-panel">
-        <h2 class="h5 mb-3">Accessible Output</h2>
-
-        <!-- Tabs -->
-        <div class="output-tabs" role="tablist">
-            <button class="output-tab active" role="tab" aria-selected="true" onclick="switchTab('html')" id="tab-html">Semantic HTML</button>
-            <button class="output-tab" role="tab" aria-selected="false" onclick="switchTab('query')" id="tab-query">Spatial Queries</button>
-            <button class="output-tab" role="tab" aria-selected="false" onclick="switchTab('datum')" id="tab-datum">Data Queries</button>
-            <button class="output-tab" role="tab" aria-selected="false" onclick="switchTab('desc')" id="tab-desc">Description Tree</button>
-            <button class="output-tab" role="tab" aria-selected="false" onclick="switchTab('alt')" id="tab-alt">Alt Text</button>
-        </div>
-
-        <!-- Tab: Semantic HTML (live, interactive) -->
-        <div class="tab-content active" id="content-html">
-            <p class="text-muted small mb-2">
-                Live semantic HTML output. Use <kbd>Tab</kbd> to enter, arrow keys to navigate between nodes
-                following the spatial layout. Screen readers will announce each node as a "diagram node".
-            </p>
-            <div id="accessible-html-output">
-                <p class="text-muted">Click "Translate to Accessible" to see the output here.</p>
+            <!-- Data Navigator layer -->
+            <div>
+                <h2 class="h6" style="margin: 0 0 4px 0;">Navigator</h2>
+                <p class="text-muted small" style="margin-bottom: 8px;">
+                    Use <kbd>Tab</kbd> to enter. <kbd>Alt</kbd>+Arrow keys navigate
+                    spatially (constraint-derived). Plain arrows use tree navigation.
+                </p>
+                <div id="accessible-html-output">
+                    <p class="text-muted">Loading...</p>
+                </div>
             </div>
         </div>
 
-        <!-- Tab: Spatial Queries (diagram-level REPL) -->
-        <div class="tab-content" id="content-query">
-            <p class="text-muted small mb-2">
-                Query the modal spatial logic of the diagram. Try expressions like
-                <code>must.rightOf(Node0)</code>, <code>can.leftOf(Node1)</code>,
-                <code>cannot.above(Node2)</code>, <code>must.aligned.x(Node0)</code>,
-                <code>grouped(Node0)</code>, <code>grouped(Node0, Node1)</code>,
-                or <code>contains(G1)</code>.
-            </p>
-            <div style="display: flex; gap: 8px; margin-bottom: 12px;">
-                <input type="text" id="query-input" placeholder="must.rightOf(Node0)"
-                       style="flex: 1; font-family: 'Courier New', monospace; font-size: 14px; padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px;"
-                       onkeydown="if(event.key==='Enter') runQuery()">
-                <button onclick="runQuery()" id="query-button" disabled>Query</button>
-            </div>
-            <div id="query-output" style="font-family: 'Courier New', monospace; font-size: 13px; background: #1e1e1e; color: #d4d4d4; padding: 16px; border-radius: 8px; max-height: 400px; overflow-y: auto; white-space: pre-wrap;">
-// Run "Translate to Accessible" first, then enter a spatial query above.
-//
-// <span style="color:#9cdcfe">Modalities:</span>
-//   <span style="color:#ce9178">must</span>  — true in ALL valid layouts (universally entailed)
-//   <span style="color:#ce9178">can</span>   — true in SOME valid layout (feasible)
-//   <span style="color:#ce9178">cannot</span> — true in NO valid layout (infeasible)
-//
-// <span style="color:#9cdcfe">Examples:</span>
-//   <span style="color:#4ec9b0">must.rightOf(Node0)</span>    — nodes that MUST be right of Node0
-//   <span style="color:#4ec9b0">can.leftOf(Node1)</span>     — nodes that CAN be left of Node1
-//   <span style="color:#4ec9b0">cannot.above(Node2)</span>   — nodes that CANNOT be above Node2
-//   <span style="color:#4ec9b0">must.aligned.x(Node0)</span> — nodes that MUST be x-aligned with Node0
-//   <span style="color:#4ec9b0">grouped(Node0)</span>        — groups containing Node0
-//   <span style="color:#4ec9b0">grouped(Node0, Node1)</span> — groups containing both nodes
-//   <span style="color:#4ec9b0">contains(G1)</span>          — members of group G1
-            </div>
-            <div id="query-history" style="margin-top: 8px; font-size: 12px; color: #888;"></div>
-        </div>
+        <!-- Right: Context + REPLs -->
+        <div id="repl-panel">
 
-        <!-- Tab: Data Queries (datum-level REPL) -->
-        <div class="tab-content" id="content-datum">
-            <p class="text-muted small mb-2">
-                Query the data instance directly. Navigate relations with dot notation:
-                <code>Node</code>, <code>left</code>, <code>Node.left</code>,
-                <code>Node.val</code>, <code>Node.left.val</code>.
-            </p>
-            <div style="display: flex; gap: 8px; margin-bottom: 12px;">
-                <input type="text" id="datum-input" placeholder="Node.left.val"
-                       style="flex: 1; font-family: 'Courier New', monospace; font-size: 14px; padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px;"
-                       onkeydown="if(event.key==='Enter') runDatumQuery()">
-                <button onclick="runDatumQuery()" id="datum-button" disabled>Query</button>
+            <!-- Spatial context — live updates on node focus -->
+            <div class="panel border">
+                <div id="spatial-context-panel" role="region" aria-label="Spatial context for focused node">
+                    <div class="context-label">Spatial Context</div>
+                    <div id="spatial-context-content">Navigate to a node to see its spatial context.</div>
+                </div>
+                <!-- Screen-reader-only live region -->
+                <div id="spatial-live-region" aria-live="polite" aria-atomic="true" class="sr-only"></div>
             </div>
-            <div id="datum-output" style="font-family: 'Courier New', monospace; font-size: 13px; background: #1e1e1e; color: #d4d4d4; padding: 16px; border-radius: 8px; max-height: 400px; overflow-y: auto; white-space: pre-wrap;">
-// Run "Translate to Accessible" first, then enter a data query above.
-//
-// <span style="color:#9cdcfe">Expressions:</span>
-//   <span style="color:#4ec9b0">Node</span>              — all atoms of type Node
-//   <span style="color:#4ec9b0">left</span>              — all tuples in the "left" relation
-//   <span style="color:#4ec9b0">Node.left</span>         — navigate "left" from Node atoms
-//   <span style="color:#4ec9b0">Node.val</span>          — navigate "val" from Node atoms
-//   <span style="color:#4ec9b0">Node.left.val</span>     — chained navigation: left child's value
-            </div>
-        </div>
 
-        <!-- Tab: Description Tree -->
-        <div class="tab-content" id="content-desc">
-            <p class="text-muted small mb-2">
-                Structured, navigable description of the diagram. Expand sections to explore.
-            </p>
-            <div id="description-tree">
-                <p class="text-muted">Click "Translate to Accessible" to see the description tree.</p>
-            </div>
-        </div>
+            <!-- Spatial REPL -->
+            <div class="panel border repl-section">
+                <h3>Spatial Queries <span class="text-muted" style="font-weight:normal; font-size:12px;">(diagram)</span></h3>
+                <p class="text-muted small" style="margin-bottom: 6px;">
+                    Query what <em>must</em>, <em>can</em>, or <em>cannot</em> hold spatially.
+                    These answer questions locked behind drag interaction in visual tools.
+                </p>
+                <div style="display: flex; gap: 8px; margin-bottom: 8px;">
+                    <label for="query-input" class="sr-only">Spatial query expression</label>
+                    <input type="text" id="query-input" placeholder="must.rightOf(Node0)"
+                           aria-describedby="query-input-hint"
+                           style="flex: 1; font-family: 'Courier New', monospace; font-size: 14px; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px;"
+                           onkeydown="if(event.key==='Enter') runQuery()">
+                    <span id="query-input-hint" class="sr-only">Enter a spatial query like must.rightOf(Node0) and press Enter. Click results to navigate to them.</span>
+                    <button onclick="runQuery()" id="query-button" disabled>Query</button>
+                </div>
+                <div id="query-output" role="log" aria-label="Spatial query results" aria-live="polite" class="repl-output">
+<span style="color:#9cdcfe">Modalities:</span>
+  <span style="color:#ce9178">must</span>  &mdash; true in ALL valid layouts
+  <span style="color:#ce9178">can</span>   &mdash; true in SOME valid layout
+  <span style="color:#ce9178">cannot</span> &mdash; true in NO valid layout
 
-        <!-- Tab: Alt Text -->
-        <div class="tab-content" id="content-alt">
-            <p class="text-muted small mb-2">
-                Flat alt-text suitable for an <code>alt</code> attribute or screen reader announcement.
-            </p>
-            <div id="alt-text-output">Click "Translate to Accessible" to generate alt text.</div>
+<span style="color:#9cdcfe">Try:</span>
+  <span style="color:#4ec9b0">must.rightOf(Node0)</span>   <span style="color:#4ec9b0">can.leftOf(Node1)</span>
+  <span style="color:#4ec9b0">cannot.above(Node2)</span>   <span style="color:#4ec9b0">must.aligned.x(Node0)</span>
+  <span style="color:#4ec9b0">grouped(Node0)</span>        <span style="color:#4ec9b0">contains(G1)</span></div>
+            </div>
+
+            <!-- Datum REPL -->
+            <div class="panel border repl-section">
+                <h3>Data Queries <span class="text-muted" style="font-weight:normal; font-size:12px;">(datum)</span></h3>
+                <p class="text-muted small" style="margin-bottom: 6px;">
+                    Query the underlying data instance. Navigate relations with dot notation.
+                </p>
+                <div style="display: flex; gap: 8px; margin-bottom: 8px;">
+                    <label for="datum-input" class="sr-only">Data query expression</label>
+                    <input type="text" id="datum-input" placeholder="Node.left.val"
+                           aria-describedby="datum-input-hint"
+                           style="flex: 1; font-family: 'Courier New', monospace; font-size: 14px; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px;"
+                           onkeydown="if(event.key==='Enter') runDatumQuery()">
+                    <span id="datum-input-hint" class="sr-only">Enter a data query like Node.left.val and press Enter</span>
+                    <button onclick="runDatumQuery()" id="datum-button" disabled>Query</button>
+                </div>
+                <div id="datum-output" role="log" aria-label="Data query results" aria-live="polite" class="repl-output">
+<span style="color:#9cdcfe">Try:</span>
+  <span style="color:#4ec9b0">Node</span>              <span style="color:#4ec9b0">left</span>
+  <span style="color:#4ec9b0">Node.left</span>         <span style="color:#4ec9b0">Node.val</span>
+  <span style="color:#4ec9b0">Node.left.val</span>     <span style="color:#4ec9b0">Node.right.val</span></div>
+            </div>
         </div>
     </div>
 
@@ -493,8 +397,6 @@ directives:
     <script src="../vendor/cola.js"></script>
     <script src="../dist/browser/spytial-core-complete.global.js"></script>
     <script>
-        // The browser bundle exposes `spytialcore` as the global.
-        // Other demos reference `CndCore`; alias for consistency.
         const CndCore = spytialcore;
 
         // ─── State ─────────────────────────────────────────────────────────
@@ -503,19 +405,6 @@ directives:
         let currentDataEvaluator = null;
         let queryHistory = [];
         let datumQueryHistory = [];
-
-        // ─── Tab Switching ─────────────────────────────────────────────────
-        function switchTab(tabId) {
-            document.querySelectorAll('.output-tab').forEach(t => {
-                t.classList.remove('active');
-                t.setAttribute('aria-selected', 'false');
-            });
-            document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-
-            document.getElementById('tab-' + tabId).classList.add('active');
-            document.getElementById('tab-' + tabId).setAttribute('aria-selected', 'true');
-            document.getElementById('content-' + tabId).classList.add('active');
-        }
 
         // ─── Status ────────────────────────────────────────────────────────
         function updateStatus(message, type) {
@@ -529,22 +418,18 @@ directives:
             try {
                 updateStatus('Processing...', 'info');
 
-                // 1. Parse JSON data
                 const jsonText = document.getElementById('json-input').value;
                 if (!jsonText.trim()) throw new Error('Please enter JSON data.');
 
                 const instance = new CndCore.JSONDataInstance(jsonText);
 
-                // 2. Create evaluator
                 const evaluator = new CndCore.SGraphQueryEvaluator();
                 evaluator.initialize({ sourceData: instance });
                 currentDataEvaluator = evaluator;
 
-                // 3. Parse layout spec
                 const cndSpec = document.getElementById('cnd-input').value || '';
                 const layoutSpec = CndCore.parseLayoutSpec(cndSpec);
 
-                // 4. Generate InstanceLayout (same as WebCola pipeline)
                 const layoutInstance = new CndCore.LayoutInstance(layoutSpec, evaluator, 0, true);
                 const layoutResult = layoutInstance.generateLayout(instance);
 
@@ -555,11 +440,11 @@ directives:
                     console.warn('Layout error (continuing):', layoutResult.error.message);
                 }
 
-                // 5. Accessible translation (the new path!)
+                // Accessible translation
                 const translator = new CndCore.AccessibleTranslator();
                 currentAccessibleLayout = translator.translate(layoutResult.layout);
 
-                // 5b. Create LayoutEvaluator if validator is available
+                // Layout evaluator for spatial REPL
                 currentLayoutEvaluator = null;
                 if (layoutResult.validator) {
                     currentLayoutEvaluator = new CndCore.LayoutEvaluator(
@@ -572,26 +457,19 @@ directives:
                     document.getElementById('query-button').disabled = true;
                 }
 
-                // 5c. Enable datum-level REPL (always available after translation)
                 document.getElementById('datum-button').disabled = false;
 
-                // 6. Render all output tabs
-                renderHTMLTab(currentAccessibleLayout);
-                renderDescriptionTab(currentAccessibleLayout);
-                renderAltTextTab(currentAccessibleLayout);
+                // Render navigator layer
+                renderNavigator(currentAccessibleLayout);
 
-                // 7. Also render visual for comparison (optional)
-                renderVisualComparison(layoutResult.layout);
+                // Render visual graph
+                renderVisualGraph(layoutResult.layout);
 
-                const queryStatus = currentLayoutEvaluator
-                    ? ' Spatial queries enabled.'
-                    : ' Spatial queries unavailable (needs qualitative validator).';
-                updateStatus('Translation complete! Explore the tabs above.' + queryStatus, 'success');
+                updateStatus('Ready. Navigate the tree or query the REPLs.', 'success');
 
             } catch (error) {
                 console.error('Translation failed:', error);
                 updateStatus('Error: ' + error.message, 'error');
-                // Reset evaluators and disable query buttons on failure
                 currentDataEvaluator = null;
                 currentLayoutEvaluator = null;
                 document.getElementById('datum-button').disabled = true;
@@ -599,98 +477,12 @@ directives:
             }
         }
 
-        // ─── Tab Renderers ─────────────────────────────────────────────────
+        // ─── Navigator Renderer ────────────────────────────────────────────
 
-        function renderHTMLTab(accessible) {
+        function renderNavigator(accessible) {
             const container = document.getElementById('accessible-html-output');
             container.innerHTML = accessible.toHTML();
             wireUpKeyboardNavigation(container);
-        }
-
-        function renderDescriptionTab(accessible) {
-            const desc = accessible.description;
-            const container = document.getElementById('description-tree');
-            const html = [];
-
-            // Overview
-            html.push(`<details open>`);
-            html.push(`  <summary class="desc-section">Overview</summary>`);
-            html.push(`  <div class="desc-detail">${esc(desc.overview.summary)}</div>`);
-            html.push(`</details>`);
-
-            // Types
-            if (desc.types.length > 0) {
-                html.push(`<details open>`);
-                html.push(`  <summary class="desc-section">Types (${desc.types.length})</summary>`);
-                for (const type of desc.types) {
-                    html.push(`  <details>`);
-                    html.push(`    <summary class="desc-item">${esc(type.typeName)} (${type.nodeCount} nodes)</summary>`);
-                    html.push(`    <div class="desc-detail">Nodes: ${type.nodeLabels.map(esc).join(', ')}</div>`);
-                    if (type.typeHierarchy.length > 1) {
-                        html.push(`    <div class="desc-detail">Hierarchy: ${type.typeHierarchy.map(esc).join(' &gt; ')}</div>`);
-                    }
-                    html.push(`  </details>`);
-                }
-                html.push(`</details>`);
-            }
-
-            // Nodes
-            if (desc.nodes.length > 0) {
-                html.push(`<details>`);
-                html.push(`  <summary class="desc-section">Nodes (${desc.nodes.length})</summary>`);
-                for (const node of desc.nodes) {
-                    html.push(`  <details>`);
-                    html.push(`    <summary class="desc-item">${esc(node.label)} (${esc(node.mostSpecificType)})</summary>`);
-                    html.push(`    <div class="desc-detail">${esc(node.summary)}</div>`);
-                    if (node.outgoing.length > 0) {
-                        html.push(`    <div class="desc-detail">Outgoing: ${node.outgoing.map(e => esc(e.summary)).join(', ')}</div>`);
-                    }
-                    if (node.incoming.length > 0) {
-                        html.push(`    <div class="desc-detail">Incoming: ${node.incoming.map(e => esc(e.summary)).join(', ')}</div>`);
-                    }
-                    html.push(`  </details>`);
-                }
-                html.push(`</details>`);
-            }
-
-            // Groups
-            if (desc.groups.length > 0) {
-                html.push(`<details>`);
-                html.push(`  <summary class="desc-section">Groups (${desc.groups.length})</summary>`);
-                for (const group of desc.groups) {
-                    html.push(`  <details>`);
-                    html.push(`    <summary class="desc-item">${esc(group.name)} (${group.nodeCount} nodes)</summary>`);
-                    html.push(`    <div class="desc-detail">${esc(group.summary)}</div>`);
-                    html.push(`  </details>`);
-                }
-                html.push(`</details>`);
-            }
-
-            // Relationships
-            if (desc.relationships.length > 0) {
-                html.push(`<details open>`);
-                html.push(`  <summary class="desc-section">Relationships (${desc.relationships.length})</summary>`);
-                for (const rel of desc.relationships) {
-                    html.push(`  <div class="desc-detail">${esc(rel.summary)}</div>`);
-                }
-                html.push(`</details>`);
-            }
-
-            // Spatial Relationships
-            if (desc.spatialRelationships.length > 0) {
-                html.push(`<details open>`);
-                html.push(`  <summary class="desc-section">Spatial Layout (${desc.spatialRelationships.length} constraints)</summary>`);
-                for (const sr of desc.spatialRelationships) {
-                    html.push(`  <div class="desc-detail">${esc(sr.description)}</div>`);
-                }
-                html.push(`</details>`);
-            }
-
-            container.innerHTML = html.join('\n');
-        }
-
-        function renderAltTextTab(accessible) {
-            document.getElementById('alt-text-output').textContent = accessible.toAltText();
         }
 
         // ─── Keyboard Navigation ───────────────────────────────────────────
@@ -699,57 +491,171 @@ directives:
             const treeItems = container.querySelectorAll('[role="treeitem"]');
             if (treeItems.length === 0) return;
 
-            // Make first item focusable
             treeItems[0].setAttribute('tabindex', '0');
+
+            // Use event delegation on the persistent container for focusin
+            container.addEventListener('focusin', (e) => {
+                const node = e.target.closest('[role="treeitem"]');
+                if (node) updateSpatialContext(node);
+            });
 
             container.addEventListener('keydown', (e) => {
                 const current = document.activeElement;
-                if (!current || !current.hasAttribute('data-nav-above')) {
-                    // Only handle nav if we're on a node with data-nav attributes
-                    if (!current || current.getAttribute('role') !== 'treeitem') return;
+                if (!current || current.getAttribute('role') !== 'treeitem') return;
+
+                // Alt+Arrow = spatial navigation (constraint-based)
+                if (e.altKey) {
+                    let targetId = null;
+                    switch (e.key) {
+                        case 'ArrowUp': targetId = current.getAttribute('data-nav-above'); break;
+                        case 'ArrowDown': targetId = current.getAttribute('data-nav-below'); break;
+                        case 'ArrowLeft': targetId = current.getAttribute('data-nav-left'); break;
+                        case 'ArrowRight': targetId = current.getAttribute('data-nav-right'); break;
+                        default: return;
+                    }
+                    if (targetId) {
+                        e.preventDefault();
+                        focusNodeById(container, current, targetId);
+                    }
+                    return;
                 }
 
-                let targetId = null;
+                // Standard WAI-ARIA tree navigation
+                const allItems = Array.from(container.querySelectorAll('[role="treeitem"]'));
+                const idx = allItems.indexOf(current);
+
                 switch (e.key) {
                     case 'ArrowUp':
-                        targetId = current.getAttribute('data-nav-above');
+                        if (idx > 0) { e.preventDefault(); focusNode(current, allItems[idx - 1]); }
                         break;
                     case 'ArrowDown':
-                        targetId = current.getAttribute('data-nav-below');
+                        if (idx < allItems.length - 1) { e.preventDefault(); focusNode(current, allItems[idx + 1]); }
                         break;
                     case 'ArrowLeft':
-                        targetId = current.getAttribute('data-nav-left');
+                        if (current.getAttribute('aria-expanded') === 'true') {
+                            e.preventDefault();
+                            current.setAttribute('aria-expanded', 'false');
+                            const group = current.querySelector('[role="group"]');
+                            if (group) group.hidden = true;
+                        } else {
+                            const parentGroup = current.closest('[role="group"]');
+                            if (parentGroup) {
+                                const parentItem = parentGroup.closest('[role="treeitem"]');
+                                if (parentItem) { e.preventDefault(); focusNode(current, parentItem); }
+                            }
+                        }
                         break;
                     case 'ArrowRight':
-                        targetId = current.getAttribute('data-nav-right');
+                        if (current.getAttribute('aria-expanded') === 'false') {
+                            e.preventDefault();
+                            current.setAttribute('aria-expanded', 'true');
+                            const group = current.querySelector('[role="group"]');
+                            if (group) group.hidden = false;
+                        } else if (current.getAttribute('aria-expanded') === 'true') {
+                            const firstChild = current.querySelector('[role="group"] > [role="treeitem"]');
+                            if (firstChild) { e.preventDefault(); focusNode(current, firstChild); }
+                        }
                         break;
-                    default:
-                        return; // Don't prevent default for other keys
-                }
-
-                if (targetId) {
-                    e.preventDefault();
-                    const target = container.querySelector('#' + targetId);
-                    if (target) {
-                        // Move tabindex
-                        current.setAttribute('tabindex', '-1');
-                        target.setAttribute('tabindex', '0');
-                        target.focus();
-                    }
                 }
             });
         }
 
-        // ─── Visual Comparison ─────────────────────────────────────────────
+        function focusNode(from, to) {
+            from.setAttribute('tabindex', '-1');
+            to.setAttribute('tabindex', '0');
+            to.focus();
+        }
 
-        async function renderVisualComparison(layout) {
+        function focusNodeById(container, from, targetId) {
+            const target = container.querySelector('#' + targetId);
+            if (target) focusNode(from, target);
+        }
+
+        // ─── Spatial Context ───────────────────────────────────────────────
+
+        function updateSpatialContext(nodeElement) {
+            if (!currentAccessibleLayout) return;
+
+            const elementId = nodeElement.id;
+            if (!elementId || !elementId.startsWith('node-')) return;
+
+            const nodeId = elementId.replace('node-', '');
+            const nb = currentAccessibleLayout.navigation.getNeighbors(nodeId);
+            if (!nb) return;
+
+            const nodeDesc = currentAccessibleLayout.description.nodes.find(n =>
+                sanitizeIdJS(n.id) === nodeId
+            );
+
+            const contextEl = document.getElementById('spatial-context-content');
+            const liveEl = document.getElementById('spatial-live-region');
+            if (!contextEl || !liveEl) return;
+
+            const label = nodeDesc ? nodeDesc.label : nodeId;
+            const type = nodeDesc ? nodeDesc.mostSpecificType : '';
+
+            const directions = [];
+            if (nb.above) directions.push({ dir: 'Above', label: getNodeLabel(nb.above) });
+            if (nb.below) directions.push({ dir: 'Below', label: getNodeLabel(nb.below) });
+            if (nb.left) directions.push({ dir: 'Left', label: getNodeLabel(nb.left) });
+            if (nb.right) directions.push({ dir: 'Right', label: getNodeLabel(nb.right) });
+
+            // Visual panel
+            let html = `<strong>${esc(label)}</strong>`;
+            if (type) html += ` <span class="context-direction">${esc(type)}</span>`;
+            html += '<br>';
+
+            if (directions.length > 0) {
+                html += directions.map(d =>
+                    `<span class="context-direction">${d.dir}: <strong>${esc(d.label)}</strong></span>`
+                ).join(' ');
+            } else {
+                html += '<span style="color:#888">No spatial neighbors (unconstrained)</span>';
+            }
+
+            if (nb.containingGroups.length > 0) {
+                html += '<br>' + nb.containingGroups.map(g =>
+                    `<span class="context-group">In: ${esc(g)}</span>`
+                ).join(' ');
+            }
+
+            contextEl.innerHTML = html;
+
+            // Screen-reader announcement
+            const srParts = [];
+            if (nb.above) srParts.push(`above ${getNodeLabel(nb.above)}`);
+            if (nb.below) srParts.push(`below ${getNodeLabel(nb.below)}`);
+            if (nb.left) srParts.push(`left of ${getNodeLabel(nb.left)}`);
+            if (nb.right) srParts.push(`right of ${getNodeLabel(nb.right)}`);
+
+            let srText = label;
+            if (srParts.length > 0) srText += '. ' + srParts.join(', ') + '.';
+            if (nb.containingGroups.length > 0) {
+                srText += ' In group ' + nb.containingGroups.join(', ') + '.';
+            }
+            liveEl.textContent = srText;
+        }
+
+        function getNodeLabel(nodeId) {
+            if (!currentAccessibleLayout) return nodeId;
+            const desc = currentAccessibleLayout.description.nodes.find(n =>
+                sanitizeIdJS(n.id) === nodeId || n.id === nodeId
+            );
+            return desc ? desc.label : nodeId;
+        }
+
+        function sanitizeIdJS(raw) {
+            return raw.replace(/[^a-zA-Z0-9_-]/g, '_');
+        }
+
+        // ─── Visual Graph ──────────────────────────────────────────────────
+
+        async function renderVisualGraph(layout) {
             try {
                 const graph = document.getElementById('graph-container');
-                if (graph && graph.renderLayout) {
-                    await graph.renderLayout(layout);
-                }
+                if (graph && graph.renderLayout) await graph.renderLayout(layout);
             } catch (e) {
-                console.warn('Visual comparison render failed (non-critical):', e);
+                console.warn('Visual render failed:', e);
             }
         }
 
@@ -762,42 +668,57 @@ directives:
             if (!expr) return;
 
             if (!currentLayoutEvaluator) {
-                output.innerHTML = '<span style="color:#f44336">Error: No layout evaluator. Run "Translate to Accessible" first.</span>';
+                output.innerHTML = '<span style="color:#f44336" role="alert">Error: No layout evaluator available.</span>';
                 return;
             }
 
             const result = currentLayoutEvaluator.evaluate(expr);
-            const lines = [];
-
-            // Query echo
-            lines.push(`<span style="color:#888">&gt;</span> <span style="color:#4ec9b0">${esc(expr)}</span>`);
 
             if (result.isError()) {
-                lines.push(`<span style="color:#f44336">${esc(result.prettyPrint())}</span>`);
+                queryHistory.push({
+                    expr,
+                    html: `<span style="color:#f44336">Error: ${esc(result.prettyPrint())}</span>`,
+                });
             } else if (result.noResult()) {
-                lines.push(`<span style="color:#888">(empty set)</span>`);
+                queryHistory.push({
+                    expr,
+                    html: `<span style="color:#888">(empty set &mdash; no results)</span>`,
+                });
             } else {
                 const atoms = result.selectedAtoms();
-                lines.push(`<span style="color:#9cdcfe">{</span> ${atoms.map(a => '<span style="color:#ce9178">' + esc(a) + '</span>').join(', ')} <span style="color:#9cdcfe">}</span>  <span style="color:#666">(${atoms.length} result${atoms.length !== 1 ? 's' : ''})</span>`);
+                const atomHtml = atoms.map(a =>
+                    `<span class="query-result-atom" role="link" tabindex="0" data-node-id="${esc(sanitizeIdJS(a))}" onclick="focusNodeFromQuery(this)" onkeydown="if(event.key==='Enter')focusNodeFromQuery(this)" style="color:#ce9178">${esc(a)}</span>`
+                ).join(', ');
+                queryHistory.push({
+                    expr,
+                    html: `<span style="color:#9cdcfe">{</span> ${atomHtml} <span style="color:#9cdcfe">}</span>  <span style="color:#666">(${atoms.length} result${atoms.length !== 1 ? 's' : ''})</span>`,
+                });
             }
 
-            lines.push('');
-
-            // Add to history
-            queryHistory.push({ expr, result: result.prettyPrint() });
-
-            // Show all history (most recent at bottom)
             const historyLines = queryHistory.map(h =>
-                `<span style="color:#888">&gt;</span> <span style="color:#4ec9b0">${esc(h.expr)}</span>\n  ${esc(h.result)}`
+                `<span style="color:#888">&gt;</span> <span style="color:#4ec9b0">${esc(h.expr)}</span>\n  ${h.html}`
             );
             output.innerHTML = historyLines.join('\n\n');
-
-            // Scroll to bottom
             output.scrollTop = output.scrollHeight;
-
-            // Clear input and refocus
             input.value = '';
             input.focus();
+        }
+
+        function focusNodeFromQuery(element) {
+            const nodeId = element.getAttribute('data-node-id');
+            if (!nodeId) return;
+
+            const container = document.getElementById('accessible-html-output');
+            const target = container.querySelector('#node-' + nodeId);
+            if (target) {
+                container.querySelectorAll('[role="treeitem"][tabindex="0"]').forEach(el => {
+                    el.setAttribute('tabindex', '-1');
+                });
+                target.setAttribute('tabindex', '0');
+                target.focus();
+                target.style.outline = '3px solid #4ec9b0';
+                setTimeout(() => { target.style.outline = ''; }, 1500);
+            }
         }
 
         // ─── Data Query REPL ───────────────────────────────────────────────
@@ -809,40 +730,34 @@ directives:
             if (!expr) return;
 
             if (!currentDataEvaluator) {
-                output.innerHTML = '<span style="color:#f44336">Error: No data evaluator. Run "Translate to Accessible" first.</span>';
+                output.innerHTML = '<span style="color:#f44336" role="alert">Error: No data evaluator available.</span>';
                 return;
             }
 
             const result = currentDataEvaluator.evaluate(expr);
-            const lines = [];
-
-            // Query echo
-            lines.push(`<span style="color:#888">&gt;</span> <span style="color:#4ec9b0">${esc(expr)}</span>`);
 
             if (result.isError()) {
-                lines.push(`<span style="color:#f44336">${esc(result.prettyPrint())}</span>`);
+                datumQueryHistory.push({
+                    expr,
+                    html: `<span style="color:#f44336">Error: ${esc(result.prettyPrint())}</span>`,
+                });
             } else if (result.noResult()) {
-                lines.push(`<span style="color:#888">(empty set)</span>`);
+                datumQueryHistory.push({
+                    expr,
+                    html: `<span style="color:#888">(empty set &mdash; no results)</span>`,
+                });
             } else {
-                // Use prettyPrint for display — handles multi-arity tuples
-                lines.push(`<span style="color:#ce9178">${esc(result.prettyPrint())}</span>`);
+                datumQueryHistory.push({
+                    expr,
+                    html: `<span style="color:#ce9178">${esc(result.prettyPrint())}</span>`,
+                });
             }
 
-            lines.push('');
-
-            // Add to history
-            datumQueryHistory.push({ expr, result: result.prettyPrint() });
-
-            // Show all history (most recent at bottom)
             const historyLines = datumQueryHistory.map(h =>
-                `<span style="color:#888">&gt;</span> <span style="color:#4ec9b0">${esc(h.expr)}</span>\n  ${esc(h.result)}`
+                `<span style="color:#888">&gt;</span> <span style="color:#4ec9b0">${esc(h.expr)}</span>\n  ${h.html}`
             );
             output.innerHTML = historyLines.join('\n\n');
-
-            // Scroll to bottom
             output.scrollTop = output.scrollHeight;
-
-            // Clear input and refocus
             input.value = '';
             input.focus();
         }
@@ -855,20 +770,15 @@ directives:
             return div.innerHTML;
         }
 
-        // ─── Initialization ────────────────────────────────────────────────
+        // ─── Init: auto-translate on load ──────────────────────────────────
 
         window.addEventListener('load', () => {
             if (typeof CndCore !== 'undefined' && CndCore.AccessibleTranslator) {
-                updateStatus('Ready. Enter JSON data and a layout spec, then click Translate.', 'info');
+                runTranslation();
             } else {
-                updateStatus('Error: CndCore bundle not loaded or AccessibleTranslator not available.', 'error');
-                console.error('Available on CndCore:', typeof CndCore !== 'undefined' ? Object.keys(CndCore) : 'CndCore not defined');
+                updateStatus('Error: CndCore bundle not loaded.', 'error');
             }
         });
     </script>
-
-    <p>
-        A diagram is not defined by how it is seen, but by the spatial relationships it encodes. Spytial makes those relationships accessible both visually and through direct queries.
-    </p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds `<spytial-explorer>` web component that extends `<webcola-cnd-graph>` with Data Navigator integration and constraint-derived spatial semantics
- Arrow keys navigate between spatial neighbors; **Shift+Arrow** restricts navigation to **must** relationships only (guaranteed in all valid layouts)
- **Enter/Esc** for group drill-in/out navigation
- Spatial context panel shows **must/can** modality badges on every neighbor relationship
- Spatial REPL (`must.rightOf(Node0)`) and datum REPL (`Node.left.val`) below the graph
- Screen reader announcements include modal spatial context (e.g., "must left of Node (3)")
- Demo page with BST example, usage guide, and embedded code snippet

## What changed
- **New:** `src/components/spytial-explorer/` — component, styles, exports
- **Modified:** `src/index.ts` — exports + custom element registration
- **Modified:** `webcola-demo/accessible-demo.html` — simplified demo using `<spytial-explorer>`
- **Modified:** `package.json` — added `data-navigator` dependency

## Key design decisions
- `SpytialExplorer extends WebColaCnDGraph` — drop-in replacement, not a wrapper
- DN overlay rendered manually (not via DN's `rendering()` module) for Shadow DOM compatibility
- Overlay positions converted from SVG coordinates using the zoom transform, with minimum clickable size (24px)
- `enableAccessibility(layout, validator, evaluator)` is the single entry point after `renderLayout()`
- Modality checked via `validator.getMust()` — O(1) set lookup per neighbor

## Test plan
- [x] `npm run build:all` passes
- [x] Demo auto-loads BST, graph renders, DN overlay visible on nodes
- [x] Arrow keys navigate spatially, context panel updates with modality badges
- [x] Shift+Arrow blocks `can` relationships, allows `must` relationships
- [x] Spatial REPL returns results, clicking atoms navigates to DN nodes
- [x] Datum REPL returns results
- [x] Entry button focuses first node, Esc exits navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)