### PR TITLE
Auto-size node boxes; fixed-font label rendering (#431)

### DIFF
--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -29,6 +29,16 @@ import type { IEvaluatorResult } from '../evaluators/interfaces';
 import { ColorPicker } from './colorpicker';
 import { type ConstraintError, type ErrorMessages, ConstraintValidator, orientationConstraintToString } from './constraint-validator';
 import { QualitativeConstraintValidator } from './qualitative-constraint-validator';
+import { estimateLabelBox } from './text-extent';
+
+/** The strings the renderer will draw inside a node's box. Used to size the box. */
+type NodeDisplayContent = {
+    label: string;
+    /** One per attribute key, formatted "key: v1, v2, ..." to match the renderer. */
+    attributeLines: string[];
+    /** One per Skolem-label key, formatted as "v1, v2, ..." (key not shown by renderer). */
+    skolemLines: string[];
+};
 const UNIVERSAL_TYPE = "univ";
 
 type ConstraintSource = RelativeOrientationConstraint | CyclicOrientationConstraint | AlignConstraint | ImplicitConstraint;
@@ -1113,7 +1123,12 @@ export class LayoutInstance {
         // Recompute visual maps after graph mutations (inferred edges / node removal)
         let nodeIconMap = this.getNodeIconMap(g);
         let nodeColorMap = this.getNodeColorMap(g, ai);
-        let nodeSizeMap = this.getNodeSizeMap(g);
+
+        // Compute the display strings once — single source of truth for "what's
+        // drawn inside the box" so the box sizer (getNodeSizeMap) and the
+        // LayoutNode mapping below see the same content.
+        let contentByNode = this.getNodeDisplayContent(g, ai, attributes);
+        let nodeSizeMap = this.getNodeSizeMap(g, contentByNode);
 
         let dcN = this.getDisconnectedNodes(g);
 
@@ -1128,13 +1143,13 @@ export class LayoutInstance {
             let nodeMetadata = g.node(nodeId);
             // If the node has a label, we can use it.
             // Otherwise, we can use the nodeId as the label.
-            let label = nodeMetadata?.label || nodeId; 
+            let label = nodeMetadata?.label || nodeId;
             let color = nodeColorMap[nodeId] || "black";
             let iconDetails = nodeIconMap[nodeId];
             let iconPath = iconDetails.path;
             let showLabels = iconDetails.showLabels;
 
-            let { height, width } = nodeSizeMap[nodeId] || { height: this.DEFAULT_NODE_HEIGHT, width: this.DEFAULT_NODE_WIDTH };
+            let { height, width } = nodeSizeMap[nodeId];
 
             const mostSpecificType = this.getMostSpecificType(nodeId, a);
             const allTypes = this.getNodeTypes(nodeId, a);
@@ -2409,11 +2424,57 @@ export class LayoutInstance {
 
 
 
-    private getNodeSizeMap(g: Graph): Record<string, { width: number; height: number }> {
-        let nodeSizeMap: Record<string, { width: number; height: number }> = {};
-        const DEFAULT_SIZE = { width: this.DEFAULT_NODE_WIDTH, height: this.DEFAULT_NODE_HEIGHT };
+    /**
+     * Compute, for every node in `g`, the strings that the renderer will draw
+     * inside its box: main label, attribute lines, and Skolem-label lines.
+     * These are the inputs to `estimateLabelBox` so the auto-sized default
+     * matches what the user will actually see.
+     *
+     * Line formatting mirrors `webcola-cnd-graph.ts`:
+     *   - main label = `g.node(nodeId).label || nodeId`
+     *   - each attribute key produces one line: `"key: v1, v2, ..."`
+     *   - each Skolem-label key produces one line: `"v1, v2, ..."` (key omitted)
+     */
+    private getNodeDisplayContent(
+        g: Graph,
+        ai: IDataInstance,
+        attributes: Record<string, Record<string, string[]>>
+    ): Record<string, NodeDisplayContent> {
+        const result: Record<string, NodeDisplayContent> = {};
+        const atoms = ai.getAtoms();
 
-        // Apply size directives first
+        for (const nodeId of g.nodes()) {
+            const nodeMetadata = g.node(nodeId);
+            const label = nodeMetadata?.label || nodeId;
+
+            const nodeAttrs = attributes[nodeId] || {};
+            const attributeLines = Object.entries(nodeAttrs)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([key, values]) => `${key}: ${values.join(', ')}`);
+
+            const atom = atoms.find((x) => x.id === nodeId);
+            const skolemLines: string[] = [];
+            if (atom?.labels) {
+                for (const values of Object.values(atom.labels)) {
+                    skolemLines.push(Array.isArray(values) ? values.join(', ') : String(values));
+                }
+            }
+
+            result[nodeId] = { label, attributeLines, skolemLines };
+        }
+        return result;
+    }
+
+    private getNodeSizeMap(
+        g: Graph,
+        contentByNode: Record<string, NodeDisplayContent>
+    ): Record<string, { width: number; height: number }> {
+        let nodeSizeMap: Record<string, { width: number; height: number }> = {};
+
+        // Apply size directives first. These come from `size` constraints in
+        // the layout spec and must produce exactly the requested dimensions
+        // (matching `sat_size` in the Lean mechanization: ∀ a ∈ S, b.width = w
+        // ∧ b.height = h).
         let sizeDirectives = this._layoutSpec.directives.sizes;
         sizeDirectives.forEach((sizeDirective) => {
             let selectedNodes: string[];
@@ -2446,13 +2507,18 @@ export class LayoutInstance {
             });
         });
 
-        // Set default sizes for nodes that do not have a size set
-        let graphNodes = [...g.nodes()];
-        graphNodes.forEach((nodeId) => {
-            if (!nodeSizeMap[nodeId]) {
-                nodeSizeMap[nodeId] = DEFAULT_SIZE;
-            }
-        });
+        // Auto-size nodes that no `size` directive matched. The estimator
+        // floor is DEFAULT_NODE_WIDTH × DEFAULT_NODE_HEIGHT (100 × 60), so
+        // short-label nodes keep their historical footprint and only
+        // long-label nodes grow.
+        const floor = { w: this.DEFAULT_NODE_WIDTH, h: this.DEFAULT_NODE_HEIGHT };
+        for (const nodeId of g.nodes()) {
+            if (nodeSizeMap[nodeId]) continue;
+            const c = contentByNode[nodeId];
+            const main = c?.label ?? '';
+            const secondary = c ? [...c.attributeLines, ...c.skolemLines] : [];
+            nodeSizeMap[nodeId] = estimateLabelBox(main, secondary, { min: floor });
+        }
 
         return nodeSizeMap;
     }

--- a/src/layout/text-extent.ts
+++ b/src/layout/text-extent.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure, browser-free utilities for sizing node boxes to fit their rendered
+ * text at the project's fixed font sizes.
+ *
+ * Architecture: layout owns box sizing, the renderer owns drawing. Both
+ * import the font-size constants below so the box and the rendered text
+ * agree on dimensions without a runtime negotiation.
+ *
+ *   - LayoutInstance.getNodeSizeMap calls `estimateLabelBox` to size each
+ *     unconstrained node so its label and any secondary lines fit at
+ *     {MAIN_LABEL_FONT_SIZE, SECONDARY_FONT_SIZE} with visual breathing
+ *     room.
+ *   - webcola-cnd-graph renders at those exact font sizes — no per-node
+ *     resizing, no wrapping. If the user pins a too-small `size` directive,
+ *     text overflows the rect (their explicit choice; sat_size still holds).
+ *
+ * Stays canvas/document-free so this module is node-runnable for tests.
+ * The estimator's per-glyph width table is calibrated to slightly
+ * over-estimate canvas-measured widths, so the heuristic is a safe upper
+ * bound on what the renderer will actually draw.
+ */
+
+/** Main node label, rendered bold. */
+export const MAIN_LABEL_FONT_SIZE = 14;
+/** Secondary lines (attribute key:value, Skolem labels), rendered smaller. */
+export const SECONDARY_FONT_SIZE = 11;
+/** Line height as a multiple of font size — used by both estimator and renderer. */
+export const LABEL_LINE_HEIGHT_RATIO = 1.35;
+
+export interface EstimateLabelBoxOptions {
+    /** Average glyph-width / font-size ratio for sans-serif text. */
+    avgGlyphRatio?: number;
+    /** Total horizontal padding (split evenly left/right). */
+    paddingX?: number;
+    /** Total vertical padding (split evenly top/bottom). */
+    paddingY?: number;
+    /** Floor — boxes never shrink below this. */
+    min?: { w: number; h: number };
+    /** Ceiling — caps how much one giant label can dominate the layout. */
+    max?: { w: number; h: number };
+}
+
+const DEFAULT_OPTIONS: Required<EstimateLabelBoxOptions> = {
+    // Slightly above measured canvas-width to cushion heuristic-vs-canvas drift.
+    avgGlyphRatio: 0.65,
+    // Padding gives the rendered text visible breathing room from the rect stroke,
+    // which sits at the box edge with only the renderer's TEXT_PADDING (8px) of slack.
+    paddingX: 32,
+    paddingY: 26,
+    min: { w: 100, h: 60 },
+    max: { w: 280, h: 140 },
+};
+
+/** Per-glyph width multiplier (relative to the average). */
+function glyphWidthUnits(code: number): number {
+    // Narrow: i, l, I, j, t, f, r, ., ,, :, ;, ', ", `, |, !, (, ), [, ], {, }
+    if (
+        code === 0x69 || code === 0x6c || code === 0x49 || code === 0x6a ||
+        code === 0x74 || code === 0x66 || code === 0x72 ||
+        code === 0x2e || code === 0x2c || code === 0x3a || code === 0x3b ||
+        code === 0x27 || code === 0x22 || code === 0x60 || code === 0x7c ||
+        code === 0x21 || code === 0x28 || code === 0x29 ||
+        code === 0x5b || code === 0x5d || code === 0x7b || code === 0x7d
+    ) {
+        return 0.5;
+    }
+    // Extra-wide: W, M, m, w, @
+    if (code === 0x57 || code === 0x4d || code === 0x6d || code === 0x77 || code === 0x40) {
+        return 1.4;
+    }
+    // Capitals (A-Z) excluding W/M.
+    if (code >= 0x41 && code <= 0x5a) {
+        return 1.1;
+    }
+    return 1.0;
+}
+
+/** Approximate the rendered width of a single line at the given font size. */
+export function estimateTextWidth(text: string, fontSize: number, avgGlyphRatio: number): number {
+    if (!text) return 0;
+    let units = 0;
+    for (let i = 0; i < text.length; i++) {
+        units += glyphWidthUnits(text.charCodeAt(i));
+    }
+    return units * fontSize * avgGlyphRatio;
+}
+
+/**
+ * Pick a node-box size that fits the main label (at MAIN_LABEL_FONT_SIZE)
+ * plus any secondary lines (at SECONDARY_FONT_SIZE), with padding.
+ *
+ * Width = max line width across both font tiers, plus paddingX. Height =
+ * one main-label line + N secondary lines (each scaled by line-height
+ * ratio), plus paddingY. Result is clamped to [min, max], with `min`
+ * acting as a floor (the historical 100×60 default) so short-label nodes
+ * keep their familiar footprint.
+ */
+export function estimateLabelBox(
+    mainLabel: string,
+    secondaryLines: string[] = [],
+    options: EstimateLabelBoxOptions = {}
+): { width: number; height: number } {
+    const opts: Required<EstimateLabelBoxOptions> = { ...DEFAULT_OPTIONS, ...options };
+
+    const cleanedSecondary = secondaryLines.filter((s) => s && s.length > 0);
+
+    const mainWidth = estimateTextWidth(mainLabel || '', MAIN_LABEL_FONT_SIZE, opts.avgGlyphRatio);
+    let maxSecondaryWidth = 0;
+    for (const line of cleanedSecondary) {
+        const w = estimateTextWidth(line, SECONDARY_FONT_SIZE, opts.avgGlyphRatio);
+        if (w > maxSecondaryWidth) maxSecondaryWidth = w;
+    }
+
+    const maxLineWidth = Math.max(mainWidth, maxSecondaryWidth);
+    const rawWidth = maxLineWidth + opts.paddingX;
+
+    const mainLineHeight = MAIN_LABEL_FONT_SIZE * LABEL_LINE_HEIGHT_RATIO;
+    const secondaryLineHeight = SECONDARY_FONT_SIZE * LABEL_LINE_HEIGHT_RATIO;
+    const rawHeight = mainLineHeight + cleanedSecondary.length * secondaryLineHeight + opts.paddingY;
+
+    return {
+        width: Math.round(clamp(rawWidth, opts.min.w, opts.max.w)),
+        height: Math.round(clamp(rawHeight, opts.min.h, opts.max.h)),
+    };
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -3,6 +3,7 @@ import { EdgeWithMetadata, NodeWithMetadata, WebColaLayout, WebColaTranslator, N
 import { InstanceLayout, isAlignmentConstraint, isInstanceLayout, isLeftConstraint, isTopConstraint, LayoutNode } from '../../layout/interfaces';
 import type { GridRouter, Group, Layout, Node, Link } from 'webcola';
 import { IInputDataInstance, ITuple, IAtom } from '../../data-instance/interfaces';
+import { MAIN_LABEL_FONT_SIZE, SECONDARY_FONT_SIZE, LABEL_LINE_HEIGHT_RATIO } from '../../layout/text-extent';
 
 let d3 = window.d3v4 || window.d3; // Use d3 v4 if available, otherwise fallback to the default window.d3
 let cola = window.cola;
@@ -132,13 +133,16 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   }
 
   /**
-   * Configuration constants for text sizing and layout
+   * Text-sizing constants. Node-label sizes (main + secondary) live in
+   * `src/layout/text-extent.ts` so the layout estimator and the renderer
+   * agree by construction. The constants below are for non-node text:
+   * group labels (DEFAULT/MIN/MAX_FONT_SIZE) and the renderer's inset for
+   * text inside node rects (TEXT_PADDING).
    */
   private static readonly DEFAULT_FONT_SIZE = 10;
   private static readonly MIN_FONT_SIZE = 6;
   private static readonly MAX_FONT_SIZE = 16;
-  private static readonly TEXT_PADDING = 8; // Padding inside node for text
-  private static readonly LINE_HEIGHT_RATIO = 1.2;
+  private static readonly TEXT_PADDING = 8;
 
   /**
    * Configuration constants for screenshot export
@@ -3135,28 +3139,8 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     return Array.from(nodeIndices);
   }
 
-  private getNodeMainLabelFontSize(node: any): number {
-    const cachedSize = node?._mainLabelFontSize;
-    if (typeof cachedSize === 'number' && Number.isFinite(cachedSize)) {
-      return cachedSize;
-    }
-
-    const nodeWidth = node?.visualWidth ?? node?.width ?? 100;
-    const nodeHeight = node?.visualHeight ?? node?.height ?? 60;
-    const maxTextWidth = Math.max(1, nodeWidth - WebColaCnDGraph.TEXT_PADDING * 2);
-    const maxTextHeight = Math.max(1, nodeHeight - WebColaCnDGraph.TEXT_PADDING * 2);
-
-    const displayLabel = node?.label || node?.name || node?.id || "Node";
-    const hasLabels = Object.keys(node?.labels || {}).length > 0;
-    const hasAttributes = Object.keys(node?.attributes || {}).length > 0;
-    const hasExtraContent = hasLabels || hasAttributes;
-    const mainLabelMaxHeight = hasExtraContent ? maxTextHeight * 0.5 : maxTextHeight;
-
-    return this.calculateOptimalFontSize(
-      displayLabel,
-      maxTextWidth,
-      Math.max(1, mainLabelMaxHeight)
-    );
+  private getNodeMainLabelFontSize(_node: any): number {
+    return MAIN_LABEL_FONT_SIZE;
   }
 
   private calculateGroupLabelFontSize(group: any, allGroups: any[]): number {
@@ -3421,85 +3405,19 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     return context.measureText(text).width;
   }
 
-  /**
-   * Calculates the optimal font size to fit text within given dimensions
-   */
-  private calculateOptimalFontSize(
-    text: string,
-    maxWidth: number,
-    maxHeight: number,
-    fontFamily?: string
-  ): number {
-    fontFamily = fontFamily ?? this.getFontFamily();
-    let fontSize = WebColaCnDGraph.DEFAULT_FONT_SIZE;
-    
-    // Start with default size and scale down if needed
-    while (fontSize > WebColaCnDGraph.MIN_FONT_SIZE) {
-      const textWidth = this.measureTextWidth(text, fontSize, fontFamily);
-      const lineHeight = fontSize * WebColaCnDGraph.LINE_HEIGHT_RATIO;
-      
-      if (textWidth <= maxWidth && lineHeight <= maxHeight) {
-        break;
-      }
-      
-      fontSize -= 0.5;
-    }
-    
-    // Scale up if there's room
-    while (fontSize < WebColaCnDGraph.MAX_FONT_SIZE) {
-      const testSize = fontSize + 0.5;
-      const textWidth = this.measureTextWidth(text, testSize, fontFamily);
-      const lineHeight = testSize * WebColaCnDGraph.LINE_HEIGHT_RATIO;
-      
-      if (textWidth > maxWidth || lineHeight > maxHeight) {
-        break;
-      }
-      
-      fontSize = testSize;
-    }
-    
-    return Math.max(WebColaCnDGraph.MIN_FONT_SIZE, Math.min(fontSize, WebColaCnDGraph.MAX_FONT_SIZE));
-  }
-
-  /**
-   * Wraps text to fit within given width, returning array of lines
-   */
-  private wrapText(text: string, maxWidth: number, fontSize: number, fontFamily?: string): string[] {
-    fontFamily = fontFamily ?? this.getFontFamily();
-    const words = text.split(/\s+/);
-    const lines: string[] = [];
-    let currentLine = '';
-    
-    for (const word of words) {
-      const testLine = currentLine ? `${currentLine} ${word}` : word;
-      const lineWidth = this.measureTextWidth(testLine, fontSize, fontFamily);
-      
-      if (lineWidth <= maxWidth) {
-        currentLine = testLine;
-      } else {
-        if (currentLine) {
-          lines.push(currentLine);
-          currentLine = word;
-        } else {
-          // Word is too long for the line, we'll have to break it
-          lines.push(word);
-        }
-      }
-    }
-    
-    if (currentLine) {
-      lines.push(currentLine);
-    }
-    
-    return lines;
-  }
-
 
 
   /**
-   * Creates main node labels with attributes using dynamic sizing and expansion
+   * Creates main node labels with attributes using fixed font sizes.
+   *
+   * Box dimensions are decided upstream by `LayoutInstance.getNodeSizeMap`
+   * via `estimateLabelBox`, which sizes each box to fit the same fixed font
+   * sizes used here. No per-node font negotiation; if a user pins a too-small
+   * `size` directive their text overflows (their explicit choice).
    */
-  private setupNodeLabelsWithDynamicSizing(nodeSelection: d3.Selection<SVGGElement, any, any, unknown>): void {
+  private setupNodeLabels(nodeSelection: d3.Selection<SVGGElement, any, any, unknown>): void {
+    const secondaryLineHeight = SECONDARY_FONT_SIZE * LABEL_LINE_HEIGHT_RATIO;
+
     nodeSelection
       .append("text")
       .attr("class", "label")
@@ -3512,136 +3430,62 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
           return;
         }
 
-        const shouldShowLabels = d.showLabels;
-        if (!shouldShowLabels) {
+        if (!d.showLabels) {
           return;
         }
 
         const textElement = d3.select(nodes[i]);
-        const nodeWidth = d.width || 100;
-        const nodeHeight = d.height || 60;
-        const maxTextWidth = nodeWidth - WebColaCnDGraph.TEXT_PADDING * 2;
-        const maxTextHeight = nodeHeight - WebColaCnDGraph.TEXT_PADDING * 2;
-        
+
         const displayLabel = d.label || d.name || d.id || "Node";
-        const attributes = d.attributes || {};
-        const attributeEntries = Object.entries(attributes).sort(([a], [b]) => a.localeCompare(b));
-        
-        // Get labels (e.g., Skolems) which are displayed in node color
-        const nodeLabels = d.labels || {};
-        const labelEntries = Object.entries(nodeLabels);
-        const hasLabels = labelEntries.length > 0;
-        
-        // Allocate space: prioritize main label, then labels (Skolems), then attributes
-        const hasAttributes = attributeEntries.length > 0;
-        const hasExtraContent = hasLabels || hasAttributes;
-        const mainLabelMaxHeight = hasExtraContent ? maxTextHeight * 0.5 : maxTextHeight;
-        
-        // Calculate font size based on available space
-        // Use the actual display label to ensure text fits within node bounds
-        const mainLabelFontSize = this.calculateOptimalFontSize(
-          displayLabel,
-          maxTextWidth,
-          mainLabelMaxHeight
-        );
-        d._mainLabelFontSize = mainLabelFontSize;
-        
-        textElement.attr("font-size", `${mainLabelFontSize}px`);
-        
-        // Add main name label on a single line
-        // When there's extra content, shift the label up to make room
-        const lineHeight = mainLabelFontSize * WebColaCnDGraph.LINE_HEIGHT_RATIO;
+        const attributeEntries = Object.entries(d.attributes || {})
+          .sort(([a], [b]) => a.localeCompare(b));
+        const labelEntries = Object.entries(d.labels || {});
         const totalSecondaryEntries = labelEntries.length + attributeEntries.length;
-        const verticalOffset = hasExtraContent ? -totalSecondaryEntries * lineHeight * 0.5 : 0;
-        
-        // Store the vertical offset on the data for use in updatePositions
+
+        // Center the entire label block on the node: shift the main label up
+        // by half the secondary block's height so the visual centroid sits at d.y.
+        const verticalOffset = totalSecondaryEntries > 0
+          ? -totalSecondaryEntries * secondaryLineHeight * 0.5
+          : 0;
+
+        // Cached for updatePositions, which re-applies dy to each tspan after layout.
         d._labelVerticalOffset = verticalOffset;
-        d._labelLineHeight = lineHeight;
-        
+        d._labelLineHeight = secondaryLineHeight;
+
+        textElement.attr("font-size", `${MAIN_LABEL_FONT_SIZE}px`);
+
         textElement
           .append("tspan")
           .attr("x", 0)
           .attr("dy", `${verticalOffset}px`)
           .attr("class", "main-label-tspan")
           .style("font-weight", "bold")
-          .style("font-size", `${mainLabelFontSize}px`)
+          .style("font-size", `${MAIN_LABEL_FONT_SIZE}px`)
           .text(displayLabel);
 
-        // Calculate font size for secondary content (labels and attributes)
-        // Find the longest secondary text to ensure all content fits
-        let longestSecondaryText = "";
-        for (const [key, values] of labelEntries) {
+        // Skolem-style labels: italic, comma-separated values per key.
+        for (const [, values] of labelEntries) {
           const labelText = Array.isArray(values) ? values.join(', ') : String(values);
-          if (labelText.length > longestSecondaryText.length) {
-            longestSecondaryText = labelText;
-          }
+          textElement
+            .append("tspan")
+            .attr("x", 0)
+            .attr("dy", `${secondaryLineHeight}px`)
+            .style("font-size", `${SECONDARY_FONT_SIZE}px`)
+            .style("fill", 'black')
+            .style("font-style", "italic")
+            .text(labelText);
         }
+
+        // Attribute lines: "key: value, value, ..."
         for (const [key, value] of attributeEntries) {
-          const attributeText = `${key}: ${value}`;
-          if (attributeText.length > longestSecondaryText.length) {
-            longestSecondaryText = attributeText;
-          }
-        }
-        
-        // Use a minimum ratio of the main label size to ensure readability
-        const minSecondaryFontSize = mainLabelFontSize * 0.65; // At least 65% of main label
-        const remainingHeight = maxTextHeight - lineHeight;
-        const calculatedSecondaryFontSize = totalSecondaryEntries > 0
-          ? this.calculateOptimalFontSize(
-              longestSecondaryText || "SampleText",
-              maxTextWidth,
-              remainingHeight / totalSecondaryEntries
-            )
-          : mainLabelFontSize * 0.8;
-        // Ensure secondary font size is at least the minimum for readability
-        const secondaryFontSize = Math.max(calculatedSecondaryFontSize, minSecondaryFontSize);
-
-        // Handle labels first (e.g., Skolems) - styled in node's color
-        if (hasLabels) {
-          // const nodeColor = d.color || 'black';
-          const nodeColor = 'black';
-          
-          for (const [key, values] of labelEntries) {
-            // For labels like Skolems, display as comma-separated list
-            const labelText = Array.isArray(values) ? values.join(', ') : String(values);
-            
-            textElement
-              .append("tspan")
-              .attr("x", 0)
-              .attr("dy", `${secondaryFontSize * WebColaCnDGraph.LINE_HEIGHT_RATIO}px`)
-              .style("font-size", `${secondaryFontSize}px`)
-              .style("fill", nodeColor)  // Style in node's color
-              .style("font-style", "italic")  // Italicize to distinguish from attributes
-              .text(labelText);
-          }
-        }
-
-        // Handle attributes (show all that fit)
-        if (hasAttributes) {
-          for (let i = 0; i < attributeEntries.length; i++) {
-            const [key, value] = attributeEntries[i];
-            const attributeText = `${key}: ${value}`;
-            
-            textElement
-              .append("tspan")
-              .attr("x", 0)
-              .attr("dy", `${secondaryFontSize * WebColaCnDGraph.LINE_HEIGHT_RATIO}px`)
-              .style("font-size", `${secondaryFontSize}px`)
-              .text(attributeText);
-          }
+          textElement
+            .append("tspan")
+            .attr("x", 0)
+            .attr("dy", `${secondaryLineHeight}px`)
+            .style("font-size", `${SECONDARY_FONT_SIZE}px`)
+            .text(`${key}: ${value}`);
         }
       });
-  }
-
-  /**
-   * Creates main node labels with attributes using tspan elements.
-   * Handles conditional label display and multi-line attribute rendering.
-   * 
-   * @param nodeSelection - D3 selection of node groups
-   */
-  private setupNodeLabels(nodeSelection: d3.Selection<SVGGElement, any, any, unknown>): void {
-    // Use the new dynamic sizing implementation
-    this.setupNodeLabelsWithDynamicSizing(nodeSelection);
   }
 
   /**

--- a/tests/layout-instance.test.ts
+++ b/tests/layout-instance.test.ts
@@ -560,4 +560,59 @@ directives:
     // The label should include the middle node's label: "route[Bravo]"
     expect(inferredEdge!.label).toBe('route[Bravo]');
   });
+
+  describe('content-aware default node size (issue #431)', () => {
+    const FLOOR_W = 100;
+    const FLOOR_H = 60;
+
+    function makeData(labels: string[]): IJsonDataInstance {
+      return {
+        atoms: labels.map((label, i) => ({ id: `n${i}`, type: 'T', label })),
+        relations: [],
+      };
+    }
+
+    it('keeps short-label nodes at the floor (no shrinking)', () => {
+      const instance = new JSONDataInstance(makeData(['x']));
+      const evaluator = createEvaluator(instance);
+      const spec = parseLayoutSpec(`constraints: []\ndirectives: []`);
+      const li = new LayoutInstance(spec, evaluator, 0, true);
+      const { layout } = li.generateLayout(instance);
+
+      const node = layout.nodes.find(n => n.id === 'n0')!;
+      expect(node.width).toBe(FLOOR_W);
+      expect(node.height).toBe(FLOOR_H);
+    });
+
+    it('grows long-label nodes past the floor up to the cap', () => {
+      const instance = new JSONDataInstance(makeData(['OverviewMetricsDashboard']));
+      const evaluator = createEvaluator(instance);
+      const spec = parseLayoutSpec(`constraints: []\ndirectives: []`);
+      const li = new LayoutInstance(spec, evaluator, 0, true);
+      const { layout } = li.generateLayout(instance);
+
+      const node = layout.nodes.find(n => n.id === 'n0')!;
+      expect(node.width).toBeGreaterThan(FLOOR_W);
+      expect(node.width).toBeLessThanOrEqual(280); // ceiling
+    });
+
+    it('still honors explicit size directives exactly (sat_size preserved)', () => {
+      const instance = new JSONDataInstance(makeData(['OverviewMetricsDashboard']));
+      const evaluator = createEvaluator(instance);
+      const spec = parseLayoutSpec(`
+constraints: []
+directives:
+  - size:
+      selector: T
+      width: 80
+      height: 50
+`);
+      const li = new LayoutInstance(spec, evaluator, 0, true);
+      const { layout } = li.generateLayout(instance);
+
+      const node = layout.nodes.find(n => n.id === 'n0')!;
+      expect(node.width).toBe(80);
+      expect(node.height).toBe(50);
+    });
+  });
 });

--- a/tests/text-extent.test.ts
+++ b/tests/text-extent.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+    estimateLabelBox,
+    estimateTextWidth,
+    MAIN_LABEL_FONT_SIZE,
+    SECONDARY_FONT_SIZE,
+    LABEL_LINE_HEIGHT_RATIO,
+} from '../src/layout/text-extent';
+
+describe('font size constants', () => {
+    it('exposes a main label font size larger than the secondary size', () => {
+        expect(MAIN_LABEL_FONT_SIZE).toBeGreaterThan(SECONDARY_FONT_SIZE);
+    });
+
+    it('exposes a sane line-height ratio', () => {
+        expect(LABEL_LINE_HEIGHT_RATIO).toBeGreaterThan(1);
+        expect(LABEL_LINE_HEIGHT_RATIO).toBeLessThan(2);
+    });
+});
+
+describe('estimateTextWidth', () => {
+    it('returns 0 for empty string', () => {
+        expect(estimateTextWidth('', MAIN_LABEL_FONT_SIZE, 0.65)).toBe(0);
+    });
+
+    it('grows roughly linearly with character count', () => {
+        const w5 = estimateTextWidth('aaaaa', MAIN_LABEL_FONT_SIZE, 0.65);
+        const w10 = estimateTextWidth('aaaaaaaaaa', MAIN_LABEL_FONT_SIZE, 0.65);
+        expect(w10).toBeCloseTo(w5 * 2, 5);
+    });
+
+    it('treats wide capitals as wider than lowercase', () => {
+        const lower = estimateTextWidth('xxxxxxxxxx', MAIN_LABEL_FONT_SIZE, 0.65);
+        const upper = estimateTextWidth('AAAAAAAAAA', MAIN_LABEL_FONT_SIZE, 0.65);
+        expect(upper).toBeGreaterThan(lower);
+    });
+
+    it('treats narrow chars as narrower than average', () => {
+        const narrow = estimateTextWidth('iiiiiiiiii', MAIN_LABEL_FONT_SIZE, 0.65);
+        const avg = estimateTextWidth('xxxxxxxxxx', MAIN_LABEL_FONT_SIZE, 0.65);
+        expect(narrow).toBeLessThan(avg);
+    });
+});
+
+describe('estimateLabelBox', () => {
+    const FLOOR = { w: 100, h: 60 };
+    const CEIL = { w: 280, h: 140 };
+
+    it('returns the floor for empty input', () => {
+        const box = estimateLabelBox('');
+        expect(box.width).toBe(FLOOR.w);
+        expect(box.height).toBe(FLOOR.h);
+    });
+
+    it('keeps short single-character labels at the floor (no shrinking)', () => {
+        const box = estimateLabelBox('x');
+        expect(box.width).toBe(FLOOR.w);
+        expect(box.height).toBe(FLOOR.h);
+    });
+
+    it('grows width past the floor for long main labels', () => {
+        const box = estimateLabelBox('OverviewMetricsDashboard');
+        expect(box.width).toBeGreaterThan(FLOOR.w);
+        expect(box.width).toBeLessThanOrEqual(CEIL.w);
+    });
+
+    it('clamps width to the ceiling for absurdly long labels', () => {
+        const box = estimateLabelBox('x'.repeat(500));
+        expect(box.width).toBe(CEIL.w);
+    });
+
+    it('measures secondary lines at the smaller secondary font size', () => {
+        // A secondary line of the same character count should produce a
+        // smaller width contribution than the main label, since secondary
+        // text is rendered at SECONDARY_FONT_SIZE.
+        const longText = 'OverviewMetricsDashboard';
+        const mainOnly = estimateLabelBox(longText);
+        const secondaryOnly = estimateLabelBox('x', [longText]);
+        expect(secondaryOnly.width).toBeLessThan(mainOnly.width);
+    });
+
+    it('grows height with each secondary line', () => {
+        const single = estimateLabelBox('label');
+        const withTwo = estimateLabelBox('label', ['attr1: value', 'attr2: value']);
+        expect(withTwo.height).toBeGreaterThan(single.height);
+        expect(withTwo.height).toBeLessThanOrEqual(CEIL.h);
+    });
+
+    it('clamps height to the ceiling for many secondary lines', () => {
+        const lines = Array.from({ length: 50 }, (_, i) => `attr${i}: v`);
+        const box = estimateLabelBox('main', lines);
+        expect(box.height).toBe(CEIL.h);
+    });
+
+    it('ignores empty secondary lines', () => {
+        const a = estimateLabelBox('main', ['', '', '']);
+        const b = estimateLabelBox('main');
+        expect(a).toEqual(b);
+    });
+
+    it('honors a custom floor (used by layoutinstance to set 100×60)', () => {
+        const box = estimateLabelBox('x', [], { min: { w: 150, h: 80 } });
+        expect(box.width).toBe(150);
+        expect(box.height).toBe(80);
+    });
+
+    it('produces integer width and height', () => {
+        const box = estimateLabelBox('SomeLabel', ['kind: example']);
+        expect(Number.isInteger(box.width)).toBe(true);
+        expect(Number.isInteger(box.height)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `src/layout/text-extent.ts`: a pure (canvas-free) `estimateLabelBox` that picks node-box dimensions from the label/attribute/Skolem text, with a 100×60 floor (no shrinking) and a 280×140 ceiling.
- Wires the estimator into `LayoutInstance.getNodeSizeMap` for any node not pinned by a `size` directive. Explicit `size` directives still produce exactly the requested width/height (matching `sat_size` in the Lean mechanization).
- Removes the renderer's dynamic font sizing. `webcola-cnd-graph` now draws main labels at a fixed 14px and secondary lines (attributes, Skolem labels) at 11px — no per-node `calculateOptimalFontSize`, no `wrapText`. The estimator and renderer share the font-size constants exported from `text-extent.ts` so the box and the rendered text agree by construction.
- If a user pins a `size` directive smaller than their content, text overflows the rect (their explicit choice; `sat_size` is honored).

Net: long labels like `OverviewMetricsDashboard` no longer get squeezed to ~6px; short labels keep their historical footprint; the renderer is ~150 lines lighter (deleted `calculateOptimalFontSize`, `wrapText`, per-node font math).

Closes #431.

## Test plan
- [x] `npm run test:run` — 1434 passed, 5 skipped (pre-existing).
- [x] `npm run build:all` — type-clean.
- [x] New unit tests in `tests/text-extent.test.ts` (clamps, padding, multi-line height, main vs secondary contributions).
- [x] New integration cases in `tests/layout-instance.test.ts` (short label at floor, long label grows under cap, explicit size directive preserved).
- [x] Browser smoke: rendered a graph with mixed-length labels — all main labels at uniform 14px; `x` and `Hi` stayed at 100×60; `OverviewMetricsDashboard` grew to 232×60; `ConfigurationManagementService` grew to 278×60 (just under the cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)