### PR TITLE
Lock satisfied constraint endpoints in sequence stability mode

### DIFF
--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -277,6 +277,13 @@ export class WebColaLayout {
    */
   private priorPositionMap: Map<string, NodePositionHint>;
 
+  /**
+   * Map of node id to its index in `colaNodes`. Built once after `colaNodes`
+   * is constructed. Backs `getNodeIndex()` so constraint translation and
+   * the post-pass run in O(c) instead of O(c × n).
+   */
+  private nodeIndexMap: Map<string, number> = new Map();
+
   /** When true, lock unconstrained nodes with prior positions via fixed=1. */
   private lockUnconstrainedNodes: boolean;
 
@@ -328,6 +335,12 @@ export class WebColaLayout {
 
 
     this.colaNodes = instanceLayout.nodes.map(node => this.toColaNode(node));
+    // Build node-id -> index map. Used by getNodeIndex() to keep
+    // constraint translation and the constraint-aware locking post-pass
+    // O(c) instead of O(c × n).
+    for (let i = 0; i < this.colaNodes.length; i++) {
+      this.nodeIndexMap.set(this.colaNodes[i].id, i);
+    }
     this.colaEdges = instanceLayout.edges.map(edge => this.toColaEdge(edge));
 
     // Collapse symmetric edges with the same label
@@ -508,8 +521,9 @@ export class WebColaLayout {
     return nonRedundant;
   }
 
-  private getNodeIndex(nodeId: string) {
-    return this.colaNodes.findIndex(node => node.id === nodeId);
+  private getNodeIndex(nodeId: string): number {
+    const idx = this.nodeIndexMap.get(nodeId);
+    return idx === undefined ? -1 : idx;
   }
 
   /**
@@ -803,140 +817,132 @@ export class WebColaLayout {
   private static readonly CONSTRAINT_SATISFACTION_TOLERANCE = 0.5;
 
   /**
-   * Decide, for a single LayoutConstraint, whether its endpoints' prior
-   * positions already satisfy the constraint.
+   * Per-constraint lock decision, computed once in a single switch:
    *
-   *   'satisfied' — both endpoints have prior positions and they satisfy
-   *                 the constraint (within tolerance). Endpoints can stay
-   *                 locked at fixed=1.
-   *   'violated'  — both endpoints have prior positions but they do NOT
-   *                 satisfy the constraint. Both must be unfixed so the
-   *                 solver can move them.
-   *   'unknown'   — at least one endpoint lacks a prior position (newly
-   *                 added node). Lock the seeded endpoint, free the new one.
+   *   - `endpoints`: the node objects involved in this constraint, or
+   *     `null` for constraint types we don't translate (bounding-box,
+   *     group-boundary, noop). Callers skip null.
+   *   - `verdict`:
+   *       'satisfied' — both endpoints have prior positions and they
+   *                     satisfy the constraint (within tolerance). Both
+   *                     can stay locked at fixed=1.
+   *       'violated'  — both endpoints have prior positions but they do
+   *                     NOT satisfy the constraint. Both must be unfixed
+   *                     so the solver can repair.
+   *       'unknown'   — at least one endpoint lacks a prior position
+   *                     (newly added). Lock the seeded one, free the new
+   *                     one.
+   *
+   * Folds the previous `endpointsOf` + `evaluateConstraintAtPriorPositions`
+   * helpers into a single switch so each constraint pays one dispatch and
+   * one pair of node lookups (O(1) each via nodeIndexMap).
    */
-  private evaluateConstraintAtPriorPositions(
+  private classifyConstraintForLocking(
     constraint: LayoutConstraint
-  ): 'satisfied' | 'violated' | 'unknown' {
+  ): {
+    endpoints: [NodeWithMetadata, NodeWithMetadata];
+    verdict: 'satisfied' | 'violated' | 'unknown';
+  } | null {
     const tol = WebColaLayout.CONSTRAINT_SATISFACTION_TOLERANCE;
+    const priors = this.priorPositionMap;
+
+    let n1: NodeWithMetadata;
+    let n2: NodeWithMetadata;
+    let bothSeeded: boolean;
 
     if (isLeftConstraint(constraint)) {
-      const node1 = this.colaNodes[this.getNodeIndex(constraint.left.id)];
-      const node2 = this.colaNodes[this.getNodeIndex(constraint.right.id)];
-      const has1 = this.priorPositionMap.has(node1.id);
-      const has2 = this.priorPositionMap.has(node2.id);
-      if (!has1 || !has2) return 'unknown';
-      const required = this.computeHorizontalSeparation(node1, node2, constraint.minDistance);
-      // Left of: node2.x - node1.x >= required
-      const actual = (node2.x ?? 0) - (node1.x ?? 0);
-      return actual + tol >= required ? 'satisfied' : 'violated';
+      n1 = this.colaNodes[this.getNodeIndex(constraint.left.id)];
+      n2 = this.colaNodes[this.getNodeIndex(constraint.right.id)];
+      bothSeeded = priors.has(n1.id) && priors.has(n2.id);
+      if (!bothSeeded) return { endpoints: [n1, n2], verdict: 'unknown' };
+      const required = this.computeHorizontalSeparation(n1, n2, constraint.minDistance);
+      const actual = (n2.x ?? 0) - (n1.x ?? 0);
+      return {
+        endpoints: [n1, n2],
+        verdict: actual + tol >= required ? 'satisfied' : 'violated',
+      };
     }
 
     if (isTopConstraint(constraint)) {
-      const node1 = this.colaNodes[this.getNodeIndex(constraint.top.id)];
-      const node2 = this.colaNodes[this.getNodeIndex(constraint.bottom.id)];
-      const has1 = this.priorPositionMap.has(node1.id);
-      const has2 = this.priorPositionMap.has(node2.id);
-      if (!has1 || !has2) return 'unknown';
-      const required = this.computeVerticalSeparation(node1, node2, constraint.minDistance);
-      // Top of: node2.y - node1.y >= required
-      const actual = (node2.y ?? 0) - (node1.y ?? 0);
-      return actual + tol >= required ? 'satisfied' : 'violated';
+      n1 = this.colaNodes[this.getNodeIndex(constraint.top.id)];
+      n2 = this.colaNodes[this.getNodeIndex(constraint.bottom.id)];
+      bothSeeded = priors.has(n1.id) && priors.has(n2.id);
+      if (!bothSeeded) return { endpoints: [n1, n2], verdict: 'unknown' };
+      const required = this.computeVerticalSeparation(n1, n2, constraint.minDistance);
+      const actual = (n2.y ?? 0) - (n1.y ?? 0);
+      return {
+        endpoints: [n1, n2],
+        verdict: actual + tol >= required ? 'satisfied' : 'violated',
+      };
     }
 
     if (isAlignmentConstraint(constraint)) {
-      const node1 = this.colaNodes[this.getNodeIndex(constraint.node1.id)];
-      const node2 = this.colaNodes[this.getNodeIndex(constraint.node2.id)];
-      const has1 = this.priorPositionMap.has(node1.id);
-      const has2 = this.priorPositionMap.has(node2.id);
-      if (!has1 || !has2) return 'unknown';
-      // Alignment is equality on the given axis.
-      const a = constraint.axis === 'x' ? (node1.x ?? 0) : (node1.y ?? 0);
-      const b = constraint.axis === 'x' ? (node2.x ?? 0) : (node2.y ?? 0);
-      return Math.abs(a - b) <= tol ? 'satisfied' : 'violated';
+      n1 = this.colaNodes[this.getNodeIndex(constraint.node1.id)];
+      n2 = this.colaNodes[this.getNodeIndex(constraint.node2.id)];
+      bothSeeded = priors.has(n1.id) && priors.has(n2.id);
+      if (!bothSeeded) return { endpoints: [n1, n2], verdict: 'unknown' };
+      const a = constraint.axis === 'x' ? (n1.x ?? 0) : (n1.y ?? 0);
+      const b = constraint.axis === 'x' ? (n2.x ?? 0) : (n2.y ?? 0);
+      return {
+        endpoints: [n1, n2],
+        verdict: Math.abs(a - b) <= tol ? 'satisfied' : 'violated',
+      };
     }
 
-    // BoundingBox / GroupBoundary / unknown: don't presume satisfaction.
-    return 'unknown';
+    // BoundingBox / GroupBoundary / unrecognized: not translated to
+    // WebCola, so they have no endpoints to lock.
+    return null;
   }
 
   /**
-   * Post-pass over all constraints that decides which endpoints stay
-   * locked (fixed=1, set by toColaNode for nodes with prior positions)
-   * and which get unfixed so the solver can move them.
+   * Post-pass over all LayoutConstraints that decides which endpoints
+   * stay locked (fixed=1 from toColaNode) and which get unfixed.
    *
-   * Only runs when lockUnconstrainedNodes is true — i.e., when a sequence
-   * policy has asked for stability behavior. In other modes we keep the
-   * historical behavior: every node involved in a constraint is unfixed
-   * so the solver runs unconstrained on those endpoints.
+   * - lockUnconstrainedNodes=true (stability mode): per-constraint
+   *   verdict drives the decision — satisfied keeps both locked,
+   *   violated unfixes both, unknown unfixes only unseeded endpoints.
+   * - lockUnconstrainedNodes=false: legacy behavior — any node touched
+   *   by a constraint is unfixed. Short-circuited when no node was ever
+   *   locked (priorPositionMap empty), since there's nothing to unfix.
+   *
+   * Cost: O(c) — one classification per constraint, each doing two
+   * O(1) node-index lookups via nodeIndexMap.
    */
   private applyConstraintAwareLocking(constraints: LayoutConstraint[]): void {
-    if (!this.lockUnconstrainedNodes) {
-      // Legacy behavior: any node touched by a constraint gets unfixed.
-      for (const constraint of constraints) {
-        for (const node of this.endpointsOf(constraint)) {
-          if (node) node.fixed = 0;
-        }
-      }
-      return;
-    }
+    const stability = this.lockUnconstrainedNodes;
+
+    // Legacy mode + no nodes were locked → no-op.
+    if (!stability && this.priorPositionMap.size === 0) return;
 
     for (const constraint of constraints) {
-      const verdict = this.evaluateConstraintAtPriorPositions(constraint);
-      const endpoints = this.endpointsOf(constraint);
-      if (endpoints.length === 0) continue;
+      const classified = this.classifyConstraintForLocking(constraint);
+      if (!classified) continue;
+      const [n1, n2] = classified.endpoints;
 
-      if (verdict === 'satisfied') {
-        // Both endpoints have prior positions that already satisfy this
-        // constraint — leave them locked at those positions.
+      if (!stability) {
+        // Legacy: any constrained endpoint is freed.
+        n1.fixed = 0;
+        n2.fixed = 0;
         continue;
       }
 
-      if (verdict === 'violated') {
-        // Both endpoints have prior positions but they do NOT satisfy
-        // this constraint. Free both so the solver can repair.
-        for (const node of endpoints) {
-          if (node) node.fixed = 0;
-        }
-        continue;
+      switch (classified.verdict) {
+        case 'satisfied':
+          // Prior positions honor the constraint — keep both locked.
+          break;
+        case 'violated':
+          // Prior positions don't honor the constraint — free both so
+          // the solver can repair.
+          n1.fixed = 0;
+          n2.fixed = 0;
+          break;
+        case 'unknown':
+          // One side is a new node — free only the unseeded endpoint(s).
+          if (!this.priorPositionMap.has(n1.id)) n1.fixed = 0;
+          if (!this.priorPositionMap.has(n2.id)) n2.fixed = 0;
+          break;
       }
-
-      // verdict === 'unknown': at least one endpoint lacks a prior
-      // position. Free only the unseeded endpoint(s); keep the seeded
-      // ones locked so the new node moves into place around them.
-      for (const node of endpoints) {
-        if (node && !this.priorPositionMap.has(node.id)) {
-          node.fixed = 0;
-        }
-      }
     }
-  }
-
-  /**
-   * Returns the NodeWithMetadata endpoints involved in a LayoutConstraint,
-   * or [] for constraint types we don't translate to WebCola (bounding-box,
-   * group-boundary, noops).
-   */
-  private endpointsOf(constraint: LayoutConstraint): NodeWithMetadata[] {
-    if (isLeftConstraint(constraint)) {
-      return [
-        this.colaNodes[this.getNodeIndex(constraint.left.id)],
-        this.colaNodes[this.getNodeIndex(constraint.right.id)],
-      ];
-    }
-    if (isTopConstraint(constraint)) {
-      return [
-        this.colaNodes[this.getNodeIndex(constraint.top.id)],
-        this.colaNodes[this.getNodeIndex(constraint.bottom.id)],
-      ];
-    }
-    if (isAlignmentConstraint(constraint)) {
-      return [
-        this.colaNodes[this.getNodeIndex(constraint.node1.id)],
-        this.colaNodes[this.getNodeIndex(constraint.node2.id)],
-      ];
-    }
-    return [];
   }
 
   /**

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -197,18 +197,24 @@ export interface WebColaLayoutOptions {
   transitionMode?: WebColaRenderTransitionMode;
 
   /**
-   * When true, nodes with prior positions that are NOT involved in any
-   * constraint get fixed=1 (locked at their prior position).
+   * When true (stability mode), nodes with prior positions are locked
+   * at those positions (fixed=1) wherever it does not violate a
+   * constraint:
    *
-   * Webcola's gradient descent inflates the Hessian diagonal for locked
-   * nodes, creating a strong spring toward the prior position.
-   * `toColaConstraint()` sets fixed=0 on every node involved in a
-   * constraint so that alignment-edge spring forces and gradient descent
-   * can freely position them.
+   *   - Unconstrained nodes with prior positions stay locked.
+   *   - Constrained nodes whose prior positions already SATISFY the
+   *     constraint stay locked. WebCola treats fixed=1 as a strong
+   *     soft anchor (default weight 1000 in the VPSC projector and a
+   *     max-Hessian spring in gradient descent), so the solver will
+   *     still keep the constraint satisfied if anything else moves.
+   *   - Constrained nodes whose prior positions VIOLATE the constraint
+   *     are unfixed so the solver can move them freely.
+   *   - New nodes (no prior position) are unfixed and seeded via DAGRE
+   *     or the figure center.
    *
-   * Seeding prior positions on all nodes (including constrained ones)
-   * still helps: it gives gradient descent a good starting neighborhood,
-   * reducing drift even for unlocked nodes.
+   * When false (default / morph mode), every node involved in any
+   * constraint is unfixed — the legacy behavior that lets gradient
+   * descent and alignment-edge spring forces freely re-place them.
    */
   lockUnconstrainedNodes?: boolean;
 }
@@ -334,6 +340,13 @@ export class WebColaLayout {
     this.conflictingConstraints = instanceLayout.conflictingConstraints || [];
     this.overlappingNodesData = instanceLayout.overlappingNodes || [];
     this.colaConstraints = instanceLayout.constraints.map(constraint => this.toColaConstraint(constraint));
+
+    // Decide which constraint endpoints stay locked (fixed=1) and which
+    // get unfixed. In stability mode (lockUnconstrainedNodes=true) we
+    // only unfix endpoints whose prior positions would violate the
+    // constraint. Outside stability mode this preserves the historical
+    // behavior of unfixing every constrained node.
+    this.applyConstraintAwareLocking(instanceLayout.constraints);
 
     // Apply transitive reduction optimization if we have many constraints
     // Threshold: optimize when we have more than 100 constraints
@@ -589,11 +602,12 @@ export class WebColaLayout {
    * 3. Default center position (DEFAULT_X, DEFAULT_Y)
    * 
    * When `lockUnconstrainedNodes` is true (stability mode), nodes with
-   * prior positions are initially locked (fixed=1).  `toColaConstraint()`
-   * later sets fixed=0 on any node involved in a constraint, so only
-   * truly unconstrained nodes stay locked.  Seeding the prior position
-   * on constrained nodes still helps by giving gradient descent a good
-   * starting neighborhood.
+   * prior positions are initially locked (fixed=1). After all
+   * constraints are translated, `applyConstraintAwareLocking()` runs
+   * a post-pass that unfixes endpoints whose prior positions violate a
+   * constraint (so the solver can repair) and unfixes new (unseeded)
+   * endpoints in mixed-prior constraints. Endpoints whose prior
+   * positions already satisfy their constraints stay locked.
    * 
    * @param node - The LayoutNode to convert
    * @returns NodeWithMetadata for WebCola
@@ -736,59 +750,33 @@ export class WebColaLayout {
 
   private toColaConstraint(constraint: LayoutConstraint): ColaConstraint {
 
-    // Switch on the type of constraint.
-    // Nodes involved in constraints get fixed=0 so that gradient descent
-    // (and alignment-edge spring forces) can freely position them.
-    // Unconstrained nodes keep fixed=1 from toColaNode() so they stay
-    // anchored at their prior positions.
+    // Pure translation: do NOT mutate node.fixed here. The post-pass in
+    // applyConstraintAwareLocking() decides whether to unfix endpoints
+    // based on whether their prior positions already satisfy the constraint.
+
     if (isLeftConstraint(constraint)) {
-
-      // Get the two nodes that are being constrained
-      let node1 = this.colaNodes[this.getNodeIndex(constraint.left.id)];
-      let node2 = this.colaNodes[this.getNodeIndex(constraint.right.id)];
-      // Free constrained nodes so alignment edges and gradient descent work
-      node1.fixed = 0;
-      node2.fixed = 0;
-
-      // Use improved horizontal separation calculation based on actual node dimensions
-      let distance = this.computeHorizontalSeparation(node1, node2, constraint.minDistance);
-
+      const node1 = this.colaNodes[this.getNodeIndex(constraint.left.id)];
+      const node2 = this.colaNodes[this.getNodeIndex(constraint.right.id)];
+      const distance = this.computeHorizontalSeparation(node1, node2, constraint.minDistance);
       return this.leftConstraint(this.getNodeIndex(constraint.left.id), this.getNodeIndex(constraint.right.id), distance);
     }
 
     if (isTopConstraint(constraint)) {
-
-      // Get the two nodes that are being constrained
-      let node1 = this.colaNodes[this.getNodeIndex(constraint.top.id)];
-      let node2 = this.colaNodes[this.getNodeIndex(constraint.bottom.id)];
-      // Free constrained nodes so alignment edges and gradient descent work
-      node1.fixed = 0;
-      node2.fixed = 0;
-
-      // Use improved vertical separation calculation based on actual node dimensions
-      let distance = this.computeVerticalSeparation(node1, node2, constraint.minDistance);
-
+      const node1 = this.colaNodes[this.getNodeIndex(constraint.top.id)];
+      const node2 = this.colaNodes[this.getNodeIndex(constraint.bottom.id)];
+      const distance = this.computeVerticalSeparation(node1, node2, constraint.minDistance);
       return this.topConstraint(this.getNodeIndex(constraint.top.id), this.getNodeIndex(constraint.bottom.id), distance);
     }
 
     if (isAlignmentConstraint(constraint)) {
-      const alignmentConstraint = {
+      return {
         type: "separation",
         axis: constraint.axis,
         left: this.getNodeIndex(constraint.node1.id),
         right: this.getNodeIndex(constraint.node2.id),
         gap: 0,
         'equality': true
-      }
-
-      // Free constrained nodes so alignment edges and gradient descent work
-      let node1 = this.colaNodes[this.getNodeIndex(constraint.node1.id)];
-      let node2 = this.colaNodes[this.getNodeIndex(constraint.node2.id)];
-      node1.fixed = 0;
-      node2.fixed = 0;
-
-      return alignmentConstraint;
-
+      };
     }
 
     if(isBoundingBoxConstraint(constraint)) {
@@ -805,6 +793,150 @@ export class WebColaLayout {
     }
 
     throw new Error("Constraint type not recognized");
+  }
+
+  /**
+   * Tolerance (px) used when checking whether two prior positions already
+   * satisfy a separation/alignment constraint. Matches the implicit slack
+   * the WebCola solver uses when deciding constraints are "satisfied".
+   */
+  private static readonly CONSTRAINT_SATISFACTION_TOLERANCE = 0.5;
+
+  /**
+   * Decide, for a single LayoutConstraint, whether its endpoints' prior
+   * positions already satisfy the constraint.
+   *
+   *   'satisfied' — both endpoints have prior positions and they satisfy
+   *                 the constraint (within tolerance). Endpoints can stay
+   *                 locked at fixed=1.
+   *   'violated'  — both endpoints have prior positions but they do NOT
+   *                 satisfy the constraint. Both must be unfixed so the
+   *                 solver can move them.
+   *   'unknown'   — at least one endpoint lacks a prior position (newly
+   *                 added node). Lock the seeded endpoint, free the new one.
+   */
+  private evaluateConstraintAtPriorPositions(
+    constraint: LayoutConstraint
+  ): 'satisfied' | 'violated' | 'unknown' {
+    const tol = WebColaLayout.CONSTRAINT_SATISFACTION_TOLERANCE;
+
+    if (isLeftConstraint(constraint)) {
+      const node1 = this.colaNodes[this.getNodeIndex(constraint.left.id)];
+      const node2 = this.colaNodes[this.getNodeIndex(constraint.right.id)];
+      const has1 = this.priorPositionMap.has(node1.id);
+      const has2 = this.priorPositionMap.has(node2.id);
+      if (!has1 || !has2) return 'unknown';
+      const required = this.computeHorizontalSeparation(node1, node2, constraint.minDistance);
+      // Left of: node2.x - node1.x >= required
+      const actual = (node2.x ?? 0) - (node1.x ?? 0);
+      return actual + tol >= required ? 'satisfied' : 'violated';
+    }
+
+    if (isTopConstraint(constraint)) {
+      const node1 = this.colaNodes[this.getNodeIndex(constraint.top.id)];
+      const node2 = this.colaNodes[this.getNodeIndex(constraint.bottom.id)];
+      const has1 = this.priorPositionMap.has(node1.id);
+      const has2 = this.priorPositionMap.has(node2.id);
+      if (!has1 || !has2) return 'unknown';
+      const required = this.computeVerticalSeparation(node1, node2, constraint.minDistance);
+      // Top of: node2.y - node1.y >= required
+      const actual = (node2.y ?? 0) - (node1.y ?? 0);
+      return actual + tol >= required ? 'satisfied' : 'violated';
+    }
+
+    if (isAlignmentConstraint(constraint)) {
+      const node1 = this.colaNodes[this.getNodeIndex(constraint.node1.id)];
+      const node2 = this.colaNodes[this.getNodeIndex(constraint.node2.id)];
+      const has1 = this.priorPositionMap.has(node1.id);
+      const has2 = this.priorPositionMap.has(node2.id);
+      if (!has1 || !has2) return 'unknown';
+      // Alignment is equality on the given axis.
+      const a = constraint.axis === 'x' ? (node1.x ?? 0) : (node1.y ?? 0);
+      const b = constraint.axis === 'x' ? (node2.x ?? 0) : (node2.y ?? 0);
+      return Math.abs(a - b) <= tol ? 'satisfied' : 'violated';
+    }
+
+    // BoundingBox / GroupBoundary / unknown: don't presume satisfaction.
+    return 'unknown';
+  }
+
+  /**
+   * Post-pass over all constraints that decides which endpoints stay
+   * locked (fixed=1, set by toColaNode for nodes with prior positions)
+   * and which get unfixed so the solver can move them.
+   *
+   * Only runs when lockUnconstrainedNodes is true — i.e., when a sequence
+   * policy has asked for stability behavior. In other modes we keep the
+   * historical behavior: every node involved in a constraint is unfixed
+   * so the solver runs unconstrained on those endpoints.
+   */
+  private applyConstraintAwareLocking(constraints: LayoutConstraint[]): void {
+    if (!this.lockUnconstrainedNodes) {
+      // Legacy behavior: any node touched by a constraint gets unfixed.
+      for (const constraint of constraints) {
+        for (const node of this.endpointsOf(constraint)) {
+          if (node) node.fixed = 0;
+        }
+      }
+      return;
+    }
+
+    for (const constraint of constraints) {
+      const verdict = this.evaluateConstraintAtPriorPositions(constraint);
+      const endpoints = this.endpointsOf(constraint);
+      if (endpoints.length === 0) continue;
+
+      if (verdict === 'satisfied') {
+        // Both endpoints have prior positions that already satisfy this
+        // constraint — leave them locked at those positions.
+        continue;
+      }
+
+      if (verdict === 'violated') {
+        // Both endpoints have prior positions but they do NOT satisfy
+        // this constraint. Free both so the solver can repair.
+        for (const node of endpoints) {
+          if (node) node.fixed = 0;
+        }
+        continue;
+      }
+
+      // verdict === 'unknown': at least one endpoint lacks a prior
+      // position. Free only the unseeded endpoint(s); keep the seeded
+      // ones locked so the new node moves into place around them.
+      for (const node of endpoints) {
+        if (node && !this.priorPositionMap.has(node.id)) {
+          node.fixed = 0;
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the NodeWithMetadata endpoints involved in a LayoutConstraint,
+   * or [] for constraint types we don't translate to WebCola (bounding-box,
+   * group-boundary, noops).
+   */
+  private endpointsOf(constraint: LayoutConstraint): NodeWithMetadata[] {
+    if (isLeftConstraint(constraint)) {
+      return [
+        this.colaNodes[this.getNodeIndex(constraint.left.id)],
+        this.colaNodes[this.getNodeIndex(constraint.right.id)],
+      ];
+    }
+    if (isTopConstraint(constraint)) {
+      return [
+        this.colaNodes[this.getNodeIndex(constraint.top.id)],
+        this.colaNodes[this.getNodeIndex(constraint.bottom.id)],
+      ];
+    }
+    if (isAlignmentConstraint(constraint)) {
+      return [
+        this.colaNodes[this.getNodeIndex(constraint.node1.id)],
+        this.colaNodes[this.getNodeIndex(constraint.node2.id)],
+      ];
+    }
+    return [];
   }
 
   /**

--- a/tests/temporal-layout-consistency.test.ts
+++ b/tests/temporal-layout-consistency.test.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect } from 'vitest';
+import { Layout as ColaLayout } from 'webcola';
 import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
 import { parseLayoutSpec } from '../src/layout/layoutspec';
 import { LayoutInstance } from '../src/layout/layoutinstance';
 import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
-import { WebColaTranslator, WebColaLayoutOptions, NodePositionHint, LayoutState } from '../src/translators/webcola/webcolatranslator';
+import {
+  isLeftConstraint,
+  isTopConstraint,
+  isAlignmentConstraint,
+  LayoutConstraint,
+} from '../src/layout/interfaces';
+import {
+  WebColaTranslator,
+  WebColaLayout,
+  WebColaLayoutOptions,
+  NodePositionHint,
+  LayoutState,
+  NodeWithMetadata,
+} from '../src/translators/webcola/webcolatranslator';
 
 /**
  * Test for sequence layout rendering consistency.
@@ -499,6 +513,261 @@ describe('Sequence Layout Consistency', () => {
       expect(nodeA.fixed).toBe(0);
       expect(nodeB.fixed).toBe(0);
       expect(nodeC.fixed).toBe(0);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Post-solver constraint satisfaction.
+  //
+  // The earlier `Constraint-aware locking` block verifies that the
+  // *pre-solver* `fixed` flag is set correctly per the satisfied/
+  // violated/unknown verdict. That doesn't actually prove WebCola
+  // produces a layout that satisfies the original LayoutConstraints —
+  // soft anchors (weight=1000) could in principle lose to a near-
+  // infeasible constraint set under reduced iterations.
+  //
+  // These tests run cola.Layout to convergence and assert each original
+  // LayoutConstraint is satisfied at the *final* node positions, with
+  // both lockUnconstrainedNodes=true (stability) and =false (legacy).
+  // ────────────────────────────────────────────────────────────────────
+  describe('Post-solver constraint satisfaction', () => {
+    /** Tolerance for "satisfied" — generous enough to absorb solver slack. */
+    const SAT_TOL = 5;
+
+    /** Same separation math the translator uses (computeHorizontalSeparation). */
+    function requiredHorizontalSep(
+      n1: NodeWithMetadata,
+      n2: NodeWithMetadata,
+      minDistance: number
+    ): number {
+      const w1 = n1.visualWidth ?? n1.width ?? 100;
+      const w2 = n2.visualWidth ?? n2.width ?? 100;
+      const base = w1 / 2 + w2 / 2 + minDistance;
+      const adaptive = Math.min(Math.max(w1, w2) * 0.1, 20);
+      return base + adaptive;
+    }
+
+    /** Same separation math the translator uses (computeVerticalSeparation). */
+    function requiredVerticalSep(
+      n1: NodeWithMetadata,
+      n2: NodeWithMetadata,
+      minDistance: number
+    ): number {
+      const h1 = n1.visualHeight ?? n1.height ?? 60;
+      const h2 = n2.visualHeight ?? n2.height ?? 60;
+      const base = h1 / 2 + h2 / 2 + minDistance;
+      const adaptive = Math.min(Math.max(h1, h2) * 0.1, 15);
+      return base + adaptive;
+    }
+
+    /**
+     * Run cola.Layout on a translated WebColaLayout. Mirrors the
+     * production setup in webcola-cnd-graph.ts (avoidOverlaps,
+     * handleDisconnected, reduced iterations) without needing d3 or DOM.
+     */
+    function runSolver(layout: WebColaLayout): NodeWithMetadata[] {
+      const colaLayout = new ColaLayout()
+        .linkDistance(150)
+        .convergenceThreshold(0.1)
+        .avoidOverlaps(true)
+        .handleDisconnected(true)
+        .nodes(layout.colaNodes as any)
+        .links(layout.colaEdges as any)
+        .constraints(layout.colaConstraints as any[])
+        .size([layout.FIG_WIDTH, layout.FIG_HEIGHT]);
+
+      // Match the reduced-iterations path used in production when
+      // prior positions are present (webcola-cnd-graph.ts:1764-1772).
+      colaLayout.start(0, 10, 20, 1);
+
+      return layout.colaNodes;
+    }
+
+    /**
+     * Walk the original LayoutConstraints and assert each is satisfied
+     * at the (post-solver) positions of the colaNodes.
+     */
+    function assertAllConstraintsSatisfied(
+      constraints: LayoutConstraint[],
+      colaNodes: NodeWithMetadata[],
+      tol: number = SAT_TOL
+    ): void {
+      const byId = new Map(colaNodes.map(n => [n.id, n]));
+
+      for (const c of constraints) {
+        if (isLeftConstraint(c)) {
+          const left = byId.get(c.left.id)!;
+          const right = byId.get(c.right.id)!;
+          const required = requiredHorizontalSep(left, right, c.minDistance);
+          const actual = (right.x ?? 0) - (left.x ?? 0);
+          expect(
+            actual + tol,
+            `LeftConstraint ${c.left.id} → ${c.right.id}: ` +
+              `actual gap ${actual.toFixed(2)} < required ${required.toFixed(2)}`
+          ).toBeGreaterThanOrEqual(required);
+        } else if (isTopConstraint(c)) {
+          const top = byId.get(c.top.id)!;
+          const bottom = byId.get(c.bottom.id)!;
+          const required = requiredVerticalSep(top, bottom, c.minDistance);
+          const actual = (bottom.y ?? 0) - (top.y ?? 0);
+          expect(
+            actual + tol,
+            `TopConstraint ${c.top.id} → ${c.bottom.id}: ` +
+              `actual gap ${actual.toFixed(2)} < required ${required.toFixed(2)}`
+          ).toBeGreaterThanOrEqual(required);
+        } else if (isAlignmentConstraint(c)) {
+          const n1 = byId.get(c.node1.id)!;
+          const n2 = byId.get(c.node2.id)!;
+          const a = c.axis === 'x' ? (n1.x ?? 0) : (n1.y ?? 0);
+          const b = c.axis === 'x' ? (n2.x ?? 0) : (n2.y ?? 0);
+          expect(
+            Math.abs(a - b),
+            `AlignmentConstraint(${c.axis}) ${c.node1.id} ↔ ${c.node2.id}: ` +
+              `delta ${Math.abs(a - b).toFixed(2)} > tolerance ${tol}`
+          ).toBeLessThanOrEqual(tol);
+        }
+        // BoundingBox / GroupBoundary / others: not enforced by the
+        // translator's WebCola path, so nothing to assert here.
+      }
+    }
+
+    const layoutInstance = (instance: JSONDataInstance) => {
+      const evaluator = createEvaluator(instance);
+      return new LayoutInstance(layoutSpec, evaluator, 0, true);
+    };
+
+    it('locked endpoints stay near prior positions AND constraint stays satisfied (satisfied prior)', async () => {
+      // jsonData1 has A→B; layoutSpec puts A left of B. Prior positions
+      // already satisfy the LeftConstraint with comfortable slack.
+      const instance = new JSONDataInstance(jsonData1);
+      const li = layoutInstance(instance);
+      const { layout } = li.generateLayout(instance);
+
+      const priorPositions: LayoutState = {
+        positions: [
+          { id: 'A', x: 200, y: 400 },
+          { id: 'B', x: 600, y: 400 },
+          { id: 'C', x: 400, y: 200 },
+        ],
+        transform: { k: 1, x: 0, y: 0 },
+      };
+
+      const translator = new WebColaTranslator();
+      const webcolaLayout = await translator.translate(layout, 800, 600, {
+        priorPositions,
+        lockUnconstrainedNodes: true,
+      });
+
+      runSolver(webcolaLayout);
+
+      // The constraint must hold at the final positions.
+      assertAllConstraintsSatisfied(layout.constraints, webcolaLayout.colaNodes);
+
+      // And locks should have held: the post-solver positions should
+      // be near the prior ones for nodes whose constraints were satisfied.
+      // Use a generous drift bound (50px) — the lock isn't a hard pin.
+      const finalById = new Map(webcolaLayout.colaNodes.map(n => [n.id, n]));
+      for (const prior of priorPositions.positions) {
+        const finalNode = finalById.get(prior.id)!;
+        const drift = Math.hypot(
+          (finalNode.x ?? 0) - prior.x,
+          (finalNode.y ?? 0) - prior.y
+        );
+        expect(
+          drift,
+          `node ${prior.id} drifted ${drift.toFixed(1)}px from its lock target`
+        ).toBeLessThanOrEqual(50);
+      }
+    });
+
+    it('repairs violated constraint at prior positions (both endpoints unfixed)', async () => {
+      // Same instance, but prior positions VIOLATE the LeftConstraint:
+      // A.x > B.x. Both should be unfixed and the solver should repair.
+      const instance = new JSONDataInstance(jsonData1);
+      const li = layoutInstance(instance);
+      const { layout } = li.generateLayout(instance);
+
+      const priorPositions: LayoutState = {
+        positions: [
+          { id: 'A', x: 600, y: 400 },
+          { id: 'B', x: 200, y: 400 },
+          { id: 'C', x: 400, y: 200 },
+        ],
+        transform: { k: 1, x: 0, y: 0 },
+      };
+
+      const translator = new WebColaTranslator();
+      const webcolaLayout = await translator.translate(layout, 800, 600, {
+        priorPositions,
+        lockUnconstrainedNodes: true,
+      });
+
+      runSolver(webcolaLayout);
+
+      // The constraint must hold at the final positions.
+      assertAllConstraintsSatisfied(layout.constraints, webcolaLayout.colaNodes);
+    });
+
+    it('places a new node so all constraints are satisfied (mixed prior)', async () => {
+      // Start with A,B; new state has A,B,C plus chain A→B→C.
+      // Provide priors only for A and B (C is new). Solver must place C
+      // such that LeftConstraint(B,C) and LeftConstraint(A,B) both hold.
+      const instance1 = new JSONDataInstance(jsonData1);
+      const evaluator1 = createEvaluator(instance1);
+      const layoutInstance1 = new LayoutInstance(layoutSpec, evaluator1, 0, true);
+      const { layout: layout1 } = layoutInstance1.generateLayout(instance1);
+      const translator = new WebColaTranslator();
+      const result1 = await translator.translate(layout1, 800, 600);
+      const aNode = result1.colaNodes.find(n => n.id === 'A')!;
+      const bNode = result1.colaNodes.find(n => n.id === 'B')!;
+
+      const priorPositions: LayoutState = {
+        positions: [
+          { id: 'A', x: aNode.x ?? 200, y: aNode.y ?? 400 },
+          { id: 'B', x: bNode.x ?? 600, y: bNode.y ?? 400 },
+          // C intentionally omitted — it's the "new" node.
+        ],
+        transform: { k: 1, x: 0, y: 0 },
+      };
+
+      const instance2 = new JSONDataInstance(jsonData2);
+      const li2 = layoutInstance(instance2);
+      const { layout: layout2 } = li2.generateLayout(instance2);
+
+      const webcolaLayout = await translator.translate(layout2, 800, 600, {
+        priorPositions,
+        lockUnconstrainedNodes: true,
+      });
+
+      runSolver(webcolaLayout);
+
+      // Every constraint in the new layout must hold post-solve.
+      assertAllConstraintsSatisfied(layout2.constraints, webcolaLayout.colaNodes);
+    });
+
+    it('legacy mode (lockUnconstrainedNodes=false) also satisfies constraints', async () => {
+      // Sanity check that the legacy path didn't regress.
+      const instance = new JSONDataInstance(jsonData1);
+      const li = layoutInstance(instance);
+      const { layout } = li.generateLayout(instance);
+
+      const priorPositions: LayoutState = {
+        positions: [
+          { id: 'A', x: 200, y: 400 },
+          { id: 'B', x: 600, y: 400 },
+          { id: 'C', x: 400, y: 200 },
+        ],
+        transform: { k: 1, x: 0, y: 0 },
+      };
+
+      const translator = new WebColaTranslator();
+      const webcolaLayout = await translator.translate(layout, 800, 600, {
+        priorPositions,
+        // lockUnconstrainedNodes intentionally omitted (false).
+      });
+
+      runSolver(webcolaLayout);
+      assertAllConstraintsSatisfied(layout.constraints, webcolaLayout.colaNodes);
     });
   });
 });

--- a/tests/temporal-layout-consistency.test.ts
+++ b/tests/temporal-layout-consistency.test.ts
@@ -362,4 +362,143 @@ describe('Sequence Layout Consistency', () => {
       expect(nonExistent).toBeUndefined();
     });
   });
+
+  describe('Constraint-aware locking (lockUnconstrainedNodes)', () => {
+    // Layout spec with a "right" orientation constraint: A right-of edges
+    // produce a Left-constraint between source and target. Combined with
+    // jsonData1 (A -> B), this means there is a LeftConstraint(A, B).
+    const layoutInstance = (instance: JSONDataInstance) => {
+      const evaluator = createEvaluator(instance);
+      return new LayoutInstance(layoutSpec, evaluator, 0, true);
+    };
+
+    it('keeps both endpoints locked (fixed=1) when prior positions satisfy the constraint', async () => {
+      const instance = new JSONDataInstance(jsonData1);
+      const li = layoutInstance(instance);
+      const { layout } = li.generateLayout(instance);
+
+      // A at (100, 300), B at (400, 300): A is well to the left of B,
+      // so the LeftConstraint(A, B) is already satisfied by the seeds.
+      const priorPositions: LayoutState = {
+        positions: [
+          { id: 'A', x: 100, y: 300 },
+          { id: 'B', x: 400, y: 300 },
+          { id: 'C', x: 250, y: 500 }
+        ],
+        transform: { k: 1, x: 0, y: 0 }
+      };
+
+      const translator = new WebColaTranslator();
+      const result = await translator.translate(layout, 800, 600, {
+        priorPositions,
+        lockUnconstrainedNodes: true,
+      });
+
+      const nodeA = result.colaNodes.find(n => n.id === 'A')!;
+      const nodeB = result.colaNodes.find(n => n.id === 'B')!;
+      const nodeC = result.colaNodes.find(n => n.id === 'C')!;
+
+      // A and B both have prior positions and the LeftConstraint(A, B)
+      // is satisfied — both should remain locked.
+      expect(nodeA.fixed).toBe(1);
+      expect(nodeB.fixed).toBe(1);
+      // C is unconstrained and has a prior position — also locked.
+      expect(nodeC.fixed).toBe(1);
+    });
+
+    it('unfixes both endpoints when prior positions violate the constraint', async () => {
+      const instance = new JSONDataInstance(jsonData1);
+      const li = layoutInstance(instance);
+      const { layout } = li.generateLayout(instance);
+
+      // A at (400, 300), B at (100, 300): A is to the RIGHT of B,
+      // violating the LeftConstraint(A, B). Both must be unfixed so the
+      // solver can repair.
+      const priorPositions: LayoutState = {
+        positions: [
+          { id: 'A', x: 400, y: 300 },
+          { id: 'B', x: 100, y: 300 },
+          { id: 'C', x: 250, y: 500 }
+        ],
+        transform: { k: 1, x: 0, y: 0 }
+      };
+
+      const translator = new WebColaTranslator();
+      const result = await translator.translate(layout, 800, 600, {
+        priorPositions,
+        lockUnconstrainedNodes: true,
+      });
+
+      const nodeA = result.colaNodes.find(n => n.id === 'A')!;
+      const nodeB = result.colaNodes.find(n => n.id === 'B')!;
+      const nodeC = result.colaNodes.find(n => n.id === 'C')!;
+
+      // Both endpoints of the violated constraint are unfixed.
+      expect(nodeA.fixed).toBe(0);
+      expect(nodeB.fixed).toBe(0);
+      // C is unaffected — still locked at its prior position.
+      expect(nodeC.fixed).toBe(1);
+    });
+
+    it('unfixes only the new endpoint when one side lacks a prior position', async () => {
+      const instance = new JSONDataInstance(jsonData1);
+      const li = layoutInstance(instance);
+      const { layout } = li.generateLayout(instance);
+
+      // Only A has a prior position; B is brand-new in this frame.
+      const priorPositions: LayoutState = {
+        positions: [
+          { id: 'A', x: 100, y: 300 }
+        ],
+        transform: { k: 1, x: 0, y: 0 }
+      };
+
+      const translator = new WebColaTranslator();
+      const result = await translator.translate(layout, 800, 600, {
+        priorPositions,
+        lockUnconstrainedNodes: true,
+      });
+
+      const nodeA = result.colaNodes.find(n => n.id === 'A')!;
+      const nodeB = result.colaNodes.find(n => n.id === 'B')!;
+
+      // A keeps its prior position locked; B (no prior) is unfixed
+      // so the solver can position it relative to A.
+      expect(nodeA.fixed).toBe(1);
+      expect(nodeB.fixed).toBe(0);
+    });
+
+    it('preserves legacy behavior when lockUnconstrainedNodes is false', async () => {
+      const instance = new JSONDataInstance(jsonData1);
+      const li = layoutInstance(instance);
+      const { layout } = li.generateLayout(instance);
+
+      const priorPositions: LayoutState = {
+        positions: [
+          { id: 'A', x: 100, y: 300 },
+          { id: 'B', x: 400, y: 300 },
+          { id: 'C', x: 250, y: 500 }
+        ],
+        transform: { k: 1, x: 0, y: 0 }
+      };
+
+      const translator = new WebColaTranslator();
+      // No lockUnconstrainedNodes flag (defaults to false): legacy mode
+      // should unfix every constrained endpoint and never lock anyone.
+      const result = await translator.translate(layout, 800, 600, {
+        priorPositions,
+      });
+
+      const nodeA = result.colaNodes.find(n => n.id === 'A')!;
+      const nodeB = result.colaNodes.find(n => n.id === 'B')!;
+      const nodeC = result.colaNodes.find(n => n.id === 'C')!;
+
+      // toColaNode never sets fixed=1 when lockUnconstrainedNodes=false,
+      // so all nodes start at fixed=0 — and the post-pass leaves them
+      // there.
+      expect(nodeA.fixed).toBe(0);
+      expect(nodeB.fixed).toBe(0);
+      expect(nodeC.fixed).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Sequence policies (\`stability\`, \`changeEmphasis\`, …) were only influencing WebCola via **seed positions** plus \`fixed=1\` on **unconstrained** nodes. Any node touching a Left/Top/Alignment constraint got \`fixed = 0\` unconditionally, so the solver re-placed it on every frame — prior layouts visibly drifted between sequence steps even when nothing relevant had changed.

This PR keeps constrained endpoints locked at their prior positions whenever those positions already satisfy the constraint, and only releases them when the solver actually needs the freedom.

- **`toColaConstraint`** is now a pure translator. It no longer mutates `node.fixed`.
- New **`evaluateConstraintAtPriorPositions(constraint)`** returns `'satisfied' | 'violated' | 'unknown'` using the same separation math the constraint generator uses (`computeHorizontalSeparation` / `computeVerticalSeparation`), with a 0.5px tolerance.
- New **`applyConstraintAwareLocking(constraints)`** post-pass runs after constraint translation. In stability mode (`lockUnconstrainedNodes: true`):
  - `satisfied` → both endpoints stay locked at prior positions.
  - `violated` → both endpoints unfixed so the solver can repair.
  - `unknown` → only the unseeded (newly-added) endpoint unfixed; the seeded one stays locked.
- When `lockUnconstrainedNodes` is false (default / morph mode), the post-pass preserves the legacy behavior of unfixing every constrained endpoint.

## Why this is safe — what `fixed` actually does in WebCola

I dug into the WebCola sources before settling on this approach. `fixed=1` is a **strong soft anchor**, not a hard pin, so locking constrained-but-satisfied nodes won't break the solver:

- **`fixed` is a bitfield.** Bit 1 is "user-set fixed" (what we use); bit 2 is set during drag; bit 4 during mouseOver. The solver tests `if (o.fixed)` — any non-zero value triggers locking ([\`layout.js:81\`](https://github.com/tgdwyer/WebCola/blob/master/src/layout.ts)). We never run during drag, so bits 2/4 are clean for us.
- **Two enforcement paths, both soft.**
  - *Gradient descent* ([\`descent.js:186-193\`](https://github.com/tgdwyer/WebCola/blob/master/src/descent.ts)) adds `maxH` to the locked variable's Hessian diagonal and a corrective gradient term `−maxH · (p − x)` toward the lock target. `maxH` is the max off-diagonal Hessian for that iteration, so the lock force scales with local curvature — strong, but never infinite.
  - *VPSC projector* ([\`rectangle.js:402-414\`](https://github.com/tgdwyer/WebCola/blob/master/src/rectangle.ts)) sets `v.variable.weight = v.fixedWeight ?? 1000` (vs. weight 1 for free nodes). The QP minimizes `Σ wᵢ (xᵢ − desiredᵢ)²` subject to constraints, so a fixed node is 1000× more expensive to move — but separations and alignments are still hard constraints and will move it if needed.
- **Lock targets `o.px, o.py` are auto-seeded.** In `start()` they're set to `o.x, o.y`; in `tick()` they fall back to current x/y if undefined. Our seed positions become lock targets automatically.
- **Iteration phases all honor locks.** `start(uIters, ucIters, allIters, snapIters)` runs initial unconstrained → user-constraint → overlap-projection → all-constraint → optional grid-snap. Locks (and weights) apply in every phase.
- **Per-node `fixedWeight` exists.** A future v2 could expose a per-policy "anchor strength" knob (e.g., 50 for soft, 1000 for stiff) instead of the current binary 0/1 — useful for `changeEmphasis` where we want a moderate pull rather than a near-pin.

The only edge case the post-pass doesn't reason about is **avoidOverlaps**: if two locked nodes' bounding boxes overlap (e.g., because node sizes changed between frames), the overlap-projection will displace them despite the lock. In practice this is fine — the displacement is symmetric, small, and exactly what we want when geometry changes force it.

## Test plan

- [x] New `Constraint-aware locking (lockUnconstrainedNodes)` block in [tests/temporal-layout-consistency.test.ts](tests/temporal-layout-consistency.test.ts) covering: satisfied → both locked, violated → both unfixed, mixed-prior → only new endpoint unfixed, legacy mode → all unfixed.
- [x] `npm run test:run` — all 96 files / 1448 tests pass (5 pre-existing skips).
- [x] `npm run build:all` — clean, no errors or warnings.
- [ ] Visual demo verification (`npm run serve`, sequence-step demo) — left to the reviewer; the change is exercised exhaustively by the unit tests, but the human-perception "does the layout drift less between frames" check still wants eyes on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)