### PR TITLE
Headless evaluation API for sequence-policy consistency analysis

### DIFF
--- a/docs/evaluation-api.md
+++ b/docs/evaluation-api.md
@@ -1,0 +1,213 @@
+# Evaluation API
+
+A small public surface for **headless consistency analysis** of spytial-core
+layouts — running the layout pipeline outside the browser and scoring
+sequence-policy output against Penlloy's two consistency metrics.
+
+> Intended for evaluation, not production rendering. The renderer's
+> tuning lives in [`webcola-cnd-graph.ts`](../src/translators/webcola/webcola-cnd-graph.ts);
+> evaluation's job is to use that production setup faithfully.
+
+---
+
+## What's exported
+
+From the package root:
+
+```ts
+import {
+  // headless layout pipeline
+  runHeadlessLayout,
+  type HeadlessLayoutOptions,
+  type HeadlessLayoutResult,
+
+  // Penlloy consistency metrics (PLATEAU 2025 §6.2)
+  positionalConsistency,
+  relativeConsistency,
+  classifyChangeEmphasisStableSet,
+  type EdgeKey,
+} from 'spytial-core';
+```
+
+| Export                              | What it does                                                                              |
+|-------------------------------------|-------------------------------------------------------------------------------------------|
+| `runHeadlessLayout`                 | `LayoutSpec + IDataInstance → post-solver positions`. No DOM, no d3.                      |
+| `positionalConsistency`             | `Σ ‖D(n) − D'(n)‖²` over persisting nodes. Squared L2.                                    |
+| `relativeConsistency`               | `Σ ‖(D(n₂)−D(n₁))−(D'(n₂)−D'(n₁))‖²` over persisting edges. Squared L2.                   |
+| `classifyChangeEmphasisStableSet`   | Recovers the stable subset for a `stable-node-reflow`-style policy from its output.       |
+
+The two metrics are pure functions over `LayoutState`; you don't need
+`runHeadlessLayout` to compute them if you have positions from
+elsewhere.
+
+---
+
+## The recipe
+
+```ts
+import {
+  parseLayoutSpec,
+  JSONDataInstance,
+  stability,
+  runHeadlessLayout,
+  positionalConsistency,
+  relativeConsistency,
+} from 'spytial-core';
+
+const spec = parseLayoutSpec(`
+  constraints:
+    - orientation:
+        selector: next
+        directions:
+          - right
+`);
+
+const prevInstance = new JSONDataInstance({
+  atoms: [
+    { id: 'A', type: 'Node', label: 'A' },
+    { id: 'B', type: 'Node', label: 'B' },
+  ],
+  relations: [{
+    id: 'next', name: 'next', types: ['Node', 'Node'],
+    tuples: [{ atoms: ['A', 'B'], types: ['Node', 'Node'] }],
+  }],
+});
+
+const currInstance = new JSONDataInstance({
+  atoms: [
+    { id: 'A', type: 'Node', label: 'A' },
+    { id: 'B', type: 'Node', label: 'B' },
+    { id: 'C', type: 'Node', label: 'C' },
+  ],
+  relations: [{
+    id: 'next', name: 'next', types: ['Node', 'Node'],
+    tuples: [
+      { atoms: ['A', 'B'], types: ['Node', 'Node'] },
+      { atoms: ['B', 'C'], types: ['Node', 'Node'] },
+    ],
+  }],
+});
+
+// 1. Lay out the previous frame from scratch.
+const prevResult = await runHeadlessLayout(spec, prevInstance);
+
+// 2. Lay out the current frame under the `stability` policy.
+const currResult = await runHeadlessLayout(spec, currInstance, {
+  policy: stability,
+  prevInstance,
+  currInstance,
+  priorPositions: prevResult.positions,
+});
+
+// 3. Score consistency.
+const positional = positionalConsistency(prevResult.positions, currResult.positions);
+const relative = relativeConsistency(
+  prevResult.positions, prevResult.edges,
+  currResult.positions, currResult.edges,
+);
+
+console.log({ positional, relative });
+```
+
+`positional` is `Σ ‖D(n) − D'(n)‖²` over nodes present in both frames.
+`relative` is the same sum over edges present in both frames, of
+edge-vector deltas. Both are 0 when the corresponding consistency
+type holds exactly.
+
+---
+
+## What the metrics measure
+
+For two diagrams `D'` (previous) and `D` (current), with `D(n) ∈ ℝ²`:
+
+```
+positional(D, D') = Σ ‖D(n) − D'(n)‖²       n ∈ nodes(D) ∩ nodes(D')
+
+relative(D, D')   = Σ ‖(D(n₂) − D(n₁)) − (D'(n₂) − D'(n₁))‖²
+                    (n₁, n₂) ∈ edges(D) ∩ edges(D')
+```
+
+Both lifted verbatim from §6.2 of:
+
+> Liang, Palliyil, Kang, Sunshine. *Towards Better Formal Methods Visualizations.* PLATEAU 2025. doi:[10.1184/R1/29086949.v1](https://doi.org/10.1184/R1/29086949.v1)
+
+Penlloy's framing distinguishes **hard** consistency (the metric is a
+constraint that must equal 0) from **soft** consistency (the metric is
+in the objective and yields under other constraint pressure).
+spytial-core's `stability` policy implements **soft** positional
+consistency: it minimizes drift but does not enforce zero.
+
+---
+
+## Two modes for `runHeadlessLayout`
+
+**Direct.** Pass `priorPositions` (and optionally `lockUnconstrainedNodes`)
+to manage prior state yourself.
+
+```ts
+runHeadlessLayout(spec, currInstance, {
+  priorPositions: prevState,
+  lockUnconstrainedNodes: true,
+});
+```
+
+**Policy-driven.** Pass `policy`, `prevInstance`, `currInstance`. The
+API applies the policy and uses its `effectivePriorState` plus
+`useReducedIterations` to set `lockUnconstrainedNodes`, matching
+production semantics in
+[`webcola-cnd-graph.ts:1645-1678`](../src/translators/webcola/webcola-cnd-graph.ts).
+
+```ts
+runHeadlessLayout(spec, currInstance, {
+  policy: changeEmphasis,
+  prevInstance,
+  currInstance,
+  priorPositions: prevState,
+});
+```
+
+If both are supplied, policy-driven wins.
+
+---
+
+## Mapping built-in policies to predicted metric values
+
+For any benchmark scenario:
+
+| Built-in policy       | Predicted `positional`               | Predicted `relative`                  |
+|-----------------------|--------------------------------------|---------------------------------------|
+| `ignoreHistory`       | high                                 | high                                  |
+| `randomPositioning`   | high                                 | high                                  |
+| `stability`           | low (≈ 0 when constraints permit)    | low (downstream of positional)        |
+| `changeEmphasis`      | low on stable subset; high on reflow | low on stable-stable edges            |
+
+Use `classifyChangeEmphasisStableSet(prior, policyOutput)` to recover
+the stable/reflow split from a `changeEmphasis` invocation:
+
+```ts
+import { changeEmphasis, classifyChangeEmphasisStableSet } from 'spytial-core';
+
+const policyResult = changeEmphasis.apply({
+  priorState, prevInstance, currInstance, spec,
+});
+const stableSet = classifyChangeEmphasisStableSet(priorState, policyResult.effectivePriorState!);
+const stablePositional = positionalConsistency(priorState, currResult.positions, stableSet);
+```
+
+---
+
+## Caveats
+
+- **`stability` holds singleton closure state.** Two evaluation runs
+  through the same `stability` reference share the same recall cache.
+  Calling `stability.apply({ priorState: { positions: [], ... }, ... })`
+  resets it. (Source:
+  [`sequence-policy.ts:316-348`](../src/translators/webcola/sequence-policy.ts).)
+- **`HeadlessLayoutOptions` does not expose iteration counts or the
+  convergence threshold.** They match production's reduced-iterations
+  path. Adding a knob here would let evaluation drift from production
+  semantics — defeating the purpose.
+- **Soft vs hard consistency is a property of the policy, not this API.**
+  spytial-core's `stability` is soft (drifts under constraint
+  pressure); a Penlloy-style hard variant would require runtime
+  changes outside this API's scope.

--- a/src/evaluation/headless-layout.ts
+++ b/src/evaluation/headless-layout.ts
@@ -1,0 +1,213 @@
+/**
+ * Headless layout pipeline: instance + spec → post-solver positions,
+ * with no DOM and no d3.
+ *
+ * Mirrors the production reduced-iterations path used in
+ * `WebColaCnDGraph.renderLayout` when prior positions are present
+ * (webcola-cnd-graph.ts:1764-1772, :1806-1816), but invokes
+ * `cola.Layout` directly so it can run inside vitest, downstream
+ * eval scripts, or any other Node-side consumer.
+ *
+ * Intended for evaluation, not for production rendering. Do not
+ * extend this with iteration or convergence knobs — production
+ * tuning lives in the renderer; evaluation's job is to use the
+ * production setup faithfully.
+ */
+
+import { Layout as ColaLayout } from 'webcola';
+import { LayoutInstance } from '../layout/layoutinstance';
+import type { LayoutSpec } from '../layout/layoutspec';
+import type { IDataInstance } from '../data-instance/interfaces';
+import type { LayoutConstraint } from '../layout/interfaces';
+import { SGraphQueryEvaluator } from '../evaluators/data/sgq-evaluator';
+import {
+  WebColaTranslator,
+  type LayoutState,
+  type NodeWithMetadata,
+  type WebColaLayoutOptions,
+} from '../translators/webcola/webcolatranslator';
+import type { SequencePolicy, SequencePolicyContext } from '../translators/webcola/sequence-policy';
+import type { EdgeKey } from './penlloy-metrics';
+
+/**
+ * Options for `runHeadlessLayout`.
+ *
+ * Two modes:
+ *
+ * 1. **Direct** — pass `priorPositions` and optionally
+ *    `lockUnconstrainedNodes`. No policy invocation.
+ * 2. **Policy-driven** — pass `policy`, `prevInstance`, `currInstance`.
+ *    The API applies the policy and uses its `effectivePriorState`
+ *    plus `useReducedIterations` (the latter as
+ *    `lockUnconstrainedNodes`, matching the production gating in
+ *    webcola-cnd-graph.ts:1676).
+ *
+ * If both are supplied the policy-driven path wins, matching
+ * production semantics.
+ */
+export interface HeadlessLayoutOptions {
+  /** Direct prior positions (used when no policy is provided). */
+  priorPositions?: LayoutState;
+  /** Direct lock flag (used when no policy is provided). */
+  lockUnconstrainedNodes?: boolean;
+
+  /** Sequence policy to apply. Requires `prevInstance` and `currInstance`. */
+  policy?: SequencePolicy;
+  /** Previous data instance, fed to the policy. */
+  prevInstance?: IDataInstance;
+  /**
+   * Current data instance, fed to the policy. Usually the same object
+   * as the `instance` argument but accepted explicitly so policies
+   * can be tested with mismatched pairs.
+   */
+  currInstance?: IDataInstance;
+
+  /** Figure width passed to the translator and solver. Default 800. */
+  figWidth?: number;
+  /** Figure height passed to the translator and solver. Default 600. */
+  figHeight?: number;
+}
+
+/**
+ * Result of `runHeadlessLayout`. Exposes the minimum surface needed
+ * to compute consistency metrics, validate constraint satisfaction,
+ * and inspect node geometry.
+ */
+export interface HeadlessLayoutResult {
+  /**
+   * Post-solver positions plus an identity transform, in the same
+   * shape policies and `WebColaTranslator.priorPositions` use. Feed
+   * this directly into `positionalConsistency` /
+   * `relativeConsistency` as the "current frame".
+   */
+  positions: LayoutState;
+  /**
+   * Edge identities (`source`, `target`, `rel`) for the layout, used
+   * to determine persistence by the relative-consistency metric.
+   * Sourced from `InstanceLayout.edges` (pre-translation) so the
+   * triples match what a downstream consumer can recover from a
+   * separate run.
+   */
+  edges: EdgeKey[];
+  /**
+   * Source `LayoutConstraint`s (Left / Top / Alignment / etc.) as
+   * produced by `LayoutInstance.generateLayout`. Use these to assert
+   * post-solver satisfaction.
+   */
+  constraints: LayoutConstraint[];
+  /**
+   * The full `NodeWithMetadata` array after the solver has mutated
+   * positions. Includes `visualWidth` / `visualHeight`, useful for
+   * computing required separations when checking constraint
+   * satisfaction.
+   */
+  nodes: NodeWithMetadata[];
+}
+
+const DEFAULT_FIG_WIDTH = 800;
+const DEFAULT_FIG_HEIGHT = 600;
+
+/**
+ * Run the layout pipeline headlessly: build a LayoutInstance, generate
+ * the InstanceLayout, translate to a WebColaLayout, run cola.Layout to
+ * convergence under the production reduced-iterations schedule, and
+ * return the post-solver state.
+ *
+ * @param spec     Parsed layout specification (from `parseLayoutSpec`).
+ * @param instance Data instance to lay out.
+ * @param options  Prior-state / policy options. See `HeadlessLayoutOptions`.
+ *
+ * @example
+ *   const spec = parseLayoutSpec(specStr);
+ *   const result = await runHeadlessLayout(spec, instance);
+ *   // result.positions is the LayoutState; pass it to positionalConsistency
+ *   // alongside a prior-frame LayoutState.
+ */
+export async function runHeadlessLayout(
+  spec: LayoutSpec,
+  instance: IDataInstance,
+  options: HeadlessLayoutOptions = {}
+): Promise<HeadlessLayoutResult> {
+  const figWidth = options.figWidth ?? DEFAULT_FIG_WIDTH;
+  const figHeight = options.figHeight ?? DEFAULT_FIG_HEIGHT;
+
+  // Build the LayoutInstance with the production-default evaluator.
+  // Evaluation does not need to vary this — production uses
+  // SGraphQueryEvaluator behind every renderer entry point.
+  const evaluator = new SGraphQueryEvaluator();
+  evaluator.initialize({ sourceData: instance });
+  const layoutInstance = new LayoutInstance(spec, evaluator, 0, true);
+  const { layout } = layoutInstance.generateLayout(instance);
+
+  // Resolve translator options. Policy-driven path mirrors
+  // webcola-cnd-graph.ts:1645-1678.
+  let translatorOptions: WebColaLayoutOptions | undefined;
+  if (options.policy && options.prevInstance && options.currInstance) {
+    const priorState: LayoutState = options.priorPositions ?? {
+      positions: [],
+      transform: { k: 1, x: 0, y: 0 },
+    };
+    const ctx: SequencePolicyContext = {
+      priorState,
+      prevInstance: options.prevInstance,
+      currInstance: options.currInstance,
+      spec,
+    };
+    const policyResult = options.policy.apply(ctx);
+    if (policyResult.effectivePriorState) {
+      translatorOptions = {
+        priorPositions: policyResult.effectivePriorState,
+        lockUnconstrainedNodes: policyResult.useReducedIterations,
+      };
+    }
+  } else if (options.priorPositions) {
+    translatorOptions = {
+      priorPositions: options.priorPositions,
+      lockUnconstrainedNodes: options.lockUnconstrainedNodes ?? false,
+    };
+  }
+
+  const translator = new WebColaTranslator();
+  const webcolaLayout = await translator.translate(
+    layout,
+    figWidth,
+    figHeight,
+    translatorOptions
+  );
+
+  // Solve. Iteration counts and convergence threshold match the
+  // reduced-iterations production path used when prior positions are
+  // present (webcola-cnd-graph.ts:1764-1772, :1803).
+  const colaLayout = new ColaLayout()
+    .linkDistance(150)
+    .convergenceThreshold(0.1)
+    .avoidOverlaps(true)
+    .handleDisconnected(true)
+    .nodes(webcolaLayout.colaNodes as any)
+    .links(webcolaLayout.colaEdges as any)
+    .constraints(webcolaLayout.colaConstraints as any[])
+    .size([webcolaLayout.FIG_WIDTH, webcolaLayout.FIG_HEIGHT]);
+  colaLayout.start(0, 10, 20, 1);
+
+  const positions: LayoutState = {
+    positions: webcolaLayout.colaNodes.map(n => ({
+      id: n.id,
+      x: n.x ?? 0,
+      y: n.y ?? 0,
+    })),
+    transform: { k: 1, x: 0, y: 0 },
+  };
+
+  const edges: EdgeKey[] = layout.edges.map(e => ({
+    source: e.source.id,
+    target: e.target.id,
+    rel: e.relationName,
+  }));
+
+  return {
+    positions,
+    edges,
+    constraints: layout.constraints,
+    nodes: webcolaLayout.colaNodes,
+  };
+}

--- a/src/evaluation/index.ts
+++ b/src/evaluation/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Public evaluation API for spytial-core.
+ *
+ * **Intended for evaluation, not for production rendering.**
+ *
+ * Provides three things downstream consistency-analysis consumers need:
+ *
+ *   1. `runHeadlessLayout` — runs the full
+ *      LayoutInstance → WebColaTranslator → cola.Layout pipeline with
+ *      no DOM dependency, returning post-solver positions plus the
+ *      edges and constraints needed to score them.
+ *   2. `positionalConsistency` / `relativeConsistency` — Penlloy's two
+ *      consistency metrics (PLATEAU 2025 §6.2), as plain pure
+ *      functions over `LayoutState`.
+ *   3. `classifyChangeEmphasisStableSet` — recovers the stable-vs-
+ *      reflow node split for a partial-consistency policy from its
+ *      output positions, with no SequencePolicy interface change.
+ *
+ * Typical recipe:
+ *
+ *   const prevResult = await runHeadlessLayout(spec, prevInstance);
+ *   const currResult = await runHeadlessLayout(spec, currInstance, {
+ *     policy: stability,
+ *     prevInstance,
+ *     currInstance,
+ *     priorPositions: prevResult.positions,
+ *   });
+ *   const m = positionalConsistency(prevResult.positions, currResult.positions);
+ *
+ * See [docs/evaluation-api.md](../../docs/evaluation-api.md) for a
+ * worked example.
+ */
+
+export {
+  runHeadlessLayout,
+  type HeadlessLayoutOptions,
+  type HeadlessLayoutResult,
+} from './headless-layout';
+
+export {
+  positionalConsistency,
+  relativeConsistency,
+  classifyChangeEmphasisStableSet,
+  type EdgeKey,
+} from './penlloy-metrics';

--- a/src/evaluation/penlloy-metrics.ts
+++ b/src/evaluation/penlloy-metrics.ts
@@ -1,0 +1,169 @@
+/**
+ * Penlloy consistency metrics, lifted verbatim from §6.2 of:
+ *
+ *   Liang, Palliyil, Kang, Sunshine. "Towards Better Formal Methods
+ *   Visualizations." PLATEAU 2025. doi:10.1184/R1/29086949.v1
+ *
+ * For two diagrams D' (previous) and D (current), with D(n) ∈ ℝ²:
+ *
+ *   positional(D, D') = Σ ‖D(n) − D'(n)‖²        n ∈ nodes(D) ∩ nodes(D')
+ *
+ *   relative(D, D')   = Σ ‖(D(n2) − D(n1)) − (D'(n2) − D'(n1))‖²
+ *                       (n1, n2) ∈ edges(D) ∩ edges(D')
+ *
+ * Both are squared L2; both sum ONLY over elements that persist across
+ * the two frames. A consistency metric is 0 exactly when that
+ * consistency type is satisfied.
+ *
+ * These functions are evaluation infrastructure — used by the in-repo
+ * assertion tests that defend the realization-policy claims, and by
+ * downstream consumers (e.g., the thesis evaluation repo) that drive
+ * richer benchmarks against the same definitions.
+ */
+
+import type { LayoutState } from '../translators/webcola/webcolatranslator';
+
+/**
+ * Edge identity used to determine persistence between two frames.
+ * Two edges are "the same" iff they share source, target, and relation
+ * name. Matches the matching key used elsewhere when deduplicating
+ * edges across frames.
+ */
+export interface EdgeKey {
+  source: string;
+  target: string;
+  rel: string;
+}
+
+const edgeKeyString = (e: EdgeKey): string =>
+  `${e.source}->${e.target}#${e.rel}`;
+
+const buildPositionMap = (state: LayoutState): Map<string, { x: number; y: number }> => {
+  const m = new Map<string, { x: number; y: number }>();
+  for (const p of state.positions) {
+    m.set(p.id, { x: p.x, y: p.y });
+  }
+  return m;
+};
+
+/**
+ * Penlloy's positional consistency metric:
+ *
+ *     Σ ‖D(n) − D'(n)‖²    over n ∈ nodes(prev) ∩ nodes(curr)
+ *
+ * Returns 0 iff every persisting node is at the same position in both
+ * frames. Squared units (px²).
+ *
+ * @param prev      Layout state from the previous frame.
+ * @param curr      Layout state from the current frame.
+ * @param restrictTo
+ *     If provided, only nodes whose id is in this set contribute to the
+ *     sum (still requires presence in both frames). Used to score the
+ *     "stable subset" half of the partial-consistency case.
+ */
+export function positionalConsistency(
+  prev: LayoutState,
+  curr: LayoutState,
+  restrictTo?: Set<string>
+): number {
+  const prevPos = buildPositionMap(prev);
+  const currPos = buildPositionMap(curr);
+
+  let total = 0;
+  for (const [id, p] of currPos) {
+    if (!prevPos.has(id)) continue;
+    if (restrictTo && !restrictTo.has(id)) continue;
+    const q = prevPos.get(id)!;
+    const dx = p.x - q.x;
+    const dy = p.y - q.y;
+    total += dx * dx + dy * dy;
+  }
+  return total;
+}
+
+/**
+ * Penlloy's relative consistency metric:
+ *
+ *     Σ ‖(D(n2) − D(n1)) − (D'(n2) − D'(n1))‖²
+ *     over (n1, n2) ∈ edges(prev) ∩ edges(curr)
+ *
+ * Returns 0 iff every persisting edge has the same vector direction and
+ * length in both frames. Squared units (px²).
+ *
+ * Persistence is by `(source, target, rel)` triple. An edge present in
+ * curr but not prev (or vice versa) does not contribute.
+ *
+ * @param prev               Previous-frame layout state.
+ * @param prevEdges          Edge set in the previous frame.
+ * @param curr               Current-frame layout state.
+ * @param currEdges          Edge set in the current frame.
+ * @param restrictToNodes
+ *     If provided, only edges whose BOTH endpoints are in this set
+ *     contribute to the sum. Used to score the "stable-stable edges"
+ *     half of the partial-consistency case.
+ */
+export function relativeConsistency(
+  prev: LayoutState,
+  prevEdges: EdgeKey[],
+  curr: LayoutState,
+  currEdges: EdgeKey[],
+  restrictToNodes?: Set<string>
+): number {
+  const prevPos = buildPositionMap(prev);
+  const currPos = buildPositionMap(curr);
+
+  const prevEdgeSet = new Set(prevEdges.map(edgeKeyString));
+
+  let total = 0;
+  for (const e of currEdges) {
+    if (!prevEdgeSet.has(edgeKeyString(e))) continue;
+    if (restrictToNodes && (!restrictToNodes.has(e.source) || !restrictToNodes.has(e.target))) continue;
+
+    const ps = prevPos.get(e.source);
+    const pt = prevPos.get(e.target);
+    const cs = currPos.get(e.source);
+    const ct = currPos.get(e.target);
+    if (!ps || !pt || !cs || !ct) continue;
+
+    const prevDx = pt.x - ps.x;
+    const prevDy = pt.y - ps.y;
+    const currDx = ct.x - cs.x;
+    const currDy = ct.y - cs.y;
+
+    const ddx = currDx - prevDx;
+    const ddy = currDy - prevDy;
+    total += ddx * ddx + ddy * ddy;
+  }
+  return total;
+}
+
+/**
+ * Recover the "stable" subset of nodes for a `stable-node-reflow`-style
+ * policy by observing which output positions equal prior positions
+ * within `tol` (default 0.5 px per axis).
+ *
+ * Lets the partial-consistency case (positional = 0 over stable;
+ * bounded over reflow) be scored without changing the SequencePolicy
+ * interface to expose a stable/reflow classification.
+ *
+ * @param prior         The prior LayoutState fed into the policy.
+ * @param policyOutput  The LayoutState the policy returned
+ *                      (`SequencePolicyResult.effectivePriorState`).
+ * @param tol           Per-axis tolerance for "unchanged". Default 0.5 px.
+ */
+export function classifyChangeEmphasisStableSet(
+  prior: LayoutState,
+  policyOutput: LayoutState,
+  tol: number = 0.5
+): Set<string> {
+  const priorPos = buildPositionMap(prior);
+  const stable = new Set<string>();
+  for (const p of policyOutput.positions) {
+    const q = priorPos.get(p.id);
+    if (!q) continue;
+    if (Math.abs(p.x - q.x) <= tol && Math.abs(p.y - q.y) <= tol) {
+      stable.add(p.id);
+    }
+  }
+  return stable;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,3 +196,18 @@ export type { ProjectionOrchestratorProps, ProjectionOrchestratorResult } from '
 // Projection Transform (pre-layout data instance transformation)
 export { applyProjectionTransform, topologicalSortWithCycleBreaking } from './data-instance/projection-transform';
 export type { Projection, ProjectionTransformOptions, ProjectionTransformResult } from './data-instance/projection-transform';
+
+// Evaluation API — headless layout + Penlloy consistency metrics.
+// Intended for sequence-policy analysis (e.g., the thesis evaluation
+// repo); not for production rendering.
+export {
+  runHeadlessLayout,
+  positionalConsistency,
+  relativeConsistency,
+  classifyChangeEmphasisStableSet,
+} from './evaluation';
+export type {
+  HeadlessLayoutOptions,
+  HeadlessLayoutResult,
+  EdgeKey,
+} from './evaluation';

--- a/tests/sequence-policy-consistency-metrics.test.ts
+++ b/tests/sequence-policy-consistency-metrics.test.ts
@@ -1,0 +1,456 @@
+import { describe, it, expect } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import {
+  ignoreHistory,
+  stability,
+  changeEmphasis,
+  randomPositioning,
+} from '../src/translators/webcola/sequence-policy';
+import {
+  runHeadlessLayout,
+  positionalConsistency,
+  relativeConsistency,
+  classifyChangeEmphasisStableSet,
+  type EdgeKey,
+} from '../src/evaluation';
+
+/**
+ * Per-policy END-TO-END behavioral tests. Each `describe` block names
+ * the policy and the promise it makes, then runs the full
+ * `runHeadlessLayout → cola.Layout → metrics` pipeline and asserts
+ * the promise holds at the **post-solver** positions.
+ *
+ * The shape of the predictions is taken from the Penlloy framework
+ * (PLATEAU 2025 §6.2) and the realization-policy table in the thesis
+ * proposal's Guzdial chart.
+ *
+ * Unit-level tests of each policy's `apply` method live in
+ * `tests/sequence-policy.test.ts`; these tests are the next layer up
+ * — they exercise what the *full pipeline* actually produces.
+ */
+
+// ──────────────────────────────────────────────────────────────────
+// Layout spec & benchmark scenarios
+// ──────────────────────────────────────────────────────────────────
+
+const layoutSpecStr = `
+constraints:
+  - orientation:
+      selector: next
+      directions:
+        - right
+`;
+const layoutSpec = parseLayoutSpec(layoutSpecStr);
+
+const atomsABC = [
+  { id: 'A', type: 'Node', label: 'A' },
+  { id: 'B', type: 'Node', label: 'B' },
+  { id: 'C', type: 'Node', label: 'C' },
+];
+
+const dataAB: IJsonDataInstance = {
+  atoms: atomsABC,
+  relations: [{
+    id: 'next', name: 'next', types: ['Node', 'Node'],
+    tuples: [{ atoms: ['A', 'B'], types: ['Node', 'Node'] }],
+  }],
+};
+
+const dataABBC: IJsonDataInstance = {
+  atoms: atomsABC,
+  relations: [{
+    id: 'next', name: 'next', types: ['Node', 'Node'],
+    tuples: [
+      { atoms: ['A', 'B'], types: ['Node', 'Node'] },
+      { atoms: ['B', 'C'], types: ['Node', 'Node'] },
+    ],
+  }],
+};
+
+const dataChain: IJsonDataInstance = dataABBC; // A→B→C
+const dataTree: IJsonDataInstance = {           // A→B, A→C — same atoms, different edges
+  atoms: atomsABC,
+  relations: [{
+    id: 'next', name: 'next', types: ['Node', 'Node'],
+    tuples: [
+      { atoms: ['A', 'B'], types: ['Node', 'Node'] },
+      { atoms: ['A', 'C'], types: ['Node', 'Node'] },
+    ],
+  }],
+};
+
+const dataAddAtomBefore: IJsonDataInstance = {
+  atoms: [
+    { id: 'A', type: 'Node', label: 'A' },
+    { id: 'B', type: 'Node', label: 'B' },
+  ],
+  relations: [{
+    id: 'next', name: 'next', types: ['Node', 'Node'],
+    tuples: [{ atoms: ['A', 'B'], types: ['Node', 'Node'] }],
+  }],
+};
+const dataAddAtomAfter: IJsonDataInstance = dataAB; // {A,B} → {A,B,C}
+
+const dataRemoveBefore: IJsonDataInstance = dataAB;
+const dataRemoveAfter: IJsonDataInstance = dataAddAtomBefore; // {A,B,C} → {A,B}
+
+interface Scenario {
+  name: string;
+  prev: JSONDataInstance;
+  curr: JSONDataInstance;
+}
+
+const scenarios: Scenario[] = [
+  { name: 'identity (same instance both frames)',  prev: new JSONDataInstance(dataAB),         curr: new JSONDataInstance(dataAB) },
+  { name: 'relation change (atoms preserved)',     prev: new JSONDataInstance(dataAB),         curr: new JSONDataInstance(dataABBC) },
+  { name: 'atom addition',                          prev: new JSONDataInstance(dataAddAtomBefore), curr: new JSONDataInstance(dataAddAtomAfter) },
+  { name: 'atom removal',                           prev: new JSONDataInstance(dataRemoveBefore),  curr: new JSONDataInstance(dataRemoveAfter) },
+  { name: 'restructure (chain → tree)',             prev: new JSONDataInstance(dataChain),      curr: new JSONDataInstance(dataTree) },
+];
+
+// ──────────────────────────────────────────────────────────────────
+// Thresholds — squared L2 px² over the persisting subset.
+//
+// Important framing: spytial-core's `stability` policy is SOFT
+// positional consistency in Penlloy's terminology — consistency lives
+// in the objective and yields under constraint pressure. It is NOT
+// hard consistency (which would require positional = 0 strictly). So
+// the tests below assert *relative* and *bounded* claims, not "= 0".
+//
+// Two sources of drift even under locks:
+//   1. The lock spring is finite (weight 1000, not ∞).
+//   2. WebCola's `handleDisconnected` re-spreads disconnected
+//      components between frames, displacing isolated atoms.
+//   3. When the new step adds a constraint the prior positions
+//      violate, the constraint-aware post-pass unfixes the endpoints
+//      and the solver moves them to satisfy the constraint.
+// All three produce real, intended drift.
+// ──────────────────────────────────────────────────────────────────
+
+/**
+ * Upper bound on identity-scenario drift under a consistency policy.
+ * Generous enough to absorb (1) finite lock spring, (2)
+ * `handleDisconnected` re-spreading, but tight enough to catch a real
+ * regression where locks stop holding at all.
+ */
+const IDENTITY_DRIFT_BUDGET = 50_000;
+
+/**
+ * Threshold above which we call positional drift "high" — i.e., the
+ * frame is clearly not preserving prior positions. changeEmphasis
+ * jitter alone contributes ≥ 30² × 2 = 1800 px² per reflow node;
+ * randomPositioning re-rolls every position, producing tens to
+ * hundreds of thousands. Pick a threshold that's clearly above lock
+ * noise.
+ */
+const POSITIONAL_HIGH = 100_000;
+
+// ──────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────
+
+/**
+ * Run a two-frame sequence under a policy:
+ *   1. Lay out `prev` cold to get the prior frame's positions.
+ *   2. Lay out `curr` with the policy applied to that prior.
+ *
+ * Returns both layouts so tests can score consistency between them.
+ */
+async function runSequence(
+  prev: JSONDataInstance,
+  curr: JSONDataInstance,
+  policy: typeof stability | typeof changeEmphasis | typeof ignoreHistory | typeof randomPositioning
+) {
+  const prevResult = await runHeadlessLayout(layoutSpec, prev);
+  const currResult = await runHeadlessLayout(layoutSpec, curr, {
+    policy,
+    prevInstance: prev,
+    currInstance: curr,
+    priorPositions: prevResult.positions,
+  });
+  return { prevResult, currResult };
+}
+
+// ──────────────────────────────────────────────────────────────────
+// stability — claim: "preserves node positions across frames"
+//
+// In Penlloy's vocabulary this is SOFT positional consistency:
+// consistency in the objective, yields to constraint pressure. We
+// therefore test two things:
+//   • Identity (no constraint conflict): drift bounded by lock noise.
+//   • Every scenario: stability strictly beats ignoreHistory on the
+//     persisting subset (the policy's actual contribution).
+// ──────────────────────────────────────────────────────────────────
+
+describe('stability — claims soft-positional consistency on persisting nodes', () => {
+  it('identity scenario: drift bounded by lock noise', async () => {
+    const { prevResult, currResult } = await runSequence(
+      new JSONDataInstance(dataAB),
+      new JSONDataInstance(dataAB),
+      stability
+    );
+    const m = positionalConsistency(prevResult.positions, currResult.positions);
+    expect(
+      m,
+      `stability on identity drifted ${m.toFixed(1)} px²; expected ≤ ${IDENTITY_DRIFT_BUDGET}`
+    ).toBeLessThanOrEqual(IDENTITY_DRIFT_BUDGET);
+  });
+
+  // Comparative claim: when the graph CHANGES between frames, stability
+  // preserves persisting positions better than ignoreHistory does.
+  //
+  // Identity is deliberately excluded — ignoreHistory on identity has
+  // zero drift (both runs are deterministic re-layouts of the same
+  // graph), so the comparison is uninformative. The dedicated identity
+  // test above covers the no-change case.
+  const changingScenarios = scenarios.filter(s => !s.name.startsWith('identity'));
+
+  for (const scenario of changingScenarios) {
+    it(`beats ignoreHistory on persisting subset for "${scenario.name}"`, async () => {
+      const stabilitySeq = await runSequence(scenario.prev, scenario.curr, stability);
+      const ignoreSeq = await runSequence(scenario.prev, scenario.curr, ignoreHistory);
+
+      const persistingIds = new Set(
+        stabilitySeq.prevResult.positions.positions
+          .map(p => p.id)
+          .filter(id => stabilitySeq.currResult.positions.positions.some(q => q.id === id))
+      );
+
+      const mStability = positionalConsistency(
+        stabilitySeq.prevResult.positions,
+        stabilitySeq.currResult.positions,
+        persistingIds
+      );
+      const mIgnore = positionalConsistency(
+        ignoreSeq.prevResult.positions,
+        ignoreSeq.currResult.positions,
+        persistingIds
+      );
+
+      expect(
+        mStability,
+        `stability ${mStability.toFixed(1)} px² should be ≤ ignoreHistory ${mIgnore.toFixed(1)} px² for "${scenario.name}"`
+      ).toBeLessThanOrEqual(mIgnore);
+    });
+  }
+
+  it('identity: relative consistency is also small (positional → relative downstream)', async () => {
+    const { prevResult, currResult } = await runSequence(
+      new JSONDataInstance(dataABBC),
+      new JSONDataInstance(dataABBC),
+      stability
+    );
+    const m = relativeConsistency(
+      prevResult.positions, prevResult.edges,
+      currResult.positions, currResult.edges
+    );
+    expect(m).toBeLessThanOrEqual(IDENTITY_DRIFT_BUDGET);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// changeEmphasis — claim: stable nodes stay fixed; changed nodes get
+// visible jitter
+// ──────────────────────────────────────────────────────────────────
+
+describe('changeEmphasis — claims stable subset preserved, reflow on changed nodes', () => {
+  it('partitions nodes into stable and reflow on relation-change scenario', async () => {
+    const prev = new JSONDataInstance(dataAB);     // edge A→B
+    const curr = new JSONDataInstance(dataABBC);   // edge A→B + B→C — B and C have new connectivity
+
+    const { prevResult, currResult } = await runSequence(prev, curr, changeEmphasis);
+
+    // Recover the stable set the policy declared, by comparing what the
+    // policy emitted to the prior. (We can't observe the policy's
+    // internal classification directly, but `effectivePriorState` IS the
+    // policy's output — and stable nodes have unchanged positions there.)
+    const policyResult = changeEmphasis.apply({
+      priorState: prevResult.positions,
+      prevInstance: prev,
+      currInstance: curr,
+      spec: layoutSpec,
+    });
+    expect(policyResult.effectivePriorState).toBeDefined();
+    const stableSet = classifyChangeEmphasisStableSet(
+      prevResult.positions,
+      policyResult.effectivePriorState!
+    );
+
+    // The scenario must actually produce a non-trivial split — at least
+    // one stable and at least one reflow node. Otherwise the policy
+    // promise is vacuous on this benchmark.
+    const allIds = new Set(currResult.positions.positions.map(p => p.id));
+    const reflowSet = new Set([...allIds].filter(id => !stableSet.has(id)));
+    expect(stableSet.size, 'expected at least one stable node').toBeGreaterThan(0);
+    expect(reflowSet.size, 'expected at least one reflow node').toBeGreaterThan(0);
+
+    // The stable subset must move LESS than the reflow subset — the
+    // policy's whole job is to make changed nodes more salient than
+    // stable ones. Compare per-node averages so subset sizes don't
+    // skew the comparison.
+    const mStable = positionalConsistency(prevResult.positions, currResult.positions, stableSet);
+    const mReflow = positionalConsistency(prevResult.positions, currResult.positions, reflowSet);
+    const stablePerNode = mStable / Math.max(1, stableSet.size);
+    const reflowPerNode = mReflow / Math.max(1, reflowSet.size);
+
+    expect(
+      reflowPerNode,
+      `reflow per-node drift ${reflowPerNode.toFixed(1)} should exceed stable per-node drift ${stablePerNode.toFixed(1)}`
+    ).toBeGreaterThan(stablePerNode);
+  });
+
+  it('identity scenario produces no reflow (no changes to emphasize)', async () => {
+    // changeEmphasis on (X, X) should leave every node stable — no
+    // node has any change to emphasize. Drift comes only from lock
+    // noise, not from any policy-induced jitter.
+    const prev = new JSONDataInstance(dataAB);
+    const curr = new JSONDataInstance(dataAB);
+    const { prevResult, currResult } = await runSequence(prev, curr, changeEmphasis);
+    const m = positionalConsistency(prevResult.positions, currResult.positions);
+    expect(m).toBeLessThanOrEqual(IDENTITY_DRIFT_BUDGET);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// ignoreHistory — claim: fresh layout each step (no consistency)
+// ──────────────────────────────────────────────────────────────────
+
+describe('ignoreHistory — claims fresh layout per step', () => {
+  it('apply() returns undefined effectivePriorState (unit-level)', () => {
+    const prev = new JSONDataInstance(dataAB);
+    const curr = new JSONDataInstance(dataABBC);
+    const result = ignoreHistory.apply({
+      priorState: { positions: [{ id: 'A', x: 100, y: 200 }], transform: { k: 1, x: 0, y: 0 } },
+      prevInstance: prev,
+      currInstance: curr,
+      spec: layoutSpec,
+    });
+    expect(result.effectivePriorState).toBeUndefined();
+    expect(result.useReducedIterations).toBe(false);
+  });
+
+  it('post-solver positions are not pinned to deliberately-different priors (restructure)', async () => {
+    // Pick a scenario where a fresh DAGRE/cola layout will produce
+    // different positions than a deliberately offset prior would lock.
+    // We provide a contrived prior to ignoreHistory — but the policy
+    // returns undefined so the prior is discarded, and the layout is
+    // computed from scratch.
+    const prev = new JSONDataInstance(dataChain);
+    const curr = new JSONDataInstance(dataTree);
+
+    // Build a contrived prior where every node is at (0, 0) — clearly
+    // not what a fresh layout would produce.
+    const contrivedPrior = {
+      positions: [
+        { id: 'A', x: 0, y: 0 },
+        { id: 'B', x: 0, y: 0 },
+        { id: 'C', x: 0, y: 0 },
+      ],
+      transform: { k: 1, x: 0, y: 0 },
+    };
+
+    const currResult = await runHeadlessLayout(layoutSpec, curr, {
+      policy: ignoreHistory,
+      prevInstance: prev,
+      currInstance: curr,
+      priorPositions: contrivedPrior,
+    });
+
+    // If ignoreHistory had honored the prior, every node would be near
+    // (0, 0) — then positional vs (0,0,0) would be ≈ 0. Since the
+    // policy returns undefined, the layout ignores the prior and
+    // produces fresh positions far from (0, 0).
+    const m = positionalConsistency(contrivedPrior, currResult.positions);
+    expect(
+      m,
+      `positional vs contrived (0,0) prior was ${m.toFixed(1)} px²; ignoreHistory should make it large`
+    ).toBeGreaterThan(POSITIONAL_HIGH);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// randomPositioning — claim: randomize within viewport bounds
+// ──────────────────────────────────────────────────────────────────
+
+describe('randomPositioning — claims positions are randomized within viewport bounds', () => {
+  it('apply() returns positions within the requested viewport bounds (unit-level)', () => {
+    const prev = new JSONDataInstance(dataAB);
+    const curr = new JSONDataInstance(dataAB);
+    const bounds = { minX: 0, maxX: 800, minY: 0, maxY: 600 };
+    const result = randomPositioning.apply({
+      priorState: { positions: [], transform: { k: 1, x: 0, y: 0 } },
+      prevInstance: prev,
+      currInstance: curr,
+      spec: layoutSpec,
+      viewportBounds: bounds,
+    });
+
+    expect(result.effectivePriorState).toBeDefined();
+    for (const p of result.effectivePriorState!.positions) {
+      expect(p.x, `${p.id}.x out of bounds`).toBeGreaterThanOrEqual(bounds.minX);
+      expect(p.x, `${p.id}.x out of bounds`).toBeLessThanOrEqual(bounds.maxX);
+      expect(p.y, `${p.id}.y out of bounds`).toBeGreaterThanOrEqual(bounds.minY);
+      expect(p.y, `${p.id}.y out of bounds`).toBeLessThanOrEqual(bounds.maxY);
+    }
+  });
+
+  // No end-to-end "drift exceeds lock noise" test for randomPositioning.
+  //
+  // randomPositioning's promise is at the policy level: it returns
+  // random positions within the viewport bounds. The unit-level test
+  // above covers that.
+  //
+  // The post-solver claim "drift is large" is unreliable: when the
+  // random positions violate the layout's hard constraints, the
+  // constraint-aware-locking post-pass unfixes the violating
+  // endpoints and the solver re-converges to a constraint-satisfying
+  // layout — which on a small graph happens to coincide with the
+  // prior fresh layout, producing near-zero drift. That coincidence
+  // is a property of constraint geometry, not a randomPositioning
+  // regression, so asserting "drift > X" here would be flaky.
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Cross-policy sanity: stability beats ignoreHistory on identity
+// ──────────────────────────────────────────────────────────────────
+
+describe('cross-policy ordering on a changing scenario', () => {
+  it('stability achieves lower positional than ignoreHistory on atom-add', async () => {
+    // Identity is excluded — ignoreHistory deterministically replays
+    // the same fresh layout, so its drift is 0 and nothing beats it.
+    // On a CHANGING scenario, ignoreHistory's drift is real (the
+    // post-add layout differs from the pre-add layout) and stability
+    // should clearly win.
+    const prev = new JSONDataInstance(dataAddAtomBefore);
+    const curr = new JSONDataInstance(dataAddAtomAfter);
+
+    const stabilitySeq = await runSequence(prev, curr, stability);
+    const ignoreSeq = await runSequence(prev, curr, ignoreHistory);
+
+    const persistingIds = new Set(
+      stabilitySeq.prevResult.positions.positions
+        .map(p => p.id)
+        .filter(id => stabilitySeq.currResult.positions.positions.some(q => q.id === id))
+    );
+
+    const mStability = positionalConsistency(
+      stabilitySeq.prevResult.positions,
+      stabilitySeq.currResult.positions,
+      persistingIds
+    );
+    const mIgnore = positionalConsistency(
+      ignoreSeq.prevResult.positions,
+      ignoreSeq.currResult.positions,
+      persistingIds
+    );
+
+    expect(
+      mStability,
+      `stability drift ${mStability.toFixed(1)} px² should be ≤ ignoreHistory drift ${mIgnore.toFixed(1)} px² on atom-add`
+    ).toBeLessThanOrEqual(mIgnore);
+  });
+});
+
+// Re-export to silence unused import warnings (EdgeKey is part of the public API surface).
+void (null as unknown as EdgeKey | null);

--- a/tests/temporal-layout-consistency.test.ts
+++ b/tests/temporal-layout-consistency.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import { Layout as ColaLayout } from 'webcola';
 import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
 import { parseLayoutSpec } from '../src/layout/layoutspec';
 import { LayoutInstance } from '../src/layout/layoutinstance';
@@ -12,12 +11,12 @@ import {
 } from '../src/layout/interfaces';
 import {
   WebColaTranslator,
-  WebColaLayout,
   WebColaLayoutOptions,
   NodePositionHint,
   LayoutState,
   NodeWithMetadata,
 } from '../src/translators/webcola/webcolatranslator';
+import { runHeadlessLayout } from '../src/evaluation';
 
 /**
  * Test for sequence layout rendering consistency.
@@ -560,28 +559,12 @@ describe('Sequence Layout Consistency', () => {
       return base + adaptive;
     }
 
-    /**
-     * Run cola.Layout on a translated WebColaLayout. Mirrors the
-     * production setup in webcola-cnd-graph.ts (avoidOverlaps,
-     * handleDisconnected, reduced iterations) without needing d3 or DOM.
-     */
-    function runSolver(layout: WebColaLayout): NodeWithMetadata[] {
-      const colaLayout = new ColaLayout()
-        .linkDistance(150)
-        .convergenceThreshold(0.1)
-        .avoidOverlaps(true)
-        .handleDisconnected(true)
-        .nodes(layout.colaNodes as any)
-        .links(layout.colaEdges as any)
-        .constraints(layout.colaConstraints as any[])
-        .size([layout.FIG_WIDTH, layout.FIG_HEIGHT]);
-
-      // Match the reduced-iterations path used in production when
-      // prior positions are present (webcola-cnd-graph.ts:1764-1772).
-      colaLayout.start(0, 10, 20, 1);
-
-      return layout.colaNodes;
-    }
+    // The previously-inline `runSolver` helper has been promoted to
+    // the public evaluation API as `runHeadlessLayout`
+    // (src/evaluation/headless-layout.ts) so downstream consistency
+    // analysis (e.g., the thesis evaluation repo) can drive the same
+    // pipeline. These tests now consume that public path, which is the
+    // best on-going test of it.
 
     /**
      * Walk the original LayoutConstraints and assert each is satisfied
@@ -631,18 +614,9 @@ describe('Sequence Layout Consistency', () => {
       }
     }
 
-    const layoutInstance = (instance: JSONDataInstance) => {
-      const evaluator = createEvaluator(instance);
-      return new LayoutInstance(layoutSpec, evaluator, 0, true);
-    };
-
     it('locked endpoints stay near prior positions AND constraint stays satisfied (satisfied prior)', async () => {
       // jsonData1 has A→B; layoutSpec puts A left of B. Prior positions
       // already satisfy the LeftConstraint with comfortable slack.
-      const instance = new JSONDataInstance(jsonData1);
-      const li = layoutInstance(instance);
-      const { layout } = li.generateLayout(instance);
-
       const priorPositions: LayoutState = {
         positions: [
           { id: 'A', x: 200, y: 400 },
@@ -652,21 +626,18 @@ describe('Sequence Layout Consistency', () => {
         transform: { k: 1, x: 0, y: 0 },
       };
 
-      const translator = new WebColaTranslator();
-      const webcolaLayout = await translator.translate(layout, 800, 600, {
+      const result = await runHeadlessLayout(layoutSpec, new JSONDataInstance(jsonData1), {
         priorPositions,
         lockUnconstrainedNodes: true,
       });
 
-      runSolver(webcolaLayout);
-
       // The constraint must hold at the final positions.
-      assertAllConstraintsSatisfied(layout.constraints, webcolaLayout.colaNodes);
+      assertAllConstraintsSatisfied(result.constraints, result.nodes);
 
       // And locks should have held: the post-solver positions should
       // be near the prior ones for nodes whose constraints were satisfied.
       // Use a generous drift bound (50px) — the lock isn't a hard pin.
-      const finalById = new Map(webcolaLayout.colaNodes.map(n => [n.id, n]));
+      const finalById = new Map(result.nodes.map(n => [n.id, n]));
       for (const prior of priorPositions.positions) {
         const finalNode = finalById.get(prior.id)!;
         const drift = Math.hypot(
@@ -683,10 +654,6 @@ describe('Sequence Layout Consistency', () => {
     it('repairs violated constraint at prior positions (both endpoints unfixed)', async () => {
       // Same instance, but prior positions VIOLATE the LeftConstraint:
       // A.x > B.x. Both should be unfixed and the solver should repair.
-      const instance = new JSONDataInstance(jsonData1);
-      const li = layoutInstance(instance);
-      const { layout } = li.generateLayout(instance);
-
       const priorPositions: LayoutState = {
         positions: [
           { id: 'A', x: 600, y: 400 },
@@ -696,61 +663,43 @@ describe('Sequence Layout Consistency', () => {
         transform: { k: 1, x: 0, y: 0 },
       };
 
-      const translator = new WebColaTranslator();
-      const webcolaLayout = await translator.translate(layout, 800, 600, {
+      const result = await runHeadlessLayout(layoutSpec, new JSONDataInstance(jsonData1), {
         priorPositions,
         lockUnconstrainedNodes: true,
       });
 
-      runSolver(webcolaLayout);
-
       // The constraint must hold at the final positions.
-      assertAllConstraintsSatisfied(layout.constraints, webcolaLayout.colaNodes);
+      assertAllConstraintsSatisfied(result.constraints, result.nodes);
     });
 
     it('places a new node so all constraints are satisfied (mixed prior)', async () => {
       // Start with A,B; new state has A,B,C plus chain A→B→C.
       // Provide priors only for A and B (C is new). Solver must place C
       // such that LeftConstraint(B,C) and LeftConstraint(A,B) both hold.
-      const instance1 = new JSONDataInstance(jsonData1);
-      const evaluator1 = createEvaluator(instance1);
-      const layoutInstance1 = new LayoutInstance(layoutSpec, evaluator1, 0, true);
-      const { layout: layout1 } = layoutInstance1.generateLayout(instance1);
-      const translator = new WebColaTranslator();
-      const result1 = await translator.translate(layout1, 800, 600);
-      const aNode = result1.colaNodes.find(n => n.id === 'A')!;
-      const bNode = result1.colaNodes.find(n => n.id === 'B')!;
+      const baseline = await runHeadlessLayout(layoutSpec, new JSONDataInstance(jsonData1));
+      const aPos = baseline.positions.positions.find(p => p.id === 'A')!;
+      const bPos = baseline.positions.positions.find(p => p.id === 'B')!;
 
       const priorPositions: LayoutState = {
         positions: [
-          { id: 'A', x: aNode.x ?? 200, y: aNode.y ?? 400 },
-          { id: 'B', x: bNode.x ?? 600, y: bNode.y ?? 400 },
+          { id: 'A', x: aPos.x, y: aPos.y },
+          { id: 'B', x: bPos.x, y: bPos.y },
           // C intentionally omitted — it's the "new" node.
         ],
         transform: { k: 1, x: 0, y: 0 },
       };
 
-      const instance2 = new JSONDataInstance(jsonData2);
-      const li2 = layoutInstance(instance2);
-      const { layout: layout2 } = li2.generateLayout(instance2);
-
-      const webcolaLayout = await translator.translate(layout2, 800, 600, {
+      const result = await runHeadlessLayout(layoutSpec, new JSONDataInstance(jsonData2), {
         priorPositions,
         lockUnconstrainedNodes: true,
       });
 
-      runSolver(webcolaLayout);
-
       // Every constraint in the new layout must hold post-solve.
-      assertAllConstraintsSatisfied(layout2.constraints, webcolaLayout.colaNodes);
+      assertAllConstraintsSatisfied(result.constraints, result.nodes);
     });
 
     it('legacy mode (lockUnconstrainedNodes=false) also satisfies constraints', async () => {
       // Sanity check that the legacy path didn't regress.
-      const instance = new JSONDataInstance(jsonData1);
-      const li = layoutInstance(instance);
-      const { layout } = li.generateLayout(instance);
-
       const priorPositions: LayoutState = {
         positions: [
           { id: 'A', x: 200, y: 400 },
@@ -760,14 +709,12 @@ describe('Sequence Layout Consistency', () => {
         transform: { k: 1, x: 0, y: 0 },
       };
 
-      const translator = new WebColaTranslator();
-      const webcolaLayout = await translator.translate(layout, 800, 600, {
+      const result = await runHeadlessLayout(layoutSpec, new JSONDataInstance(jsonData1), {
         priorPositions,
         // lockUnconstrainedNodes intentionally omitted (false).
       });
 
-      runSolver(webcolaLayout);
-      assertAllConstraintsSatisfied(layout.constraints, webcolaLayout.colaNodes);
+      assertAllConstraintsSatisfied(result.constraints, result.nodes);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a small, documented public surface so downstream consistency analysis can drive the spytial-core layout pipeline headlessly and score sequence-policy output against Penlloy's two consistency metrics — without coupling library refactors to thesis evidence by committing benchmark fixtures into this repo.

The Guzdial chart for the thesis proposal places the realization-policy work under RQ6 and explicitly **separates two evaluation claims** (per `Thesis_Proposal/guzdial-chart.md`):

1. **Definitional (analytical, no users).** *"{spytial}'s realization policies achieve Liang et al.'s consistency types according to Penlloy's own optimization formulation."* Falsifiable by computing two scalar metrics on policy output. **This is the {spytial}-specific contribution.**
2. **Behavioral (user study).** Out of scope for the codebase.

This PR instruments the library to make claim 1 testable by anyone — in-repo CI for the four built-in policies, externally for richer benchmarks (CLRS sequences, algorithm visualizations, etc.).

## Public API (re-exported from package root)

| Export | What it does |
|---|---|
| `runHeadlessLayout(spec, instance, options)` | `LayoutInstance → WebColaTranslator → cola.Layout` end-to-end, no DOM. Mirrors the production reduced-iterations path used when prior positions are present (`webcola-cnd-graph.ts:1764-1772`). |
| `positionalConsistency(prev, curr, restrictTo?)` | `Σ ‖D(n) − D'(n)‖²` over persisting nodes. Penlloy §6.2 verbatim. |
| `relativeConsistency(prev, prevEdges, curr, currEdges, restrictTo?)` | `Σ ‖(D(n₂) − D(n₁)) − (D'(n₂) − D'(n₁))‖²` over persisting edges. Same source. |
| `classifyChangeEmphasisStableSet(prior, policyOutput)` | Recovers the stable subset for a `stable-node-reflow`-style policy by observing which output positions equal prior positions. No SequencePolicy interface change needed. |

`docs/evaluation-api.md` documents the recipe with a worked example and notes the soft-vs-hard consistency framing.

## In-repo tests

`tests/sequence-policy-consistency-metrics.test.ts` is structured one `describe` per policy, where each describe states the policy's promise in its name and asserts it post-solver:

- **`stability` — soft-positional consistency.** Identity scenario drift is bounded; on every changing scenario, drift over the persisting subset is ≤ `ignoreHistory`'s drift on the same subset. (Hard consistency would require `= 0` strictly; spytial-core is soft because the lock spring is finite and the constraint-aware post-pass can unfix endpoints to satisfy new constraints.)
- **`changeEmphasis` — stable subset preserved, reflow on changed nodes.** On a relation-change scenario, classify the stable subset via `classifyChangeEmphasisStableSet`, then assert per-node drift over reflow exceeds per-node drift over stable. Identity scenario produces no reflow.
- **`ignoreHistory` — fresh layout per step.** Unit-level: `apply` returns `effectivePriorState: undefined`. Behavioral: a contrived `(0,0)` prior that the policy must IGNORE produces post-solver positions far from `(0,0)`.
- **`randomPositioning` — randomize within bounds.** Unit-level: `apply` returns positions inside the requested viewport. (No end-to-end "drift exceeds X" — when random seeds violate hard constraints, the constraint-aware post-pass unfixes endpoints and the solver re-converges, which on a small graph happens to coincide with the prior layout. That's geometry, not a regression.)
- **Cross-policy.** On a *changing* scenario (atom-add), `stability` drift ≤ `ignoreHistory` drift over the persisting subset.

This is the next layer up from `tests/sequence-policy.test.ts` (which unit-tests `apply` outputs); these tests exercise what the *full pipeline* actually produces.

## Refactor

The inline `runSolver` helper in `tests/temporal-layout-consistency.test.ts` is replaced by `runHeadlessLayout` — the public API is now the single source of truth, and the existing post-solver tests dogfood it.

## What stays out

- Richer benchmark scenarios (CLRS, algorithm visualizations, Liang-style state-pair suites).
- The characterization script that walks a benchmark × policy matrix and emits the appendix table.
- The appendix table itself.

These belong in the thesis evaluation repo that depends on a pinned spytial-core version. Out of scope for this PR by design — that's the architectural choice this PR enables.

## Test plan

- [x] `npm run test:run -- tests/sequence-policy-consistency-metrics.test.ts` — all 12 new tests pass.
- [x] `npm run test:run -- tests/temporal-layout-consistency.test.ts` — all 15 existing tests still pass after the refactor.
- [x] `npm run build:all` — clean, no errors or warnings.
- [x] Ad-hoc check: `npx tsx` import of the public API from outside `tests/` produces a sensible scalar (`positional = 0 px²` on a stability-friendly atom-add scenario).
- [ ] Visual / behavioral verification — N/A; this is pure-math instrumentation, no rendering changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)