### PR TITLE
SpytialExplorer: robust overlay positioning + multi-mode navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/components/spytial-explorer/explorer-styles.ts
+++ b/src/components/spytial-explorer/explorer-styles.ts
@@ -5,7 +5,8 @@
 export function getExplorerCSS(): string {
     return /* css */ `
     :host {
-        display: block;
+        display: flex;
+        flex-direction: column;
         font-family: system-ui, -apple-system, sans-serif;
         color: #333;
         --accent: #5a3d8a;
@@ -16,6 +17,18 @@ export function getExplorerCSS(): string {
         --repl-fg: #d4d4d4;
         --success: #2e7d32;
         --error: #c62828;
+    }
+
+    /* Override parent's svg-container to share height with explorer panel */
+    #svg-container {
+        flex: 1;
+        min-height: 200px;
+        height: auto !important;
+    }
+
+    #se-explorer-panel {
+        flex-shrink: 0;
+        padding: 8px 0;
     }
 
     /* ─── Layout ─────────────────────────────────────────────── */

--- a/src/components/spytial-explorer/explorer-styles.ts
+++ b/src/components/spytial-explorer/explorer-styles.ts
@@ -550,5 +550,46 @@ export function getExplorerCSS(): string {
     .highlight-flash {
         outline: 3px solid #4ec9b0 !important;
     }
+
+    /* ─── Navigation mode toolbar ────────────────────────────────── */
+
+    .nav-mode-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 6px;
+        background: rgba(255, 255, 255, 0.95);
+        border-radius: 4px;
+        margin: 4px;
+        font-size: 12px;
+    }
+
+    .nav-mode-toolbar [role="radio"] {
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+        border-radius: 3px;
+        padding: 3px 8px;
+        font-size: 11px;
+        cursor: pointer;
+        font-weight: 500;
+        color: #555;
+    }
+
+    .nav-mode-toolbar [role="radio"]:hover {
+        background: #e8e0f5;
+    }
+
+    .nav-mode-toolbar [role="radio"][aria-checked="true"] {
+        background: var(--accent);
+        color: white;
+        border-color: var(--accent);
+    }
+
+    .relation-key-hint {
+        font-family: 'Courier New', monospace;
+        font-size: 11px;
+        color: #888;
+        margin-left: 6px;
+    }
     `;
 }

--- a/src/components/spytial-explorer/explorer-styles.ts
+++ b/src/components/spytial-explorer/explorer-styles.ts
@@ -481,16 +481,16 @@ export function getExplorerCSS(): string {
 
     .repl-output {
         font-family: 'Courier New', monospace;
-        font-size: 12px;
+        font-size: 11px;
         background: var(--repl-bg);
         color: var(--repl-fg);
-        padding: 12px;
-        border-radius: 6px;
-        flex: 1;
-        min-height: 80px;
-        max-height: 300px;
+        padding: 8px 10px;
+        border-radius: 4px;
+        min-height: 32px;
+        max-height: 150px;
         overflow-y: auto;
         white-space: pre-wrap;
+        line-height: 1.4;
     }
 
     /* ─── Query result atoms ─────────────────────────────────── */

--- a/src/components/spytial-explorer/spytial-explorer.ts
+++ b/src/components/spytial-explorer/spytial-explorer.ts
@@ -761,13 +761,9 @@ export class SpytialExplorer extends WebColaCnDGraph {
                 e.stopPropagation();
 
                 const targetId = this.relationEdgeMap.get(this.dnCurrentFocusId)?.get(mapping.relationName);
-                if (!targetId) {
-                    this.announce(`No ${mapping.relationName} from ${this.getNodeLabel(this.dnCurrentFocusId)}.`);
-                    return;
-                }
+                if (!targetId) return;
 
                 this.focusDNNode(targetId);
-                this.announce(`Following ${mapping.relationName} to ${this.getNodeLabel(targetId)}.`);
                 return;
             }
 
@@ -779,32 +775,23 @@ export class SpytialExplorer extends WebColaCnDGraph {
             e.stopPropagation();
 
             const nextNode = this.dnInputHandler.move(this.dnCurrentFocusId, direction);
-            if (!nextNode) {
-                this.announce(`No ${direction} neighbor from ${this.getNodeLabel(this.dnCurrentFocusId)}.`);
-                return;
-            }
+            if (!nextNode) return;
 
-            // Must mode: block if relationship isn't must
+            // Must mode: silently block if relationship isn't must
             if (this.currentNavMode === 'must') {
                 const modality = this.getModality(
                     this.dnCurrentFocusId,
                     direction as SpatialDir,
                     nextNode.id,
                 );
-                if (modality !== 'must') {
-                    this.announce(`No must-${direction} neighbor. This is a ${modality} relationship.`);
-                    return;
-                }
+                if (modality !== 'must') return;
             }
 
             // Group boundary check
             if (this.groupStack.length > 0) {
                 const currentGroup = this.groupStack[this.groupStack.length - 1];
                 const members = this.groupMemberMap.get(currentGroup);
-                if (members && !members.includes(nextNode.id)) {
-                    this.announce(`Edge of group ${currentGroup}. Press Escape to leave group.`);
-                    return;
-                }
+                if (members && !members.includes(nextNode.id)) return;
             }
 
             this.focusDNNode(nextNode.id);
@@ -829,19 +816,10 @@ export class SpytialExplorer extends WebColaCnDGraph {
      */
     private switchNavigationMode(mode: NavigationMode): void {
         if (mode === this.currentNavMode) return;
-
-        if (mode === 'relations' && this.relationKeyMap.length === 0) {
-            this.announce('No data relations available for relation navigation.');
-            return;
-        }
+        if (mode === 'relations' && this.relationKeyMap.length === 0) return;
 
         this.currentNavMode = mode;
         this.updateModeUI();
-
-        const modeDesc = mode === 'spatial' ? 'Spatial — arrow keys move to nearest neighbor'
-            : mode === 'must' ? 'Must-only — arrow keys follow only guaranteed relationships'
-            : `Relations — ${this.relationKeyMap.map(m => `${m.key} ${m.relationName}`).join(', ')}`;
-        this.announce(`Navigation mode: ${modeDesc}.`);
     }
 
     /**

--- a/src/components/spytial-explorer/spytial-explorer.ts
+++ b/src/components/spytial-explorer/spytial-explorer.ts
@@ -402,36 +402,39 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
         const descMap = new Map(nodeDescs.map(d => [d.id, d]));
 
+        // ─── Compute position-based spatial neighbors ─────────────────
+        // Use actual layout positions to find nearest neighbor in each
+        // cardinal direction. This works regardless of what constraints
+        // exist — navigation follows the visual layout.
+        const positions = this.getNodePositions();
+        const posMap = new Map(positions.map(p => [p.id, p]));
+        const spatialNeighbors = this.computePositionBasedNeighbors(positions);
+
         // ─── Build DN structure ───────────────────────────────────────
         const dnNodes: Record<string, any> = {};
         const dnEdges: Record<string, any> = {};
         const dnElementData: Record<string, any> = {};
         let edgeCounter = 0;
 
-        for (const [nodeId, neighbors] of nav.entries()) {
-            if (!svgNodeMap.has(nodeId)) continue;
+        const nodeIds = positions.map(p => p.id).filter(id => svgNodeMap.has(id));
 
+        for (const nodeId of nodeIds) {
             const renderId = `dn-node-${this.sanitizeId(nodeId)}`;
             const desc = descMap.get(nodeId);
             const nodeEdges: string[] = [];
+            const neighbors = spatialNeighbors.get(nodeId);
 
-            // Simple direction-labeled edges for spatial navigation
-            const directions: Array<[SpatialDir, string | null]> = [
-                ['left', neighbors.left],
-                ['right', neighbors.right],
-                ['up', neighbors.above],
-                ['down', neighbors.below],
-            ];
-
-            for (const [dir, targetId] of directions) {
-                if (!targetId) continue;
-                const edgeId = `e${edgeCounter++}`;
-                dnEdges[edgeId] = {
-                    source: nodeId,
-                    target: targetId,
-                    navigationRules: [dir],
-                };
-                nodeEdges.push(edgeId);
+            if (neighbors) {
+                for (const [dir, targetId] of Object.entries(neighbors)) {
+                    if (!targetId) continue;
+                    const edgeId = `e${edgeCounter++}`;
+                    dnEdges[edgeId] = {
+                        source: nodeId,
+                        target: targetId,
+                        navigationRules: [dir],
+                    };
+                    nodeEdges.push(edgeId);
+                }
             }
 
             dnNodes[nodeId] = {
@@ -484,6 +487,60 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
         this.wireDNKeyboard();
         this.setupZoomTracking(svgContainer, svgNodeMap);
+    }
+
+    /**
+     * Compute nearest neighbor in each cardinal direction from node positions.
+     *
+     * For "left": among all nodes with x < this node's x, pick the closest
+     * by Euclidean distance (weighted to prefer nodes roughly on the same axis).
+     * Same logic for right/up/down.
+     */
+    private computePositionBasedNeighbors(
+        positions: Array<{ id: string; x: number; y: number }>,
+    ): Map<string, Record<SpatialDir, string | null>> {
+        const result = new Map<string, Record<SpatialDir, string | null>>();
+
+        for (const node of positions) {
+            const neighbors: Record<SpatialDir, string | null> = {
+                left: null, right: null, up: null, down: null,
+            };
+
+            let bestLeft = Infinity, bestRight = Infinity, bestUp = Infinity, bestDown = Infinity;
+
+            for (const other of positions) {
+                if (other.id === node.id) continue;
+
+                const dx = other.x - node.x;
+                const dy = other.y - node.y;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+
+                // Left: other.x < node.x (must be meaningfully to the left)
+                if (dx < -1 && dist < bestLeft) {
+                    bestLeft = dist;
+                    neighbors.left = other.id;
+                }
+                // Right: other.x > node.x
+                if (dx > 1 && dist < bestRight) {
+                    bestRight = dist;
+                    neighbors.right = other.id;
+                }
+                // Up: other.y < node.y (SVG y-axis: smaller = higher)
+                if (dy < -1 && dist < bestUp) {
+                    bestUp = dist;
+                    neighbors.up = other.id;
+                }
+                // Down: other.y > node.y
+                if (dy > 1 && dist < bestDown) {
+                    bestDown = dist;
+                    neighbors.down = other.id;
+                }
+            }
+
+            result.set(node.id, neighbors);
+        }
+
+        return result;
     }
 
     /**

--- a/src/components/spytial-explorer/spytial-explorer.ts
+++ b/src/components/spytial-explorer/spytial-explorer.ts
@@ -25,7 +25,7 @@ import { AccessibleTranslator } from '../../translators/accessible/accessible-tr
 import { LayoutEvaluator } from '../../evaluators/layout/layout-evaluator';
 import { getExplorerCSS } from './explorer-styles';
 import type { AccessibleLayout, SpatialNeighbors } from '../../translators/accessible/accessible-translator';
-import type { InstanceLayout, LayoutGroup } from '../../layout/interfaces';
+import type { InstanceLayout, LayoutGroup, LayoutEdge } from '../../layout/interfaces';
 import type { QualitativeConstraintValidator } from '../../layout/qualitative-constraint-validator';
 import type { SGraphQueryEvaluator } from '../../evaluators/data/sgq-evaluator';
 // Data Navigator — structure and input modules (rendering done manually for Shadow DOM compat)
@@ -41,6 +41,9 @@ type ValidatorDirection = 'leftOf' | 'rightOf' | 'above' | 'below';
 /** Spatial direction as used internally (arrow keys / nav map) */
 type SpatialDir = 'left' | 'right' | 'up' | 'down';
 
+/** Navigation modes — how arrow keys are interpreted */
+type NavigationMode = 'spatial' | 'must' | 'relations';
+
 interface AnnotatedNeighbor {
     nodeId: string;
     direction: SpatialDir;
@@ -52,6 +55,9 @@ interface QueryHistoryEntry {
     html: string;
     srText: string;
 }
+
+/** Maps arrow keys to DN navigation rule labels */
+type NavigationRuleSet = Record<string, { key: string; direction: 'target' | 'source' }>;
 
 // ─── Component ─────────────────────────────────────────────────────────────
 
@@ -72,6 +78,14 @@ export class SpytialExplorer extends WebColaCnDGraph {
     private groupStack: string[] = [];          // stack of group names we've entered
     private groupMemberMap: Map<string, string[]> = new Map(); // groupName → nodeIds
     private nodeGroupMap: Map<string, string[]> = new Map();   // nodeId → groupNames
+
+    // Navigation mode state
+    private currentNavMode: NavigationMode = 'spatial';
+    private spatialRules: NavigationRuleSet = {};
+    private mustRules: NavigationRuleSet = {};
+    private relationRules: NavigationRuleSet = {};
+    private relationKeyMap: Array<{ key: string; label: string; relationName: string }> = [];
+    private zoomObserver: MutationObserver | null = null;
 
     // Query histories
     private spatialHistory: QueryHistoryEntry[] = [];
@@ -129,9 +143,8 @@ export class SpytialExplorer extends WebColaCnDGraph {
         // If layout already completed (e.g., enableAccessibility called late),
         // set up immediately
         if (this.getNodePositions().length > 0) {
-            const g = this.shadowRoot!.querySelector('svg > g');
-            const transform = g?.getAttribute('transform') ?? '';
-            if (transform.includes('scale') && !transform.includes('scale(1)')) {
+            const t = this.getCurrentTransform();
+            if (t.k !== 1 || t.x !== 0 || t.y !== 0) {
                 // Transform already applied — set up now
                 requestAnimationFrame(() => this.setupDataNavigator());
             }
@@ -251,7 +264,7 @@ export class SpytialExplorer extends WebColaCnDGraph {
         this.dnOverlayContainer = document.createElement('div');
         this.dnOverlayContainer.id = 'dn-overlay-root';
         this.dnOverlayContainer.setAttribute('role', 'application');
-        this.dnOverlayContainer.setAttribute('aria-label', 'Diagram navigation. Arrow keys move between nodes. Shift plus arrow restricts to must relationships. Enter to go into a group. Escape to leave.');
+        this.dnOverlayContainer.setAttribute('aria-label', 'Diagram navigation. Arrow keys move between nodes. Press 1 for spatial mode, 2 for must-only mode, 3 for relation mode. Enter to go into a group. Escape to leave.');
         this.dnOverlayContainer.style.cssText = 'position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none;';
 
         // Insert into the svg-container (which has position: relative)
@@ -367,68 +380,45 @@ export class SpytialExplorer extends WebColaCnDGraph {
     /**
      * Build a Data Navigator structure from the spatial navigation map
      * and overlay focusable elements on the SVG.
+     *
+     * Positioning uses getBoundingClientRect() on actual SVG elements,
+     * which automatically handles zoom/pan transforms.
      */
-    /**
-     * Extract the current SVG pan/zoom transform so overlay elements
-     * can be positioned in container-pixel coordinates.
-     */
-    private getSVGTransform(): { tx: number; ty: number; scale: number } {
-        const shadow = this.shadowRoot!;
-        const g = shadow.querySelector('svg > g');
-        if (!g) return { tx: 0, ty: 0, scale: 1 };
-
-        const transformAttr = g.getAttribute('transform') ?? '';
-        const translateMatch = transformAttr.match(/translate\(\s*([-\d.]+)[,\s]+([-\d.]+)\s*\)/);
-        const scaleMatch = transformAttr.match(/scale\(\s*([-\d.]+)\s*\)/);
-
-        return {
-            tx: translateMatch ? parseFloat(translateMatch[1]) : 0,
-            ty: translateMatch ? parseFloat(translateMatch[2]) : 0,
-            scale: scaleMatch ? parseFloat(scaleMatch[1]) : 1,
-        };
-    }
-
     private setupDataNavigator(): void {
         if (!this.accessibleLayout || !this.currentInstanceLayout) return;
 
+        const shadow = this.shadowRoot!;
         const nav = this.accessibleLayout.navigation;
         const nodeDescs = this.accessibleLayout.description.nodes;
-        const positions = this.getNodePositions();
-        const layoutNodes = this.currentInstanceLayout.nodes;
+        const layout = this.currentInstanceLayout;
 
-        if (positions.length === 0) return;
+        // Build a map from node ID → SVG <g> element via D3's __data__ binding
+        const svgNodeMap = this.buildSVGNodeMap();
+        if (svgNodeMap.size === 0) return;
 
-        // Get SVG transform for coordinate conversion
-        const svgTransform = this.getSVGTransform();
+        const svgContainer = shadow.querySelector('#svg-container') as HTMLElement;
+        if (!svgContainer) return;
 
-        // Build position + size lookup
-        const posMap = new Map(positions.map(p => [p.id, p]));
-        const sizeMap = new Map(layoutNodes.map(n => [
-            n.id,
-            { width: (n as any).visualWidth ?? n.width ?? 50, height: (n as any).visualHeight ?? n.height ?? 30 },
-        ]));
         const descMap = new Map(nodeDescs.map(d => [d.id, d]));
 
-        // ─── Build DN structure manually ───────────────────────────────
-        // We build the Structure object directly rather than using DN's
-        // structure() function, because our navigation graph comes from
-        // the constraint solver, not from raw data dimensions.
-
+        // ─── Build DN structure with multi-label edges ────────────────
         const dnNodes: Record<string, any> = {};
         const dnEdges: Record<string, any> = {};
         const dnElementData: Record<string, any> = {};
         let edgeCounter = 0;
 
+        // Track which node IDs have DN nodes (for relation edge filtering)
+        const dnNodeIds = new Set<string>();
+
         for (const [nodeId, neighbors] of nav.entries()) {
-            const pos = posMap.get(nodeId);
-            const size = sizeMap.get(nodeId);
-            const desc = descMap.get(nodeId);
-            if (!pos || !size) continue;
+            if (!svgNodeMap.has(nodeId)) continue;
+            dnNodeIds.add(nodeId);
 
             const renderId = `dn-node-${this.sanitizeId(nodeId)}`;
+            const desc = descMap.get(nodeId);
             const nodeEdges: string[] = [];
 
-            // Create edges for each spatial direction
+            // Create multi-label edges for each spatial direction
             const directions: Array<[SpatialDir, string | null]> = [
                 ['left', neighbors.left],
                 ['right', neighbors.right],
@@ -438,11 +428,16 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
             for (const [dir, targetId] of directions) {
                 if (!targetId) continue;
+                // Multi-label: spatial_* always, must_* when constraint-guaranteed
+                const labels = [`spatial_${dir}`];
+                if (this.getModality(nodeId, dir, targetId) === 'must') {
+                    labels.push(`must_${dir}`);
+                }
                 const edgeId = `e${edgeCounter++}`;
                 dnEdges[edgeId] = {
                     source: nodeId,
                     target: targetId,
-                    navigationRules: [dir],
+                    navigationRules: labels,
                 };
                 nodeEdges.push(edgeId);
             }
@@ -455,23 +450,8 @@ export class SpytialExplorer extends WebColaCnDGraph {
                 type: desc?.mostSpecificType ?? '',
             };
 
-            // Element data for rendering — convert SVG coords to container pixels
-            // Enforce a minimum clickable size so nodes remain interactive at low zoom
-            const MIN_NODE_SIZE = 24;
-            const pixelX = pos.x * svgTransform.scale + svgTransform.tx;
-            const pixelY = pos.y * svgTransform.scale + svgTransform.ty;
-            const rawW = size.width * svgTransform.scale;
-            const rawH = size.height * svgTransform.scale;
-            const pixelW = Math.max(rawW, MIN_NODE_SIZE);
-            const pixelH = Math.max(rawH, MIN_NODE_SIZE);
-
+            // Element data — positions computed from getBoundingClientRect
             dnElementData[renderId] = {
-                spatialProperties: {
-                    x: pixelX - pixelW / 2,
-                    y: pixelY - pixelH / 2,
-                    width: pixelW,
-                    height: pixelH,
-                },
                 semantics: {
                     label: () => this.buildNodeAnnouncement(nodeId),
                     role: 'button',
@@ -480,15 +460,32 @@ export class SpytialExplorer extends WebColaCnDGraph {
             };
         }
 
+        // ─── Add relation edges from the layout ──────────────────────
+        // These let users follow named data relations (left, right, val, etc.)
+        const relationNames = this.addRelationEdges(layout.edges, dnNodes, dnEdges, dnNodeIds, edgeCounter);
+
+        // ─── Build navigation rule sets ──────────────────────────────
+
+        this.spatialRules = {
+            spatial_left:  { key: 'ArrowLeft',  direction: 'target' },
+            spatial_right: { key: 'ArrowRight', direction: 'target' },
+            spatial_up:    { key: 'ArrowUp',    direction: 'target' },
+            spatial_down:  { key: 'ArrowDown',  direction: 'target' },
+        };
+
+        this.mustRules = {
+            must_left:  { key: 'ArrowLeft',  direction: 'target' },
+            must_right: { key: 'ArrowRight', direction: 'target' },
+            must_up:    { key: 'ArrowUp',    direction: 'target' },
+            must_down:  { key: 'ArrowDown',  direction: 'target' },
+        };
+
+        this.buildRelationRules(relationNames);
+
         const dnStructure = {
             nodes: dnNodes,
             edges: dnEdges,
-            navigationRules: {
-                left: { key: 'ArrowLeft', direction: 'target' as const },
-                right: { key: 'ArrowRight', direction: 'target' as const },
-                up: { key: 'ArrowUp', direction: 'target' as const },
-                down: { key: 'ArrowDown', direction: 'target' as const },
-            },
+            navigationRules: this.spatialRules,
             elementData: dnElementData,
         };
 
@@ -496,28 +493,159 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
         this.dnInputHandler = dataNavigator.input({
             structure: dnStructure,
-            navigationRules: dnStructure.navigationRules,
+            navigationRules: this.spatialRules,
             entryPoint: nav.nodeOrder[0],
         });
 
         // ─── Render DN overlay nodes ───────────────────────────────────
-        // We render manually instead of using DN's rendering module because
-        // we're inside a Shadow DOM and DN's renderer uses document.getElementById.
 
-        this.renderDNOverlay(dnStructure, dnElementData);
+        this.renderDNOverlay(dnStructure, svgNodeMap, svgContainer);
 
-        // ─── Wire keyboard navigation on the overlay ───────────────────
+        // ─── Wire keyboard + zoom tracking ─────────────────────────────
 
-        this.wireDNKeyboard(dnStructure);
+        this.wireDNKeyboard();
+        this.setupZoomTracking(svgContainer, svgNodeMap);
+    }
+
+    /**
+     * Build a map from node ID → SVG <g> DOM element by reading
+     * D3's __data__ binding on each rendered node group.
+     */
+    private buildSVGNodeMap(): Map<string, SVGGElement> {
+        const shadow = this.shadowRoot!;
+        const result = new Map<string, SVGGElement>();
+        const nodeGroups = shadow.querySelectorAll('g.node, g.error-node');
+        for (const g of nodeGroups) {
+            const d = (g as any).__data__;
+            if (d && d.id) {
+                result.set(d.id, g as SVGGElement);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Add DN edges for data relations (left, right, val, etc.) from the layout.
+     * Returns the set of unique relation names found.
+     */
+    private addRelationEdges(
+        edges: LayoutEdge[],
+        dnNodes: Record<string, any>,
+        dnEdges: Record<string, any>,
+        dnNodeIds: Set<string>,
+        edgeCounter: number,
+    ): string[] {
+        const seenRelations = new Set<string>();
+
+        for (const edge of edges) {
+            const relName = edge.relationName || edge.label;
+            if (!relName) continue;
+            // Skip group edges
+            if (edge.groupId) continue;
+
+            const sourceId = edge.source.id;
+            const targetId = edge.target.id;
+
+            // Only add edges between nodes that exist in our DN graph
+            if (!dnNodeIds.has(sourceId) || !dnNodeIds.has(targetId)) continue;
+
+            seenRelations.add(relName);
+
+            const edgeId = `rel_e${edgeCounter++}`;
+            dnEdges[edgeId] = {
+                source: sourceId,
+                target: targetId,
+                navigationRules: [`rel_${relName}`],
+            };
+
+            // Ensure both nodes list this edge
+            if (dnNodes[sourceId]) dnNodes[sourceId].edges.push(edgeId);
+        }
+
+        return [...seenRelations];
+    }
+
+    /**
+     * Build the relation navigation rule set — maps the first 4 relations
+     * to arrow keys in declaration order.
+     */
+    private buildRelationRules(relationNames: string[]): void {
+        const keys = ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'];
+        const labels = ['←', '↑', '→', '↓'];
+
+        this.relationRules = {};
+        this.relationKeyMap = [];
+
+        for (let i = 0; i < Math.min(relationNames.length, keys.length); i++) {
+            const ruleLabel = `rel_${relationNames[i]}`;
+            this.relationRules[ruleLabel] = { key: keys[i], direction: 'target' };
+            this.relationKeyMap.push({
+                key: labels[i],
+                label: relationNames[i],
+                relationName: relationNames[i],
+            });
+        }
+    }
+
+    /**
+     * Set up a MutationObserver on the zoomable SVG group to reposition
+     * overlay nodes when the user zooms or pans.
+     */
+    private setupZoomTracking(svgContainer: HTMLElement, svgNodeMap: Map<string, SVGGElement>): void {
+        // Clean up previous observer
+        if (this.zoomObserver) {
+            this.zoomObserver.disconnect();
+            this.zoomObserver = null;
+        }
+
+        const zoomableG = this.shadowRoot!.querySelector('g.zoomable');
+        if (!zoomableG) return;
+
+        this.zoomObserver = new MutationObserver(() => {
+            this.repositionOverlayNodes(svgContainer, svgNodeMap);
+        });
+        this.zoomObserver.observe(zoomableG, { attributes: true, attributeFilter: ['transform'] });
+    }
+
+    /**
+     * Reposition all overlay nodes to match current SVG node positions.
+     * Called after zoom/pan changes.
+     */
+    private repositionOverlayNodes(svgContainer: HTMLElement, svgNodeMap: Map<string, SVGGElement>): void {
+        if (!this.dnOverlayContainer) return;
+
+        const containerRect = svgContainer.getBoundingClientRect();
+        const MIN_NODE_SIZE = 24;
+
+        for (const el of this.dnOverlayContainer.querySelectorAll('.dn-spatial-node')) {
+            const nodeId = (el as HTMLElement).dataset.nodeId;
+            if (!nodeId) continue;
+
+            const svgG = svgNodeMap.get(nodeId);
+            if (!svgG) continue;
+
+            const rect = svgG.getBoundingClientRect();
+            const w = Math.max(rect.width, MIN_NODE_SIZE);
+            const h = Math.max(rect.height, MIN_NODE_SIZE);
+            const x = rect.left - containerRect.left + (rect.width - w) / 2;
+            const y = rect.top - containerRect.top + (rect.height - h) / 2;
+
+            (el as HTMLElement).style.left = `${x}px`;
+            (el as HTMLElement).style.top = `${y}px`;
+            (el as HTMLElement).style.width = `${w}px`;
+            (el as HTMLElement).style.height = `${h}px`;
+        }
     }
 
     /**
      * Render focusable overlay elements on top of the SVG nodes.
-     * These are what Data Navigator users interact with.
+     * Positions are derived from getBoundingClientRect() on the actual SVG
+     * elements, which automatically handles zoom/pan transforms.
      */
     private renderDNOverlay(
         structure: any,
-        elementData: Record<string, any>,
+        svgNodeMap: Map<string, SVGGElement>,
+        svgContainer: HTMLElement,
     ): void {
         if (!this.dnOverlayContainer) return;
 
@@ -535,21 +663,31 @@ export class SpytialExplorer extends WebColaCnDGraph {
         });
         this.dnOverlayContainer.appendChild(entryBtn);
 
+        // Mode toolbar
+        this.renderModeToolbar();
+
+        const containerRect = svgContainer.getBoundingClientRect();
+        const MIN_NODE_SIZE = 24;
+
         // Create a focusable element for each node
         for (const [nodeId, node] of Object.entries(structure.nodes) as any[]) {
             const renderId = node.renderId;
-            const data = elementData[renderId];
-            if (!data) continue;
+            const svgG = svgNodeMap.get(nodeId);
+            if (!svgG) continue;
 
-            const sp = data.spatialProperties;
+            // Position from actual SVG element bounding rect
+            const rect = svgG.getBoundingClientRect();
+            const w = Math.max(rect.width, MIN_NODE_SIZE);
+            const h = Math.max(rect.height, MIN_NODE_SIZE);
+            const x = rect.left - containerRect.left + (rect.width - w) / 2;
+            const y = rect.top - containerRect.top + (rect.height - h) / 2;
+
             const el = document.createElement('div');
             el.id = renderId;
-            el.className = `dn-spatial-node ${data.cssClass || ''}`;
+            el.className = 'dn-spatial-node';
             el.setAttribute('role', 'button');
             el.setAttribute('tabindex', '-1');
-            el.setAttribute('aria-label', typeof data.semantics?.label === 'function'
-                ? data.semantics.label()
-                : (data.semantics?.label || nodeId));
+            el.setAttribute('aria-label', this.buildNodeAnnouncement(nodeId));
             el.dataset.nodeId = nodeId;
 
             // Tag with groups for group navigation
@@ -560,10 +698,10 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
             el.style.cssText = `
                 position: absolute;
-                left: ${sp.x}px;
-                top: ${sp.y}px;
-                width: ${sp.width}px;
-                height: ${sp.height}px;
+                left: ${x}px;
+                top: ${y}px;
+                width: ${w}px;
+                height: ${h}px;
                 pointer-events: auto;
                 cursor: pointer;
                 border-radius: 4px;
@@ -581,18 +719,62 @@ export class SpytialExplorer extends WebColaCnDGraph {
     }
 
     /**
+     * Render the navigation mode toolbar inside the overlay container.
+     */
+    private renderModeToolbar(): void {
+        if (!this.dnOverlayContainer) return;
+
+        const toolbar = document.createElement('div');
+        toolbar.className = 'nav-mode-toolbar';
+        toolbar.setAttribute('role', 'radiogroup');
+        toolbar.setAttribute('aria-label', 'Navigation mode');
+        toolbar.style.cssText = 'pointer-events: auto;';
+
+        const modes: Array<{ mode: NavigationMode; label: string; key: string }> = [
+            { mode: 'spatial', label: 'Spatial', key: '1' },
+            { mode: 'must', label: 'Must-only', key: '2' },
+            { mode: 'relations', label: 'Relations', key: '3' },
+        ];
+
+        for (const { mode, label, key } of modes) {
+            const btn = document.createElement('button');
+            btn.setAttribute('role', 'radio');
+            btn.setAttribute('aria-checked', mode === this.currentNavMode ? 'true' : 'false');
+            btn.dataset.mode = mode;
+            btn.textContent = `${label} (${key})`;
+            btn.addEventListener('click', () => this.switchNavigationMode(mode));
+            toolbar.appendChild(btn);
+        }
+
+        // Relation key mapping hint (shown when in relation mode)
+        const keyHint = document.createElement('span');
+        keyHint.className = 'relation-key-hint';
+        keyHint.id = 'se-relation-key-hint';
+        keyHint.style.display = this.currentNavMode === 'relations' ? 'inline' : 'none';
+        keyHint.textContent = this.relationKeyMap.map(m => `${m.key} ${m.label}`).join('  ');
+        toolbar.appendChild(keyHint);
+
+        this.dnOverlayContainer.appendChild(toolbar);
+    }
+
+    /**
      * Wire keyboard navigation on the DN overlay.
      *
-     * - Arrow keys: navigate to nearest neighbor in that direction (current layout)
-     * - Shift+Arrow: navigate only along MUST relationships (guaranteed in all valid layouts)
+     * - Arrow keys: navigate based on current mode (spatial/must/relations)
+     * - 1/2/3: switch navigation mode
      * - Enter: drill into a group
      * - Esc: leave a group (or exit navigation)
      */
-    private wireDNKeyboard(_structure: any): void {
+    private wireDNKeyboard(): void {
         if (!this.dnOverlayContainer || !this.dnInputHandler) return;
 
         this.dnOverlayContainer.addEventListener('keydown', (e) => {
             if (!this.dnCurrentFocusId || !this.dnInputHandler) return;
+
+            // ─── Mode switching ──────────────────────────────────
+            if (e.key === '1') { this.switchNavigationMode('spatial'); e.preventDefault(); return; }
+            if (e.key === '2') { this.switchNavigationMode('must'); e.preventDefault(); return; }
+            if (e.key === '3') { this.switchNavigationMode('relations'); e.preventDefault(); return; }
 
             // ─── Group navigation ─────────────────────────────────
             if (e.key === 'Enter') {
@@ -615,29 +797,19 @@ export class SpytialExplorer extends WebColaCnDGraph {
                 return;
             }
 
-            // ─── Spatial navigation ───────────────────────────────
+            // ─── Navigation ──────────────────────────────────────
             const direction = this.dnInputHandler.keydownValidator(e);
             if (!direction) return;
 
             e.preventDefault();
             e.stopPropagation();
 
-            const mustOnly = e.shiftKey;
             const nextNode = this.dnInputHandler.move(this.dnCurrentFocusId, direction);
 
-            if (!nextNode) return;
-
-            // If Shift is held, only allow must relationships
-            if (mustOnly) {
-                const modality = this.getModality(
-                    this.dnCurrentFocusId,
-                    direction as SpatialDir,
-                    nextNode.id,
-                );
-                if (modality !== 'must') {
-                    this.announce(`No must-${direction} neighbor. This is a can relationship.`);
-                    return;
-                }
+            if (!nextNode) {
+                // Announce no neighbor in current mode
+                this.announceNoNeighbor(direction);
+                return;
             }
 
             // If we're inside a group, only navigate to group members
@@ -655,9 +827,83 @@ export class SpytialExplorer extends WebColaCnDGraph {
             const el = this.shadowRoot!.getElementById(renderId);
             if (el) {
                 el.focus();
-                this.highlightNodes([nextNode.id]);
+                // Call directly — don't rely solely on focus event
+                this.onDNNodeFocused(nextNode.id);
+            }
+
+            // Mode-specific announcement
+            if (this.currentNavMode === 'relations') {
+                const relName = this.getRelationNameFromDirection(direction);
+                if (relName) {
+                    this.announce(`Following ${relName} to ${this.getNodeLabel(nextNode.id)}.`);
+                }
             }
         });
+    }
+
+    /**
+     * Switch navigation mode and update DN's active key bindings.
+     */
+    private switchNavigationMode(mode: NavigationMode): void {
+        if (mode === this.currentNavMode) return;
+
+        const ruleSet = mode === 'spatial' ? this.spatialRules
+            : mode === 'must' ? this.mustRules
+            : this.relationRules;
+
+        // Ensure the rule set has entries (relations may be empty)
+        if (Object.keys(ruleSet).length === 0 && mode === 'relations') {
+            this.announce('No data relations available for relation navigation.');
+            return;
+        }
+
+        this.dnInputHandler?.setNavigationKeyBindings?.(ruleSet);
+        this.currentNavMode = mode;
+        this.updateModeUI();
+        this.announce(`Navigation mode: ${mode}.`);
+    }
+
+    /**
+     * Update the toolbar UI to reflect the current navigation mode.
+     */
+    private updateModeUI(): void {
+        if (!this.dnOverlayContainer) return;
+
+        const toolbar = this.dnOverlayContainer.querySelector('.nav-mode-toolbar');
+        if (!toolbar) return;
+
+        for (const btn of toolbar.querySelectorAll('[role="radio"]')) {
+            const isActive = (btn as HTMLElement).dataset.mode === this.currentNavMode;
+            btn.setAttribute('aria-checked', isActive ? 'true' : 'false');
+        }
+
+        const keyHint = toolbar.querySelector('#se-relation-key-hint') as HTMLElement;
+        if (keyHint) {
+            keyHint.style.display = this.currentNavMode === 'relations' ? 'inline' : 'none';
+        }
+    }
+
+    /**
+     * Announce that no neighbor was found in the given direction for the current mode.
+     */
+    private announceNoNeighbor(direction: string): void {
+        const nodeLabel = this.dnCurrentFocusId ? this.getNodeLabel(this.dnCurrentFocusId) : 'current node';
+        if (this.currentNavMode === 'must') {
+            this.announce(`No must-${direction.replace('must_', '')} neighbor from ${nodeLabel}.`);
+        } else if (this.currentNavMode === 'relations') {
+            const relName = this.getRelationNameFromDirection(direction) ?? direction;
+            this.announce(`No ${relName} relation from ${nodeLabel}.`);
+        } else {
+            this.announce(`No ${direction.replace('spatial_', '')} neighbor from ${nodeLabel}.`);
+        }
+    }
+
+    /**
+     * Extract the relation name from a DN direction label like "rel_left" → "left".
+     */
+    private getRelationNameFromDirection(direction: string): string | null {
+        if (direction.startsWith('rel_')) return direction.slice(4);
+        return null;
     }
 
     // ─── Group Navigation ─────────────────────────────────────────────
@@ -990,7 +1236,9 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
         if (el) {
             el.focus();
-            this.highlightNodes([nodeId]);
+            // Call directly — don't rely solely on focus event firing
+            this.dnCurrentFocusId = nodeId;
+            this.onDNNodeFocused(nodeId);
         }
     }
 

--- a/src/components/spytial-explorer/spytial-explorer.ts
+++ b/src/components/spytial-explorer/spytial-explorer.ts
@@ -56,9 +56,6 @@ interface QueryHistoryEntry {
     srText: string;
 }
 
-/** Maps arrow keys to DN navigation rule labels */
-type NavigationRuleSet = Record<string, { key: string; direction: 'target' | 'source' }>;
-
 // ─── Component ─────────────────────────────────────────────────────────────
 
 export class SpytialExplorer extends WebColaCnDGraph {
@@ -81,10 +78,9 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
     // Navigation mode state
     private currentNavMode: NavigationMode = 'spatial';
-    private spatialRules: NavigationRuleSet = {};
-    private mustRules: NavigationRuleSet = {};
-    private relationRules: NavigationRuleSet = {};
-    private relationKeyMap: Array<{ key: string; label: string; relationName: string }> = [];
+    private relationKeyMap: Array<{ key: string; arrowKey: string; relationName: string }> = [];
+    // (nodeId, relationName) → targetNodeId — for relation mode navigation
+    private relationEdgeMap: Map<string, Map<string, string>> = new Map();
     private zoomObserver: MutationObserver | null = null;
 
     // Query histories
@@ -383,6 +379,11 @@ export class SpytialExplorer extends WebColaCnDGraph {
      *
      * Positioning uses getBoundingClientRect() on actual SVG elements,
      * which automatically handles zoom/pan transforms.
+     *
+     * DN edges use simple direction labels (left/right/up/down).
+     * Mode filtering (must-only, relations) is handled in the keyboard
+     * handler rather than via DN's setNavigationKeyBindings, which is
+     * more reliable and gives us full control over announcements.
      */
     private setupDataNavigator(): void {
         if (!this.accessibleLayout || !this.currentInstanceLayout) return;
@@ -401,24 +402,20 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
         const descMap = new Map(nodeDescs.map(d => [d.id, d]));
 
-        // ─── Build DN structure with multi-label edges ────────────────
+        // ─── Build DN structure ───────────────────────────────────────
         const dnNodes: Record<string, any> = {};
         const dnEdges: Record<string, any> = {};
         const dnElementData: Record<string, any> = {};
         let edgeCounter = 0;
 
-        // Track which node IDs have DN nodes (for relation edge filtering)
-        const dnNodeIds = new Set<string>();
-
         for (const [nodeId, neighbors] of nav.entries()) {
             if (!svgNodeMap.has(nodeId)) continue;
-            dnNodeIds.add(nodeId);
 
             const renderId = `dn-node-${this.sanitizeId(nodeId)}`;
             const desc = descMap.get(nodeId);
             const nodeEdges: string[] = [];
 
-            // Create multi-label edges for each spatial direction
+            // Simple direction-labeled edges for spatial navigation
             const directions: Array<[SpatialDir, string | null]> = [
                 ['left', neighbors.left],
                 ['right', neighbors.right],
@@ -428,16 +425,11 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
             for (const [dir, targetId] of directions) {
                 if (!targetId) continue;
-                // Multi-label: spatial_* always, must_* when constraint-guaranteed
-                const labels = [`spatial_${dir}`];
-                if (this.getModality(nodeId, dir, targetId) === 'must') {
-                    labels.push(`must_${dir}`);
-                }
                 const edgeId = `e${edgeCounter++}`;
                 dnEdges[edgeId] = {
                     source: nodeId,
                     target: targetId,
-                    navigationRules: labels,
+                    navigationRules: [dir],
                 };
                 nodeEdges.push(edgeId);
             }
@@ -450,7 +442,6 @@ export class SpytialExplorer extends WebColaCnDGraph {
                 type: desc?.mostSpecificType ?? '',
             };
 
-            // Element data — positions computed from getBoundingClientRect
             dnElementData[renderId] = {
                 semantics: {
                     label: () => this.buildNodeAnnouncement(nodeId),
@@ -460,32 +451,20 @@ export class SpytialExplorer extends WebColaCnDGraph {
             };
         }
 
-        // ─── Add relation edges from the layout ──────────────────────
-        // These let users follow named data relations (left, right, val, etc.)
-        const relationNames = this.addRelationEdges(layout.edges, dnNodes, dnEdges, dnNodeIds, edgeCounter);
+        // ─── Build relation map for relation-mode navigation ─────────
+        this.buildRelationMap(layout.edges);
 
-        // ─── Build navigation rule sets ──────────────────────────────
-
-        this.spatialRules = {
-            spatial_left:  { key: 'ArrowLeft',  direction: 'target' },
-            spatial_right: { key: 'ArrowRight', direction: 'target' },
-            spatial_up:    { key: 'ArrowUp',    direction: 'target' },
-            spatial_down:  { key: 'ArrowDown',  direction: 'target' },
+        const navigationRules = {
+            left:  { key: 'ArrowLeft',  direction: 'target' as const },
+            right: { key: 'ArrowRight', direction: 'target' as const },
+            up:    { key: 'ArrowUp',    direction: 'target' as const },
+            down:  { key: 'ArrowDown',  direction: 'target' as const },
         };
-
-        this.mustRules = {
-            must_left:  { key: 'ArrowLeft',  direction: 'target' },
-            must_right: { key: 'ArrowRight', direction: 'target' },
-            must_up:    { key: 'ArrowUp',    direction: 'target' },
-            must_down:  { key: 'ArrowDown',  direction: 'target' },
-        };
-
-        this.buildRelationRules(relationNames);
 
         const dnStructure = {
             nodes: dnNodes,
             edges: dnEdges,
-            navigationRules: this.spatialRules,
+            navigationRules,
             elementData: dnElementData,
         };
 
@@ -493,7 +472,7 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
         this.dnInputHandler = dataNavigator.input({
             structure: dnStructure,
-            navigationRules: this.spatialRules,
+            navigationRules,
             entryPoint: nav.nodeOrder[0],
         });
 
@@ -525,63 +504,39 @@ export class SpytialExplorer extends WebColaCnDGraph {
     }
 
     /**
-     * Add DN edges for data relations (left, right, val, etc.) from the layout.
-     * Returns the set of unique relation names found.
+     * Build the relation map from layout edges.
+     * Maps (sourceNodeId, relationName) → targetNodeId for relation-mode nav.
+     * Also builds the key mapping (first 4 relations → arrow keys).
      */
-    private addRelationEdges(
-        edges: LayoutEdge[],
-        dnNodes: Record<string, any>,
-        dnEdges: Record<string, any>,
-        dnNodeIds: Set<string>,
-        edgeCounter: number,
-    ): string[] {
+    private buildRelationMap(edges: LayoutEdge[]): void {
+        this.relationEdgeMap.clear();
+        this.relationKeyMap = [];
+
         const seenRelations = new Set<string>();
 
         for (const edge of edges) {
             const relName = edge.relationName || edge.label;
-            if (!relName) continue;
-            // Skip group edges
-            if (edge.groupId) continue;
+            if (!relName || edge.groupId) continue;
 
             const sourceId = edge.source.id;
             const targetId = edge.target.id;
 
-            // Only add edges between nodes that exist in our DN graph
-            if (!dnNodeIds.has(sourceId) || !dnNodeIds.has(targetId)) continue;
-
+            if (!this.relationEdgeMap.has(sourceId)) {
+                this.relationEdgeMap.set(sourceId, new Map());
+            }
+            this.relationEdgeMap.get(sourceId)!.set(relName, targetId);
             seenRelations.add(relName);
-
-            const edgeId = `rel_e${edgeCounter++}`;
-            dnEdges[edgeId] = {
-                source: sourceId,
-                target: targetId,
-                navigationRules: [`rel_${relName}`],
-            };
-
-            // Ensure both nodes list this edge
-            if (dnNodes[sourceId]) dnNodes[sourceId].edges.push(edgeId);
         }
 
-        return [...seenRelations];
-    }
+        // Map first 4 unique relations to arrow keys
+        const arrowKeys = ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'];
+        const labels = ['\u2190', '\u2191', '\u2192', '\u2193'];
+        const relationNames = [...seenRelations];
 
-    /**
-     * Build the relation navigation rule set — maps the first 4 relations
-     * to arrow keys in declaration order.
-     */
-    private buildRelationRules(relationNames: string[]): void {
-        const keys = ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'];
-        const labels = ['←', '↑', '→', '↓'];
-
-        this.relationRules = {};
-        this.relationKeyMap = [];
-
-        for (let i = 0; i < Math.min(relationNames.length, keys.length); i++) {
-            const ruleLabel = `rel_${relationNames[i]}`;
-            this.relationRules[ruleLabel] = { key: keys[i], direction: 'target' };
+        for (let i = 0; i < Math.min(relationNames.length, arrowKeys.length); i++) {
             this.relationKeyMap.push({
                 key: labels[i],
-                label: relationNames[i],
+                arrowKey: arrowKeys[i],
                 relationName: relationNames[i],
             });
         }
@@ -751,7 +706,7 @@ export class SpytialExplorer extends WebColaCnDGraph {
         keyHint.className = 'relation-key-hint';
         keyHint.id = 'se-relation-key-hint';
         keyHint.style.display = this.currentNavMode === 'relations' ? 'inline' : 'none';
-        keyHint.textContent = this.relationKeyMap.map(m => `${m.key} ${m.label}`).join('  ');
+        keyHint.textContent = this.relationKeyMap.map(m => `${m.key} ${m.relationName}`).join('  ');
         toolbar.appendChild(keyHint);
 
         this.dnOverlayContainer.appendChild(toolbar);
@@ -760,10 +715,11 @@ export class SpytialExplorer extends WebColaCnDGraph {
     /**
      * Wire keyboard navigation on the DN overlay.
      *
-     * - Arrow keys: navigate based on current mode (spatial/must/relations)
-     * - 1/2/3: switch navigation mode
-     * - Enter: drill into a group
-     * - Esc: leave a group (or exit navigation)
+     * DN always uses simple direction labels (left/right/up/down).
+     * Mode filtering is handled here:
+     *   - Spatial: move() directly (all neighbors)
+     *   - Must-only: move() then block if modality !== 'must'
+     *   - Relations: bypass DN, use relationEdgeMap directly
      */
     private wireDNKeyboard(): void {
         if (!this.dnOverlayContainer || !this.dnInputHandler) return;
@@ -788,7 +744,6 @@ export class SpytialExplorer extends WebColaCnDGraph {
                 if (this.groupStack.length > 0) {
                     this.handleGroupEscape();
                 } else {
-                    // Exit navigation entirely
                     (this.shadowRoot!.activeElement as HTMLElement)?.blur();
                     this.dnCurrentFocusId = null;
                 }
@@ -797,7 +752,26 @@ export class SpytialExplorer extends WebColaCnDGraph {
                 return;
             }
 
-            // ─── Navigation ──────────────────────────────────────
+            // ─── Relation mode: bypass DN, use relation map ──────
+            if (this.currentNavMode === 'relations') {
+                const mapping = this.relationKeyMap.find(m => m.arrowKey === e.code);
+                if (!mapping) return;
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                const targetId = this.relationEdgeMap.get(this.dnCurrentFocusId)?.get(mapping.relationName);
+                if (!targetId) {
+                    this.announce(`No ${mapping.relationName} from ${this.getNodeLabel(this.dnCurrentFocusId)}.`);
+                    return;
+                }
+
+                this.focusDNNode(targetId);
+                this.announce(`Following ${mapping.relationName} to ${this.getNodeLabel(targetId)}.`);
+                return;
+            }
+
+            // ─── Spatial / Must modes: use DN move() ─────────────
             const direction = this.dnInputHandler.keydownValidator(e);
             if (!direction) return;
 
@@ -805,14 +779,25 @@ export class SpytialExplorer extends WebColaCnDGraph {
             e.stopPropagation();
 
             const nextNode = this.dnInputHandler.move(this.dnCurrentFocusId, direction);
-
             if (!nextNode) {
-                // Announce no neighbor in current mode
-                this.announceNoNeighbor(direction);
+                this.announce(`No ${direction} neighbor from ${this.getNodeLabel(this.dnCurrentFocusId)}.`);
                 return;
             }
 
-            // If we're inside a group, only navigate to group members
+            // Must mode: block if relationship isn't must
+            if (this.currentNavMode === 'must') {
+                const modality = this.getModality(
+                    this.dnCurrentFocusId,
+                    direction as SpatialDir,
+                    nextNode.id,
+                );
+                if (modality !== 'must') {
+                    this.announce(`No must-${direction} neighbor. This is a ${modality} relationship.`);
+                    return;
+                }
+            }
+
+            // Group boundary check
             if (this.groupStack.length > 0) {
                 const currentGroup = this.groupStack[this.groupStack.length - 1];
                 const members = this.groupMemberMap.get(currentGroup);
@@ -822,45 +807,41 @@ export class SpytialExplorer extends WebColaCnDGraph {
                 }
             }
 
-            this.dnCurrentFocusId = nextNode.id;
-            const renderId = nextNode.renderId;
-            const el = this.shadowRoot!.getElementById(renderId);
-            if (el) {
-                el.focus();
-                // Call directly — don't rely solely on focus event
-                this.onDNNodeFocused(nextNode.id);
-            }
-
-            // Mode-specific announcement
-            if (this.currentNavMode === 'relations') {
-                const relName = this.getRelationNameFromDirection(direction);
-                if (relName) {
-                    this.announce(`Following ${relName} to ${this.getNodeLabel(nextNode.id)}.`);
-                }
-            }
+            this.focusDNNode(nextNode.id);
         });
     }
 
     /**
-     * Switch navigation mode and update DN's active key bindings.
+     * Focus a DN overlay node by ID — updates tracking, context panel, highlights.
+     */
+    private focusDNNode(nodeId: string): void {
+        this.dnCurrentFocusId = nodeId;
+        const renderId = `dn-node-${this.sanitizeId(nodeId)}`;
+        const el = this.shadowRoot!.getElementById(renderId);
+        if (el) {
+            el.focus();
+            this.onDNNodeFocused(nodeId);
+        }
+    }
+
+    /**
+     * Switch navigation mode. Purely local state — DN structure is unchanged.
      */
     private switchNavigationMode(mode: NavigationMode): void {
         if (mode === this.currentNavMode) return;
 
-        const ruleSet = mode === 'spatial' ? this.spatialRules
-            : mode === 'must' ? this.mustRules
-            : this.relationRules;
-
-        // Ensure the rule set has entries (relations may be empty)
-        if (Object.keys(ruleSet).length === 0 && mode === 'relations') {
+        if (mode === 'relations' && this.relationKeyMap.length === 0) {
             this.announce('No data relations available for relation navigation.');
             return;
         }
 
-        this.dnInputHandler?.setNavigationKeyBindings?.(ruleSet);
         this.currentNavMode = mode;
         this.updateModeUI();
-        this.announce(`Navigation mode: ${mode}.`);
+
+        const modeDesc = mode === 'spatial' ? 'Spatial — arrow keys move to nearest neighbor'
+            : mode === 'must' ? 'Must-only — arrow keys follow only guaranteed relationships'
+            : `Relations — ${this.relationKeyMap.map(m => `${m.key} ${m.relationName}`).join(', ')}`;
+        this.announce(`Navigation mode: ${modeDesc}.`);
     }
 
     /**
@@ -881,29 +862,6 @@ export class SpytialExplorer extends WebColaCnDGraph {
         if (keyHint) {
             keyHint.style.display = this.currentNavMode === 'relations' ? 'inline' : 'none';
         }
-    }
-
-    /**
-     * Announce that no neighbor was found in the given direction for the current mode.
-     */
-    private announceNoNeighbor(direction: string): void {
-        const nodeLabel = this.dnCurrentFocusId ? this.getNodeLabel(this.dnCurrentFocusId) : 'current node';
-        if (this.currentNavMode === 'must') {
-            this.announce(`No must-${direction.replace('must_', '')} neighbor from ${nodeLabel}.`);
-        } else if (this.currentNavMode === 'relations') {
-            const relName = this.getRelationNameFromDirection(direction) ?? direction;
-            this.announce(`No ${relName} relation from ${nodeLabel}.`);
-        } else {
-            this.announce(`No ${direction.replace('spatial_', '')} neighbor from ${nodeLabel}.`);
-        }
-    }
-
-    /**
-     * Extract the relation name from a DN direction label like "rel_left" → "left".
-     */
-    private getRelationNameFromDirection(direction: string): string | null {
-        if (direction.startsWith('rel_')) return direction.slice(4);
-        return null;
     }
 
     // ─── Group Navigation ─────────────────────────────────────────────
@@ -983,6 +941,7 @@ export class SpytialExplorer extends WebColaCnDGraph {
         const annotated = this.getAnnotatedNeighbors(nodeId);
 
         this.updateContextPanel(label, type, nb, annotated);
+        this.clearNodeHighlights();
         this.highlightNodes([nodeId]);
 
         // Dispatch event for external consumers

--- a/src/components/spytial-explorer/spytial-explorer.ts
+++ b/src/components/spytial-explorer/spytial-explorer.ts
@@ -824,7 +824,20 @@ export class SpytialExplorer extends WebColaCnDGraph {
                 return;
             }
 
-            // ─── Spatial / Must modes: use DN move() ─────────────
+            // ─── Must mode: find closest must-neighbor in direction ─
+            if (this.currentNavMode === 'must') {
+                const dir = this.arrowKeyToDir(e.code);
+                if (!dir) return;
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                const target = this.findClosestMustNeighbor(this.dnCurrentFocusId, dir);
+                if (target) this.focusDNNode(target);
+                return;
+            }
+
+            // ─── Spatial mode: use DN move() ─────────────────────
             const direction = this.dnInputHandler.keydownValidator(e);
             if (!direction) return;
 
@@ -833,16 +846,6 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
             const nextNode = this.dnInputHandler.move(this.dnCurrentFocusId, direction);
             if (!nextNode) return;
-
-            // Must mode: silently block if relationship isn't must
-            if (this.currentNavMode === 'must') {
-                const modality = this.getModality(
-                    this.dnCurrentFocusId,
-                    direction as SpatialDir,
-                    nextNode.id,
-                );
-                if (modality !== 'must') return;
-            }
 
             // Group boundary check
             if (this.groupStack.length > 0) {
@@ -853,6 +856,55 @@ export class SpytialExplorer extends WebColaCnDGraph {
 
             this.focusDNNode(nextNode.id);
         });
+    }
+
+    /**
+     * Find the closest node that MUST be in the given direction from the current node.
+     * Queries the constraint validator for the must-set, then picks the nearest by position.
+     */
+    private findClosestMustNeighbor(fromNodeId: string, dir: SpatialDir): string | null {
+        if (!this.constraintValidator) return null;
+
+        const validatorDir = this.spatialDirToValidatorDir(dir);
+        let mustSet: Set<string>;
+        try {
+            mustSet = this.constraintValidator.getMust(fromNodeId, validatorDir);
+        } catch {
+            return null;
+        }
+        if (mustSet.size === 0) return null;
+
+        // Find the closest must-node by position
+        const positions = this.getNodePositions();
+        const posMap = new Map(positions.map(p => [p.id, p]));
+        const fromPos = posMap.get(fromNodeId);
+        if (!fromPos) return null;
+
+        let closest: string | null = null;
+        let bestDist = Infinity;
+
+        for (const targetId of mustSet) {
+            const tp = posMap.get(targetId);
+            if (!tp) continue;
+            const dist = Math.sqrt((tp.x - fromPos.x) ** 2 + (tp.y - fromPos.y) ** 2);
+            if (dist < bestDist) {
+                bestDist = dist;
+                closest = targetId;
+            }
+        }
+
+        return closest;
+    }
+
+    /** Map e.code to our SpatialDir, or null if not an arrow key. */
+    private arrowKeyToDir(code: string): SpatialDir | null {
+        switch (code) {
+            case 'ArrowLeft':  return 'left';
+            case 'ArrowRight': return 'right';
+            case 'ArrowUp':    return 'up';
+            case 'ArrowDown':  return 'down';
+            default: return null;
+        }
     }
 
     /**

--- a/webcola-demo/accessible-demo.html
+++ b/webcola-demo/accessible-demo.html
@@ -105,9 +105,10 @@
 
     <!-- ─── Usage Guide ─────────────────────────────────────────────── -->
     <div class="usage-guide">
-        <h2>How to Use This Demo</h2>
+        <details>
+        <summary><h2 style="display:inline;cursor:pointer;margin:0">How to Use This Demo</h2></summary>
 
-        <div class="two-col">
+        <div class="two-col" style="margin-top:12px">
             <div>
                 <h3>Keyboard Navigation (Data Navigator)</h3>
                 <ul>
@@ -154,6 +155,8 @@
                 </ul>
             </div>
         </div>
+
+        </details>
 
         <details>
             <summary><h3 style="display:inline;cursor:pointer">Using <code>&lt;spytial-explorer&gt;</code> in Your Own Page</h3></summary>

--- a/webcola-demo/accessible-demo.html
+++ b/webcola-demo/accessible-demo.html
@@ -74,7 +74,7 @@
         </div>
     </div>
 
-    <spytial-explorer id="explorer" width="900" height="500"></spytial-explorer>
+    <spytial-explorer id="explorer" style="width: 100%; max-width: 1200px; height: 650px; margin: 0 auto;"></spytial-explorer>
 
     <!-- ─── Usage Guide ─────────────────────────────────────────────── -->
     <div class="usage-guide">
@@ -85,8 +85,14 @@
                 <h3>Keyboard Navigation (Data Navigator)</h3>
                 <ul>
                     <li>Click <strong>"Enter diagram navigation"</strong> (or <kbd>Tab</kbd> to it) to start</li>
-                    <li><kbd>&larr;</kbd> <kbd>&rarr;</kbd> <kbd>&uarr;</kbd> <kbd>&darr;</kbd> &mdash; move between nodes spatially (current layout)</li>
-                    <li><kbd>Shift</kbd>+<kbd>&larr;</kbd> etc. &mdash; move only along <strong>must</strong> relationships (guaranteed in ALL valid layouts)</li>
+                    <li><kbd>&larr;</kbd> <kbd>&rarr;</kbd> <kbd>&uarr;</kbd> <kbd>&darr;</kbd> &mdash; move between nodes (behavior depends on navigation mode)</li>
+                    <li><strong>Navigation modes</strong> (press <kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd> to switch):
+                        <ul>
+                            <li><kbd>1</kbd> <strong>Spatial</strong> &mdash; nearest neighbor in current layout</li>
+                            <li><kbd>2</kbd> <strong>Must-only</strong> &mdash; only constraint-guaranteed relationships (true in ALL valid layouts)</li>
+                            <li><kbd>3</kbd> <strong>Relations</strong> &mdash; follow named data relations (left, right, val)</li>
+                        </ul>
+                    </li>
                     <li><kbd>Enter</kbd> &mdash; drill into a group (navigate among group members)</li>
                     <li><kbd>Esc</kbd> &mdash; leave group, or exit diagram navigation</li>
                     <li>The <strong>Spatial Context</strong> panel updates live with modality badges (<span style="background:#c8e6c9;padding:0 4px;border-radius:2px;font-size:11px;font-weight:700">MUST</span> / <span style="background:#fff3e0;padding:0 4px;border-radius:2px;font-size:11px;font-weight:700">CAN</span>)</li>

--- a/webcola-demo/accessible-demo.html
+++ b/webcola-demo/accessible-demo.html
@@ -74,7 +74,9 @@
         </div>
     </div>
 
-    <spytial-explorer id="explorer" style="width: 100%; max-width: 1400px; height: 85vh; min-height: 600px; margin: 0 auto; resize: vertical; overflow: auto;"></spytial-explorer>
+    <div style="max-width: 1400px; margin: 0 auto; border: 1px solid #ccc; border-radius: 8px; resize: both; overflow: hidden; height: 85vh; min-height: 400px; min-width: 400px;">
+        <spytial-explorer id="explorer" style="width: 100%; height: 100%;"></spytial-explorer>
+    </div>
 
     <!-- ─── Usage Guide ─────────────────────────────────────────────── -->
     <div class="usage-guide">

--- a/webcola-demo/accessible-demo.html
+++ b/webcola-demo/accessible-demo.html
@@ -74,7 +74,7 @@
         </div>
     </div>
 
-    <spytial-explorer id="explorer" style="width: 100%; max-width: 1200px; height: 650px; margin: 0 auto;"></spytial-explorer>
+    <spytial-explorer id="explorer" style="width: 100%; max-width: 1400px; height: 85vh; min-height: 600px; margin: 0 auto; resize: vertical; overflow: auto;"></spytial-explorer>
 
     <!-- ─── Usage Guide ─────────────────────────────────────────────── -->
     <div class="usage-guide">
@@ -128,7 +128,8 @@
             </div>
         </div>
 
-        <h3>Using <code>&lt;spytial-explorer&gt;</code> in Your Own Page</h3>
+        <details>
+            <summary><h3 style="display:inline;cursor:pointer">Using <code>&lt;spytial-explorer&gt;</code> in Your Own Page</h3></summary>
 <pre><span class="comment">&lt;!-- 1. Include dependencies --&gt;</span>
 &lt;script src=<span class="string">"d3.v4.min.js"</span>&gt;&lt;/script&gt;
 &lt;script src=<span class="string">"cola.js"</span>&gt;&lt;/script&gt;
@@ -153,6 +154,7 @@
   <span class="comment">//    Data Navigator overlay, spatial context, spatial + datum REPLs</span>
   explorer.<span class="fn">enableAccessibility</span>(result.layout, result.validator, evaluator);
 &lt;/script&gt;</pre>
+        </details>
     </div>
 
     <!-- Load the library bundle (registers <spytial-explorer> automatically) -->

--- a/webcola-demo/accessible-demo.html
+++ b/webcola-demo/accessible-demo.html
@@ -74,9 +74,34 @@
         </div>
     </div>
 
-    <div style="max-width: 1400px; margin: 0 auto; border: 1px solid #ccc; border-radius: 8px; resize: both; overflow: hidden; height: 85vh; min-height: 400px; min-width: 400px;">
+    <div id="explorer-wrapper" style="max-width: 1400px; margin: 0 auto; border: 1px solid #ccc; border-radius: 8px; overflow: hidden; height: 85vh; min-height: 400px; min-width: 400px; position: relative;">
         <spytial-explorer id="explorer" style="width: 100%; height: 100%;"></spytial-explorer>
+        <div id="resize-handle" style="position: absolute; bottom: 0; right: 0; width: 20px; height: 20px; cursor: nwse-resize; background: linear-gradient(135deg, transparent 50%, #999 50%, transparent 52%, #999 65%, transparent 67%, #999 80%, transparent 82%); border-radius: 0 0 8px 0; z-index: 10;" title="Drag to resize"></div>
     </div>
+    <script>
+    // Custom drag-resize for the explorer wrapper
+    (function() {
+        const handle = document.getElementById('resize-handle');
+        const wrapper = document.getElementById('explorer-wrapper');
+        if (!handle || !wrapper) return;
+        let startX, startY, startW, startH;
+        handle.addEventListener('mousedown', function(e) {
+            e.preventDefault();
+            startX = e.clientX; startY = e.clientY;
+            startW = wrapper.offsetWidth; startH = wrapper.offsetHeight;
+            function onMove(e) {
+                wrapper.style.width = Math.max(400, startW + e.clientX - startX) + 'px';
+                wrapper.style.height = Math.max(300, startH + e.clientY - startY) + 'px';
+            }
+            function onUp() {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+            }
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        });
+    })();
+    </script>
 
     <!-- ─── Usage Guide ─────────────────────────────────────────────── -->
     <div class="usage-guide">


### PR DESCRIPTION
## Summary

- **Overlay positioning**: Replaced manual transform math with `getBoundingClientRect()` on actual SVG elements — automatically handles zoom/pan/viewBox scaling
- **Zoom/pan tracking**: `MutationObserver` on `<g class="zoomable">` repositions overlays on zoom/pan
- **Position-based spatial neighbors**: Nearest neighbor computed from actual node positions (Euclidean distance), not just from constraints — works in all 4 directions regardless of CND spec
- **Multi-mode navigation** via toolbar or keyboard `1`/`2`/`3`:
  - **Spatial** — closest neighbor in each cardinal direction
  - **Must-only** — queries `getMust(nodeId, direction)` for all must-neighbors, navigates to closest by position
  - **Relations** — follow named data relations (left, right, val) mapped to arrow keys
- **Focus fix**: `onDNNodeFocused()` called directly after `el.focus()` instead of relying on focus events
- **Layout fix**: Explorer panel (context + REPLs) renders below graph via flexbox, no overlapping
- **Demo improvements**: resizable diagram container with drag handle, collapsible usage guide + code snippet, smaller REPL output boxes

## Test plan

- [ ] `npm run build:all` succeeds
- [ ] `npm run serve` → open accessible-demo.html → BST renders with all 7 nodes
- [ ] Drag bottom-right handle to resize diagram container
- [ ] Arrow keys navigate spatially in all 4 directions
- [ ] Press `2` → must-only mode: arrows navigate to closest must-neighbor (skips can relationships)
- [ ] Press `3` → relation mode: arrows follow named relations (left/right/val)
- [ ] Press `1` → back to spatial mode
- [ ] Spatial/datum REPL queries work, results clickable
- [ ] Context panel updates on node focus with modality badges
- [ ] "How to Use" and code snippet sections are collapsed by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)