### PR TITLE
Skip edge crossing optimization on dense graphs

### DIFF
--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -127,6 +127,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    * Configuration constants for edge crossing optimization
    */
   private static readonly MAX_CROSSING_OPTIMIZATION_PASSES = 3;
+  private static readonly CROSSING_OPTIMIZATION_EDGE_THRESHOLD = 15;
   private static readonly CROSSING_NUDGE_DISTANCE = 12;
   private static readonly PORT_MARGIN_FRACTION = 0.15;
 
@@ -5497,6 +5498,19 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   private optimizeCrossings(): void {
     // Need at least 2 non-alignment edges to have a crossing
     if (this.computedRoutes.size < 2) return;
+
+    // Skip O(E²) crossing optimization on dense graphs — the base routing
+    // (port angle sorting + blocking-node avoidance) is good enough.
+    let candidateEdges = 0;
+    if (this.currentLayout?.links) {
+      for (const edge of this.currentLayout.links as EdgeWithMetadata[]) {
+        if (this.isAlignmentEdge(edge)) continue;
+        if (edge.source.id === edge.target.id) continue;
+        if (!this.computedRoutes.get(edge.id)) continue;
+        candidateEdges++;
+      }
+    }
+    if (candidateEdges > WebColaCnDGraph.CROSSING_OPTIMIZATION_EDGE_THRESHOLD) return;
 
     for (let pass = 0; pass < WebColaCnDGraph.MAX_CROSSING_OPTIMIZATION_PASSES; pass++) {
       const crossings = this.detectEdgeCrossings();


### PR DESCRIPTION
## Summary
- The O(E² × S²) `optimizeCrossings()` pass (added in v2.2.4) is skipped when a graph has more than 15 candidate edges
- The rest of the routing pipeline (port angle sorting, perpendicular routing, blocking-node avoidance) still runs, producing good multi-point routes
- Threshold is configurable via `CROSSING_OPTIMIZATION_EDGE_THRESHOLD`

## Test plan
- [ ] `npm run build:all` passes
- [ ] Visual check: small graphs (< 15 edges) still get crossing optimization
- [ ] Visual check: dense graphs (> 15 edges) render faster without degraded route quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)