### PR TITLE
Own the missing-name policy in SGraphQueryEvaluator

### DIFF
--- a/src/evaluators/data/sgq-evaluator.ts
+++ b/src/evaluators/data/sgq-evaluator.ts
@@ -1,6 +1,12 @@
 import IEvaluator, {EvaluatorResult} from "../interfaces";
 import {SimpleGraphQueryEvaluator, EvaluationResult, ErrorResult} from "simple-graph-query";
 
+// Matched structurally rather than by `instanceof NameNotFoundError` so this
+// file is version-agnostic across simple-graph-query releases — prior versions
+// swallowed NameNotFoundError internally (the branch never fires); newer
+// versions surface it in ErrorResult.error (the branch handles it).
+const NAME_NOT_FOUND_ERROR_NAME = "NameNotFoundError";
+
 import {EvaluationContext, EvaluatorConfig, IEvaluatorResult } from "../interfaces";
 import { IDataInstance } from "../../data-instance/interfaces";
 import {SingleValue, Tuple} from "../interfaces";
@@ -270,11 +276,27 @@ export class SGraphQueryEvaluator implements IEvaluator {
       return cachedResult;
     }
 
-    const result = this.eval.evaluateExpression(expression);
+    const rawResult = this.eval.evaluateExpression(expression);
 
+    // Policy boundary: simple-graph-query surfaces NameNotFoundError when an
+    // expression references a name the data instance doesn't contain.
+    // spytial-core decides what that means for all downstream consumers —
+    // which is "treat missing names as empty results" (e.g. a tree node
+    // without `right` children should produce no constraints, not an error).
+    // Parse errors and other real failures still propagate through as
+    // ErrorResult.
+    let policyResult: EvaluationResult = rawResult;
+    if (isErrorResult(rawResult) && rawResult.error.name === NAME_NOT_FOUND_ERROR_NAME) {
+      if (config?.warnOnMissingName) {
+        console.warn(
+          `[SGraphQueryEvaluator] missing name in "${expression}": ${rawResult.error.message}`
+        );
+      }
+      policyResult = [];
+    }
 
     // Now we need to wrap the result in our IEvaluatorResult interface
-    const wrappedResult = new SGQEvaluatorResult(result, expression);
+    const wrappedResult = new SGQEvaluatorResult(policyResult, expression);
     
     // Implement LRU eviction: if cache is at max size, remove oldest entry
     if (this.evaluatorCache.size >= this.MAX_CACHE_SIZE) {

--- a/src/evaluators/interfaces.ts
+++ b/src/evaluators/interfaces.ts
@@ -57,6 +57,13 @@ export interface EvaluatorConfig {
   maxResults?: number;
   /** Instance index to evaluate against (for multi-instance contexts) */
   instanceIndex?: number;
+  /**
+   * When true, log a warning if the expression references a name that the
+   * underlying evaluator cannot resolve. The policy is still to return an
+   * empty result (so consumers like a binary-tree node with no `right`
+   * children don't break), but the warning helps authors catch typos.
+   */
+  warnOnMissingName?: boolean;
 }
 
 /**

--- a/tests/sgq-missing-name-policy.test.ts
+++ b/tests/sgq-missing-name-policy.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+
+// A minimal instance resembling the binary-tree motivating case:
+// one relation `left` with a single tuple, and no `right` relation at all.
+// A selector referencing `right` must not throw, must not produce an error
+// result, and must yield zero tuples (so downstream constraint generation
+// silently does nothing).
+const binaryTreeOnlyLeft: IJsonDataInstance = {
+  atoms: [
+    { id: 'root', type: 'Node', label: 'root' },
+    { id: 'leftChild', type: 'Node', label: 'leftChild' },
+  ],
+  relations: [
+    {
+      id: 'left',
+      name: 'left',
+      types: ['Node', 'Node'],
+      tuples: [{ atoms: ['root', 'leftChild'], types: ['Node', 'Node'] }],
+    },
+  ],
+};
+
+function makeEvaluator(instance: JSONDataInstance): SGraphQueryEvaluator {
+  const evaluator = new SGraphQueryEvaluator();
+  evaluator.initialize({ sourceData: instance });
+  return evaluator;
+}
+
+// Simulate the post-upgrade behavior of simple-graph-query: surface
+// NameNotFoundError in ErrorResult.error rather than silently returning [].
+// We intercept the underlying evaluator so the policy boundary is exercised
+// regardless of which simple-graph-query version happens to be installed.
+function stubRawEvaluatorToThrowNameNotFound(
+  evaluator: SGraphQueryEvaluator,
+  missingExpression: string,
+): void {
+  const rawEvaluator = (evaluator as unknown as { eval: { evaluateExpression: (expr: string) => unknown } }).eval;
+  const original = rawEvaluator.evaluateExpression.bind(rawEvaluator);
+  rawEvaluator.evaluateExpression = (expression: string) => {
+    if (expression === missingExpression) {
+      const err = new Error(`bad name ${expression} referenced!`);
+      err.name = 'NameNotFoundError';
+      return { error: err };
+    }
+    return original(expression);
+  };
+}
+
+describe('SGraphQueryEvaluator missing-name policy', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns a non-error empty result when the expression references a name the data does not contain', () => {
+    const instance = new JSONDataInstance(binaryTreeOnlyLeft);
+    const evaluator = makeEvaluator(instance);
+    stubRawEvaluatorToThrowNameNotFound(evaluator, 'right');
+
+    const result = evaluator.evaluate('right');
+
+    expect(result.isError()).toBe(false);
+    expect(result.noResult()).toBe(true);
+    expect(result.selectedTwoples()).toEqual([]);
+  });
+
+  it('does not log by default', () => {
+    const instance = new JSONDataInstance(binaryTreeOnlyLeft);
+    const evaluator = makeEvaluator(instance);
+    stubRawEvaluatorToThrowNameNotFound(evaluator, 'right');
+
+    evaluator.evaluate('right');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning when warnOnMissingName is set on the evaluator config', () => {
+    const instance = new JSONDataInstance(binaryTreeOnlyLeft);
+    const evaluator = makeEvaluator(instance);
+    stubRawEvaluatorToThrowNameNotFound(evaluator, 'right');
+
+    evaluator.evaluate('right', { warnOnMissingName: true });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warnMsg = warnSpy.mock.calls[0][0] as string;
+    expect(warnMsg).toContain('right');
+    expect(warnMsg).toContain('SGraphQueryEvaluator');
+  });
+
+  it('still surfaces non-NameNotFound errors (e.g. parse errors) as error results', () => {
+    const instance = new JSONDataInstance(binaryTreeOnlyLeft);
+    const evaluator = makeEvaluator(instance);
+
+    // Inject a generic error (simulating what a parse error would look like
+    // once simple-graph-query preserves the original typed error).
+    const rawEvaluator = (evaluator as unknown as { eval: { evaluateExpression: (expr: string) => unknown } }).eval;
+    rawEvaluator.evaluateExpression = () => ({
+      error: Object.assign(new Error('Parse error at 1:0: mismatched input'), {
+        name: 'ParseError',
+      }),
+    });
+
+    const result = evaluator.evaluate('{ x : Node |');
+
+    expect(result.isError()).toBe(true);
+  });
+
+  it('passes real-data evaluations through unchanged (relation that does exist)', () => {
+    const instance = new JSONDataInstance(binaryTreeOnlyLeft);
+    const evaluator = makeEvaluator(instance);
+
+    const result = evaluator.evaluate('left');
+
+    expect(result.isError()).toBe(false);
+    expect(result.noResult()).toBe(false);
+    expect(result.selectedTwoples()).toEqual([['root', 'leftChild']]);
+  });
+});
+
+describe('LayoutInstance end-to-end: orientation on a missing selector', () => {
+  it('generates zero constraints and records no selector error when the selector references a name not in the data', () => {
+    const instance = new JSONDataInstance(binaryTreeOnlyLeft);
+    const evaluator = makeEvaluator(instance);
+    stubRawEvaluatorToThrowNameNotFound(evaluator, 'right');
+
+    const layoutSpec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: right
+      directions:
+        - right
+  - orientation:
+      selector: left
+      directions:
+        - left
+`);
+    const layoutInstance = new LayoutInstance(layoutSpec, evaluator, 0, true);
+    const result = layoutInstance.generateLayout(instance);
+
+    // The `right` selector silently yields nothing (binary-tree-with-only-left
+    // case). The `left` selector still produces its constraint. Crucially,
+    // `right` does NOT appear in selectorErrors — it's expected-missing, not
+    // a real error.
+    const rightErrors = result.selectorErrors.filter(e => e.selector === 'right');
+    expect(rightErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Counterpart to [sidprasad/simple-graph-query#51](https://github.com/sidprasad/simple-graph-query/pull/51), which stops swallowing `NameNotFoundError` inside the query engine. Addresses [simple-graph-query#47](https://github.com/sidprasad/simple-graph-query/issues/47).

This PR makes `SGraphQueryEvaluator` the single place that decides what to do when a selector references a name the data instance doesn't contain — **silently treat it as an empty result**. The motivating case is a spytial-py binary tree where a specific node has only `left` children; evaluating `right` must produce no constraints, not an error.

## Changes

- **Policy moves up one layer**. In `sgq-evaluator.ts`, catch the surfaced `NameNotFoundError` at the `evaluateExpression` call site and substitute `[]`. Downstream `LayoutInstance` sees a non-error `IEvaluatorResult` with `noResult() === true` and silently generates zero constraints — the existing end-to-end behavior, preserved.
- **Opt-in diagnostic**. New `warnOnMissingName?: boolean` on `EvaluatorConfig`. Default off (noiseless for production). When set, logs one `console.warn` line per missing-name evaluation — useful for catching typos in layout specs during development.
- **Version-agnostic**. The policy matches structurally via `error.name === "NameNotFoundError"` rather than `instanceof`, because simple-graph-query v2.6.0 doesn't re-export the class at runtime. With the currently installed v2.6.0 the branch is dead code (the engine still swallows internally); once v2.7.0 ships with the companion PR, the policy activates without further spytial-core changes.
- Parse errors and other real failures still flow through as `ErrorResult`, so `LayoutInstance`'s selector-error reporting is unchanged for genuine failures.

## Why here, not in simple-graph-query

Different contexts may want different policies (a REPL showing typos vs. a layout pass silently ignoring missing fields vs. a synthesis run treating missing as a signal). Keeping the engine pure and letting spytial-core be the shared policy boundary means all three consumers (spytial-py, copeanddrag, future consumers) inherit one consistent choice.

## Test plan
- [x] `npx vitest run tests/sgq-missing-name-policy.test.ts` — 6 tests pass (5 unit + 1 LayoutInstance end-to-end binary-tree regression)
- [x] `npx vitest run` — full suite 1421 pass / 5 skipped (skip count unchanged)
- [x] `npx tsc --noEmit` — no new errors introduced by this PR (pre-existing webcola errors unrelated)
- [ ] After [simple-graph-query#51](https://github.com/sidprasad/simple-graph-query/pull/51) merges and ships, bump the `simple-graph-query` dep here and re-run the suite to confirm the policy activates with real data (currently the policy test path is exercised via a stub since v2.6.0 swallows `NameNotFoundError` internally)

## Release ordering

1. Merge & publish [simple-graph-query#51](https://github.com/sidprasad/simple-graph-query/pull/51)
2. Bump the `simple-graph-query` dep in this repo, merge this PR, publish spytial-core
3. copeanddrag and spytial-py bump spytial-core on their own cadence. No source changes required there — copeanddrag's defensive try/catch around `selectedTwoples()` stays as defense-in-depth per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)