### PR TITLE
Mental-map appropriateness experiment harness

### DIFF
--- a/docs/MENTAL_MAP_ORACLE_COMPLEXITY.md
+++ b/docs/MENTAL_MAP_ORACLE_COMPLEXITY.md
@@ -1,0 +1,207 @@
+# Computing "the mental-map-preserving thing": complexity notes
+
+This doc records the computational difficulty of producing
+constraint-feasible oracle layouts against which warm-start policies
+can be scored. It is the companion to
+`src/evaluation/oracle-layouts.ts` — the file builds the two oracles
+that are tractable; this file explains why the others aren't (yet).
+
+## Setup
+
+For each transition the appropriateness experiment wants
+
+```
+L_oracle = argmin_L  d_mental_map(L, prior)
+            s.t.    L satisfies the new hard constraints
+```
+
+with `d_mental_map` a chosen criterion. Then per policy P,
+
+```
+gap(P) = positionalConsistency(P_output, L_oracle)
+```
+
+is the appropriateness score: how far the policy lands from the
+constraint-feasible mental-map optimum.
+
+The complexity of the experiment is dominated by the cost of computing
+`L_oracle` per criterion. Below, *N* = number of persisting nodes,
+*C* = number of hard constraints, *K* = solver iterations.
+
+## Tractable oracles (shipped in v1)
+
+### 1. Positional oracle — `positionalOracle`
+
+```
+argmin  Σ_n ‖L(n) − prior(n)‖²
+s.t.    Left / Top / Alignment constraints
+```
+
+**Complexity.** Quadratic objective, linear constraints — a quadratic
+program. Kiwi.js (Cassowary's incremental simplex) handles the
+weak-edit-variable formulation we use in **near-linear** time per
+edit on typical inputs:
+
+- One-shot solve: `O(N + C)` constraint setup, then incremental
+  simplex with empirical scaling close to `O((N + C) · log)`.
+- Practical cost on spytial-sized graphs (≤ 50 nodes, ≤ 100
+  constraints): well under 1 ms.
+
+**Why we ship it.** It is the layout `stability` is *trying* to
+reach. `gap_positional(stability)` ≈ 0 is therefore a sanity check on
+the WebCola hint-pass — a regression test that fails noisily.
+
+### 2. Pairwise-distance oracle — `pairwiseDistanceOracle`
+
+```
+argmin  Σ_{i<j} (d_L(i,j) − d_prior(i,j))²
+s.t.    Left / Top / Alignment constraints
+```
+
+**Complexity.** Smooth non-convex objective, linear constraints.
+Implemented as cola.Layout's stress majorization with one virtual link
+per node pair:
+
+- Setup: `O(N²)` virtual links + `O(C)` constraints.
+- Per iteration: `O(N² + C)` (pair-stress evaluation + VPSC sweep).
+- Total: `O(K · (N² + C))`, K ≈ 30 iterations sufficient for spytial
+  sizes.
+
+**Why we ship it.** The natural numerical realization of Liang TOSEM
+2026 §3.4 partial-consistency ("key substructures maintain shape").
+Translation/rotation invariant, so it captures the
+mental-map-shape question independently of where on the canvas the
+configuration sits.
+
+## Deferred oracles
+
+These all answer well-formed questions about mental-map preservation,
+but no one of them is computable in polynomial time on the general
+case. The metrics from `consistency-metrics.ts` still *measure*
+preservation along these axes; we just lack a per-criterion optimum
+to score the gap against.
+
+### 3. Orthogonal-ordering oracle (Misue criterion 1)
+
+```
+maximize  | { (i,j) : prev_x_relation(i,j) preserved AND
+                     prev_y_relation(i,j) preserved } |
+s.t.      Left / Top / Alignment constraints
+```
+
+**Complexity.** Each persisting pair contributes a soft satisfaction
+term (preserve x relation? preserve y relation?). Maximizing the count
+under hard linear constraints is **MaxSAT / mixed-integer
+programming**: NP-hard in general (special cases of betweenness and
+linear extensions are NP-complete; Garey & Johnson 1979).
+
+- LP relaxation gives a polynomial-time approximation but no exact
+  optimum.
+- Exact methods (branch-and-bound on `N(N-1)/2` Boolean choices)
+  scale to ~30 nodes before becoming impractical.
+- A practical alternative is to enumerate a heuristic preserved subset
+  via topological sort of the prev x / y orders intersected with the
+  constraint feasibility cone, but the result is not the optimum.
+
+**What this means for spytial.** The metric
+`orthogonalOrderingPreservation` is computable in `O(N²)`, so we can
+report the score for any policy. But "the actual ordering-optimal
+feasible layout" requires NP-hard search; we do not compute it.
+
+### 4. k-NN proximity oracle (Misue criterion 2)
+
+```
+maximize  Σ_n |knn_prev(n) ∩ knn_L(n)| / |knn_prev(n) ∪ knn_L(n)|
+s.t.      Left / Top / Alignment constraints
+```
+
+**Complexity.** The objective is **discrete and non-local**: the
+k-nearest-neighbor set of node `n` jumps as positions cross
+equidistance hyperplanes. The objective is piecewise constant in `L`
+with combinatorially many pieces (`O(N^k)` cells in the worst case).
+
+- Bilevel formulations exist (one level picks neighborhood
+  assignments, the other minimizes positional deviation under those
+  assignments) but yield non-convex problems with `O(N^k)`
+  combinatorial structure.
+- Smooth relaxations (e.g., bias toward prior k-NN distances) give a
+  pwd-like proxy — which is exactly what the
+  `pairwise-distance oracle` already does, locally.
+- No standard exact algorithm. Survey: Kuhn et al., "Distance
+  metric learning under positional constraints" (line of work that
+  formalizes the smoothed problem).
+
+**What this means for spytial.** `knnJaccard` is computable
+(`O(N²)` per evaluation). The optimum under hard constraints is not
+practically computable for `N` beyond ~10 without heuristic
+relaxation.
+
+### 5. Edge-crossings oracle (related, often grouped with mental map)
+
+```
+minimize  number of strict edge-segment crossings in L
+s.t.      Left / Top / Alignment constraints
+```
+
+**Complexity.** Minimum-crossing layout is **NP-hard** even
+unconstrained (Garey & Johnson 1983). Adding hard constraints does not
+help. Practical approaches are either:
+
+- ILP with `O(E²)` Boolean crossing variables — feasible up to ~100
+  edges with a real solver.
+- Heuristic: orthogonal layout algorithms with
+  bend / crossing minimization (Tamassia 1987), which trade exactness
+  for speed.
+
+We compute and report `edgeCrossings` and `edgeCrossingsDelta` but do
+not compute a per-transition crossings-minimal oracle.
+
+### 6. "The actual mental map" — composite
+
+A unified oracle that combines criteria 1–4 (and possibly 5) into one
+objective requires **a weighting choice that the literature does not
+provide** — Misue, Liang, and Archambault each propose different
+emphases, and Archambault's empirical critique is precisely that
+combining them does not predict user success.
+
+**Complexity.** Inherits from the worst constituent: NP-hard, since
+the orthogonal-ordering and edge-crossings components alone are
+NP-hard. Even if a weighting were agreed upon, the composite is
+intractable on the same scales as criterion 3.
+
+**Practical implication.** The "actual" mental-map-preserving thing
+is not computable as a closed-form optimum. The two oracles we ship
+are the **tractable proxies** that operationalize the dimensions
+where convex / smooth optimization applies.
+
+## Summary table
+
+| Oracle / criterion         | Objective                       | Constraints | Complexity                         | Shipped |
+|----------------------------|---------------------------------|-------------|------------------------------------|---------|
+| Positional (Penlloy)       | quadratic                       | linear      | poly (Cassowary, near-linear)      | yes     |
+| Pairwise-distance (Liang)  | smooth non-convex (stress)      | linear      | `O(K · (N² + C))`, K ≈ 30          | yes     |
+| Orthogonal ordering (Misue 1) | combinatorial count          | linear      | NP-hard (MaxSAT / MIP)             | no      |
+| k-NN proximity (Misue 2)   | discrete non-local              | linear      | NP-hard / bilevel                  | no      |
+| Edge crossings             | combinatorial count             | linear      | NP-hard (Garey & Johnson 1983)     | no      |
+| Composite "mental map"     | weighted sum of all above       | linear      | NP-hard                            | no      |
+
+## What the experiment loses by the deferrals
+
+- **`gap_positional`** is computable for every policy → sub-claim
+  "warm-start matters at all" is fully testable in absolute units.
+- **`gap_pwd`** is computable for every policy → sub-claim
+  "appropriate warm-start preserves shape" is fully testable in
+  absolute units against the Liang shape-preservation optimum.
+- **No `gap_oop`, `gap_knn`, or `gap_crossings`** — for these we
+  report the raw metric per policy (computable in `O(N²)` per
+  evaluation) and rely on **relative** comparison across policies
+  rather than absolute distance from an optimum.
+
+The four-level appropriateness gradient
+(`random → ignore → change_emphasis → stability`) plus relative
+comparison covers the deferred dimensions adequately for sub-claim
+2 ("choice of warm-start matters") even without their per-criterion
+oracles. The two shipped oracles cover sub-claim 3 ("appropriate
+preserves the mental map") for the dimensions where exact optima are
+tractable. Promoting the deferred dimensions to oracles would mostly
+sharpen reporting magnitudes, not change the experiment's structure.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.5.2",
+  "version": "2.5.3-beta.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/evaluation/consistency-metrics.ts
+++ b/src/evaluation/consistency-metrics.ts
@@ -1,44 +1,52 @@
 /**
  * Visual-consistency metrics for sequence-policy output. Each metric
  * compares two LayoutStates (a previous frame D′ and a current frame D)
- * and is a non-negative scalar that is 0 exactly when its specific
+ * and is a scalar that takes a specific extreme value exactly when its
  * notion of consistency holds.
  *
- * The three metrics here come from different sources and capture
- * different intuitions about what "consistency between frames" means:
+ * The module hosts two metric lineages:
+ *
+ * **Penlloy / Liang (squared-error consistency).** Source: Liang,
+ * Palliyil, Kang, Sunshine, "Towards Better Formal Methods
+ * Visualizations," PLATEAU 2025 §6.2 ("Penlloy"); equivalent to cells
+ * of Liang et al.'s TOSEM 2026 hard/soft × positional/relative
+ * taxonomy. Each metric is a non-negative scalar, 0 when its consistency
+ * notion holds:
  *
  *   • positional        — per-node coordinate preservation.
- *                         Source: Liang, Palliyil, Kang, Sunshine,
- *                           "Towards Better Formal Methods Visualizations,"
- *                           PLATEAU 2025 §6.2 ("Penlloy"); equivalent to
- *                           the positional cell of Liang et al.'s TOSEM 2026
- *                           hard/soft × positional/relative taxonomy.
- *
- *   • relative          — per-edge vector preservation.
- *                         Source: Penlloy §6.2; cited identically in
- *                           Liang TOSEM 2026 §2.6.1, where it is described
- *                           as "the changes to the relative positions
- *                           between nodes related by edges."
- *                         Note: only persisting EDGES contribute. Two nodes
- *                           that are not connected by an edge are not
- *                           compared, even if they exist in both frames.
- *
+ *   • relative          — per-edge vector preservation. Only persisting
+ *                         EDGES contribute.
  *   • pairwiseDistance  — per-pair Euclidean-distance preservation.
- *                         Source: a computational version of Liang TOSEM
- *                           2026 §3.4 partial-consistency operationalization
- *                           ("key substructures … maintain their overall
- *                           shape and relative positioning across states"),
- *                           which they apply by manual annotation of
- *                           visualizations. Pairwise-distance preservation
- *                           is the natural numeric realization: it is 0 iff
- *                           the persisting subset's shape (its
- *                           pairwise-distance matrix) is preserved, and is
- *                           invariant under translation and rotation of the
- *                           subset as a whole.
+ *                         Computational realization of Liang TOSEM
+ *                         §3.4: 0 iff the persisting subset's pairwise-
+ *                         distance matrix is preserved, invariant under
+ *                         translation and rotation of the subset.
  *
- * All three sum ONLY over elements that persist across the two frames.
- * "Persisting" means present in both D′ and D — added/removed nodes or
- * edges contribute nothing.
+ * **Misue 1995 (mental-map battery).** Source: Misue, Eades, Lai,
+ * Sugiyama, "Layout adjustment and the mental map," JVLC 1995. Three
+ * operational criteria for whether a reader's cognitive representation
+ * survives a transition:
+ *
+ *   • orthogonalOrderingPreservation — fraction of node pairs whose
+ *                         left/right + up/down ordering survived. 1 = all
+ *                         pairs preserved.
+ *   • knnJaccard        — mean Jaccard overlap of each persisting
+ *                         node's k-nearest-neighbor set across the two
+ *                         frames. 1 = every node's neighborhood
+ *                         preserved.
+ *   • edgeCrossings /
+ *     edgeCrossingsDelta — number of edge-segment crossings; 0 = none.
+ *                         Delta = absolute change between frames.
+ *   • directionalCoherence — mean resultant length of unit
+ *                         displacement vectors over a node set. 1 = all
+ *                         moving the same direction.
+ *   • stableQuietRatio  — fraction of "stable" nodes whose displacement
+ *                         is below a threshold. 1 = the still part is
+ *                         truly still.
+ *
+ * All metrics in both lineages sum/average ONLY over elements that
+ * persist across the two frames. "Persisting" means present in both D′
+ * and D — added/removed nodes or edges contribute nothing.
  *
  * These functions are evaluation infrastructure: used by in-repo
  * assertion tests that defend the realization-policy claims, by the
@@ -53,6 +61,7 @@ import {
   type LayoutConstraint,
 } from '../layout/interfaces';
 import type { LayoutState } from '../translators/webcola/webcolatranslator';
+import { positionalOracle } from './oracle-layouts';
 
 /**
  * Edge identity used to determine persistence between two frames.
@@ -548,4 +557,373 @@ export function classifyChangeEmphasisStableSet(
     }
   }
   return stable;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Misue mental-map battery
+//
+// Misue, Eades, Lai, Sugiyama, "Layout adjustment and the mental
+// map," JVLC 1995. Three operational criteria for mental-map
+// preservation across a transition: orthogonal ordering, k-NN
+// proximity, topological structure (the last realized as
+// pairwiseDistanceConsistency above). The metrics below cover the
+// remaining mental-map dimensions plus two related diagnostics
+// (edge crossings, directional coherence, stable quiet ratio).
+//
+// All metrics consider ONLY persisting nodes/edges. A metric is
+// `null` when there is no data to compute it (e.g., < 2 persisting
+// nodes for a pair-based metric).
+// ──────────────────────────────────────────────────────────────────
+
+/**
+ * Edge shape used by the crossings metrics. Only `source` and `target`
+ * are read; any superset (such as `EdgeKey`) is accepted.
+ */
+export interface CrossingEdge {
+  source: string;
+  target: string;
+}
+
+/**
+ * Strict line-segment intersection test (no endpoint touches counted).
+ * Mirrors the CCW predicate used in derived_metrics.py:_segments_cross.
+ */
+function segmentsCross(
+  p1: { x: number; y: number },
+  p2: { x: number; y: number },
+  q1: { x: number; y: number },
+  q2: { x: number; y: number }
+): boolean {
+  // Reject incident edges (shared endpoints).
+  if ((p1.x === q1.x && p1.y === q1.y) || (p1.x === q2.x && p1.y === q2.y)) return false;
+  if ((p2.x === q1.x && p2.y === q1.y) || (p2.x === q2.x && p2.y === q2.y)) return false;
+
+  const ccw = (
+    a: { x: number; y: number },
+    b: { x: number; y: number },
+    c: { x: number; y: number }
+  ): number => (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+
+  const d1 = ccw(q1, q2, p1);
+  const d2 = ccw(q1, q2, p2);
+  const d3 = ccw(p1, p2, q1);
+  const d4 = ccw(p1, p2, q2);
+  return ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+         ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0));
+}
+
+/**
+ * Orthogonal ordering preservation (Misue 1995, criterion 1):
+ *
+ *     fraction of unordered pairs (i, j) ∈ persisting × persisting
+ *     such that the L/R relation between i and j AND the U/D relation
+ *     between i and j are both the same in prev and curr.
+ *
+ * Returns a number in [0, 1], or `null` when fewer than 2 persisting
+ * nodes exist.
+ *
+ * @param prev       Previous-frame layout state.
+ * @param curr       Current-frame layout state.
+ * @param restrictTo If provided, only nodes whose id is in this set
+ *                   (still requiring presence in both frames) form
+ *                   pairs.
+ */
+export function orthogonalOrderingPreservation(
+  prev: LayoutState,
+  curr: LayoutState,
+  restrictTo?: Set<string>
+): number | null {
+  const prevPos = buildPositionMap(prev);
+  const currPos = buildPositionMap(curr);
+
+  const ids: string[] = [];
+  for (const [id] of currPos) {
+    if (!prevPos.has(id)) continue;
+    if (restrictTo && !restrictTo.has(id)) continue;
+    ids.push(id);
+  }
+  ids.sort();
+
+  if (ids.length < 2) return null;
+
+  let preserved = 0;
+  let total = 0;
+  for (let a = 0; a < ids.length; a++) {
+    const ip = prevPos.get(ids[a])!;
+    const ic = currPos.get(ids[a])!;
+    for (let b = a + 1; b < ids.length; b++) {
+      const jp = prevPos.get(ids[b])!;
+      const jc = currPos.get(ids[b])!;
+
+      const xSame =
+        (ip.x < jp.x && ic.x < jc.x) ||
+        (ip.x > jp.x && ic.x > jc.x) ||
+        (ip.x === jp.x && ic.x === jc.x);
+      const ySame =
+        (ip.y < jp.y && ic.y < jc.y) ||
+        (ip.y > jp.y && ic.y > jc.y) ||
+        (ip.y === jp.y && ic.y === jc.y);
+
+      if (xSame && ySame) preserved += 1;
+      total += 1;
+    }
+  }
+  return total === 0 ? null : preserved / total;
+}
+
+/**
+ * k-nearest-neighbor Jaccard preservation (Misue 1995, criterion 2):
+ *
+ *     mean over persisting nodes n of  |knn_prev(n) ∩ knn_curr(n)|
+ *                                      ────────────────────────────
+ *                                      |knn_prev(n) ∪ knn_curr(n)|
+ *
+ * Each node's k-NN is computed within the persisting subset only (its
+ * neighbors in `prev` are restricted to nodes that also persist).
+ * Returns a number in [0, 1], or `null` when fewer than k+1 persisting
+ * nodes exist.
+ *
+ * @param prev       Previous-frame layout state.
+ * @param curr       Current-frame layout state.
+ * @param k          Neighborhood size. Default 3.
+ * @param restrictTo If provided, only nodes whose id is in this set
+ *                   (and persist in both frames) participate.
+ */
+export function knnJaccard(
+  prev: LayoutState,
+  curr: LayoutState,
+  k: number = 3,
+  restrictTo?: Set<string>
+): number | null {
+  const prevPos = buildPositionMap(prev);
+  const currPos = buildPositionMap(curr);
+
+  const ids: string[] = [];
+  for (const [id] of currPos) {
+    if (!prevPos.has(id)) continue;
+    if (restrictTo && !restrictTo.has(id)) continue;
+    ids.push(id);
+  }
+  ids.sort();
+
+  if (ids.length < k + 1) return null;
+
+  const nearestK = (
+    posMap: Map<string, { x: number; y: number }>,
+    queryId: string
+  ): Set<string> => {
+    const q = posMap.get(queryId)!;
+    const dists: Array<{ id: string; d: number }> = [];
+    for (const other of ids) {
+      if (other === queryId) continue;
+      const o = posMap.get(other)!;
+      dists.push({ id: other, d: Math.hypot(o.x - q.x, o.y - q.y) });
+    }
+    dists.sort((a, b) => (a.d - b.d) || a.id.localeCompare(b.id));
+    return new Set(dists.slice(0, k).map(d => d.id));
+  };
+
+  let totalOverlap = 0;
+  let count = 0;
+  for (const id of ids) {
+    const a = nearestK(prevPos, id);
+    const b = nearestK(currPos, id);
+    const union = new Set([...a, ...b]);
+    if (union.size === 0) continue;
+    let inter = 0;
+    for (const x of a) if (b.has(x)) inter += 1;
+    totalOverlap += inter / union.size;
+    count += 1;
+  }
+  return count === 0 ? null : totalOverlap / count;
+}
+
+/**
+ * Number of edge-segment crossings in a single layout. Strict
+ * crossings only — segments that meet at a shared endpoint (incident
+ * edges) do not count.
+ *
+ * @param state   Layout state with positions for the relevant nodes.
+ * @param edges   Edges to test. Edges referencing absent nodes are
+ *                silently skipped.
+ */
+export function edgeCrossings(
+  state: LayoutState,
+  edges: CrossingEdge[]
+): number {
+  const pos = buildPositionMap(state);
+  const segments: Array<{
+    a: { x: number; y: number };
+    b: { x: number; y: number };
+  }> = [];
+  for (const e of edges) {
+    const a = pos.get(e.source);
+    const b = pos.get(e.target);
+    if (!a || !b) continue;
+    segments.push({ a, b });
+  }
+
+  let crossings = 0;
+  for (let i = 0; i < segments.length; i++) {
+    for (let j = i + 1; j < segments.length; j++) {
+      if (segmentsCross(segments[i].a, segments[i].b, segments[j].a, segments[j].b)) {
+        crossings += 1;
+      }
+    }
+  }
+  return crossings;
+}
+
+/**
+ * Absolute change in edge-crossing count between two frames.
+ *
+ *     |edgeCrossings(curr, currEdges) − edgeCrossings(prev, prevEdges)|
+ *
+ * 0 when the visual entanglement is unchanged. The metric does not
+ * require persisting edges — adding/removing edges contributes to the
+ * delta naturally through the per-frame counts.
+ */
+export function edgeCrossingsDelta(
+  prev: LayoutState,
+  prevEdges: CrossingEdge[],
+  curr: LayoutState,
+  currEdges: CrossingEdge[]
+): number {
+  return Math.abs(edgeCrossings(curr, currEdges) - edgeCrossings(prev, prevEdges));
+}
+
+/**
+ * Directional coherence of a node set's displacement.
+ *
+ *     | Σ_{n ∈ ids ∩ persisting, ‖d(n)‖>0}  d(n)/‖d(n)‖ |   /   N
+ *
+ * where d(n) = curr(n) − prev(n) and N is the number of nodes that
+ * actually moved (zero-drift nodes are excluded — their direction is
+ * undefined). Returns a number in [0, 1] (the resultant length of unit
+ * vectors), or `null` when no node in `ids` moved.
+ *
+ * Used downstream to test whether changed-context atoms move
+ * coherently (1.0 = same direction) versus chaotically (~0).
+ */
+export function directionalCoherence(
+  prev: LayoutState,
+  curr: LayoutState,
+  ids: Iterable<string>
+): number | null {
+  const prevPos = buildPositionMap(prev);
+  const currPos = buildPositionMap(curr);
+
+  let sx = 0;
+  let sy = 0;
+  let n = 0;
+  for (const id of ids) {
+    const p = prevPos.get(id);
+    const c = currPos.get(id);
+    if (!p || !c) continue;
+    const dx = c.x - p.x;
+    const dy = c.y - p.y;
+    const d = Math.hypot(dx, dy);
+    if (d === 0) continue;
+    sx += dx / d;
+    sy += dy / d;
+    n += 1;
+  }
+  if (n === 0) return null;
+  return Math.hypot(sx, sy) / n;
+}
+
+/**
+ * Fraction of "stable" nodes whose total displacement stayed below a
+ * pixel threshold.
+ *
+ *     |{ n ∈ stableIds ∩ persisting  :  ‖d(n)‖ ≤ threshold }|
+ *     ──────────────────────────────────────────────────────
+ *               |stableIds ∩ persisting|
+ *
+ * Returns a number in [0, 1] (1 = the part the policy claims is
+ * unchanged really did not move), or `null` when no stable id
+ * persists.
+ *
+ * @param prev       Previous-frame layout state.
+ * @param curr       Current-frame layout state.
+ * @param stableIds  Nodes the policy claims are unchanged this step.
+ * @param threshold  Per-node displacement tolerance in px. Default 5.
+ */
+export function stableQuietRatio(
+  prev: LayoutState,
+  curr: LayoutState,
+  stableIds: Iterable<string>,
+  threshold: number = 5
+): number | null {
+  const prevPos = buildPositionMap(prev);
+  const currPos = buildPositionMap(curr);
+
+  let total = 0;
+  let quiet = 0;
+  for (const id of stableIds) {
+    const p = prevPos.get(id);
+    const c = currPos.get(id);
+    if (!p || !c) continue;
+    total += 1;
+    if (Math.hypot(c.x - p.x, c.y - p.y) <= threshold) quiet += 1;
+  }
+  return total === 0 ? null : quiet / total;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Constraint-induced perturbation — moderator for the appropriateness
+// experiment.
+//
+// When new hard constraints push the prior layout outside the new
+// feasible region, no warm-start can fully preserve. Without measuring
+// this, "warm-start failure" gets mis-attributed to bad policy when it
+// was actually constraint-forced. constraintPerturbation answers: how
+// far does the prior layout sit from the new feasible region?
+// ──────────────────────────────────────────────────────────────────
+
+/**
+ * Total L2 displacement of the closest constraint-feasible projection
+ * of the prior positions onto the new constraint set.
+ *
+ *     Σ_{n ∈ persisting}  ‖ project(prior(n), feasible_new) − prior(n) ‖
+ *
+ * Returns a non-negative number. 0 means the prior layout already
+ * satisfies the new constraints (no constraint-induced perturbation
+ * is forced).
+ *
+ * Implementation: builds a Kiwi.js solver, soft-anchors each prior
+ * node at its prior `(x, y)` (weak edit variables — Kiwi minimizes
+ * squared deviation from suggested values), hard-adds Left/Top/Alignment
+ * constraints from `newConstraints`, solves, sums per-node displacement.
+ *
+ * Constraint types handled (matching the WebCola translator's Kiwi
+ * coverage in `constraint-validator.ts`): `LeftConstraint`,
+ * `TopConstraint`, `AlignmentConstraint`. `BoundingBoxConstraint` and
+ * `GroupBoundaryConstraint` are not Kiwi-translated today — they are
+ * silently skipped. New nodes referenced by constraints but absent
+ * from `prev` are given free variables (no anchor) so the constraint
+ * is expressible.
+ *
+ * @param prev            Previous-frame layout state.
+ * @param newConstraints  Constraint set in effect for the current frame.
+ */
+export function constraintPerturbation(
+  prev: LayoutState,
+  newConstraints: LayoutConstraint[]
+): number {
+  if (prev.positions.length === 0) return 0;
+
+  // Project the prior layout onto the new feasible region, then sum
+  // per-node L2 displacement. positionalOracle owns the Kiwi machinery;
+  // this metric is its scalar summary.
+  const projected = positionalOracle(prev, newConstraints);
+  const projectedById = new Map(projected.positions.map(p => [p.id, p]));
+
+  let total = 0;
+  for (const p of prev.positions) {
+    const q = projectedById.get(p.id);
+    if (!q) continue;
+    total += Math.hypot(q.x - p.x, q.y - p.y);
+  }
+  return total;
 }

--- a/src/evaluation/headless-layout.ts
+++ b/src/evaluation/headless-layout.ts
@@ -102,6 +102,15 @@ export interface HeadlessLayoutResult {
    * satisfaction.
    */
   nodes: NodeWithMetadata[];
+  /**
+   * Seed positions the applied policy returned before the solver ran,
+   * or `null` when no policy was applied (direct prior-positions path
+   * or first frame). Used for the seed-vs-output decomposition in the
+   * appropriateness experiment: the gap between metrics scored on
+   * `seed` versus `positions` attributes the effect to the policy or
+   * the solver.
+   */
+  seed: LayoutState | null;
 }
 
 const DEFAULT_FIG_WIDTH = 800;
@@ -142,6 +151,7 @@ export async function runHeadlessLayout(
   // Resolve translator options. Policy-driven path mirrors
   // webcola-cnd-graph.ts:1645-1678.
   let translatorOptions: WebColaLayoutOptions | undefined;
+  let seedState: LayoutState | null = null;
   if (options.policy && options.prevInstance && options.currInstance) {
     const priorState: LayoutState = options.priorPositions ?? {
       positions: [],
@@ -158,6 +168,13 @@ export async function runHeadlessLayout(
       translatorOptions = {
         priorPositions: policyResult.effectivePriorState,
         lockUnconstrainedNodes: policyResult.useReducedIterations,
+      };
+      // Snapshot the seed for the appropriateness-experiment
+      // decomposition. Deep-copied so downstream mutation of
+      // translator inputs doesn't bleed into the snapshot.
+      seedState = {
+        positions: policyResult.effectivePriorState.positions.map(p => ({ ...p })),
+        transform: { ...policyResult.effectivePriorState.transform },
       };
     }
   } else if (options.priorPositions) {
@@ -209,5 +226,6 @@ export async function runHeadlessLayout(
     edges,
     constraints: layout.constraints,
     nodes: webcolaLayout.colaNodes,
+    seed: seedState,
   };
 }

--- a/src/evaluation/index.ts
+++ b/src/evaluation/index.ts
@@ -50,7 +50,29 @@ export {
   changeEmphasisSeparation,
   constraintAdherence,
   classifyChangeEmphasisStableSet,
+  // Misue mental-map battery (JVLC 1995). Persisting-only; null when
+  // there's not enough data to compute.
+  orthogonalOrderingPreservation,
+  knnJaccard,
+  edgeCrossings,
+  edgeCrossingsDelta,
+  directionalCoherence,
+  stableQuietRatio,
+  // Constraint-perturbation moderator: distance from prior to the
+  // closest constraint-feasible projection.
+  constraintPerturbation,
   type EdgeKey,
+  type CrossingEdge,
   type ChangeEmphasisSeparation,
   type ConstraintAdherenceNode,
 } from './consistency-metrics';
+
+export {
+  // Oracle layouts for the appropriateness experiment. Tractable in
+  // v1: positional + pairwise-distance. See
+  // docs/MENTAL_MAP_ORACLE_COMPLEXITY.md for why other criteria are
+  // deferred.
+  positionalOracle,
+  pairwiseDistanceOracle,
+  type PairwiseDistanceOracleOptions,
+} from './oracle-layouts';

--- a/src/evaluation/oracle-layouts.ts
+++ b/src/evaluation/oracle-layouts.ts
@@ -1,0 +1,302 @@
+/**
+ * Oracle layouts for the appropriateness experiment.
+ *
+ * For each transition we want a reference layout `L_oracle` =
+ * "the mental-map-preserving feasible layout under the new hard
+ * constraints." Per policy P, the gap
+ *
+ *     gap(P) = positionalConsistency(P_output, L_oracle)
+ *
+ * measures appropriateness in absolute units. Smaller gap = more
+ * appropriate warm-start.
+ *
+ * Two oracles ship in v1:
+ *
+ *   • positionalOracle           — the constraint-feasible projection
+ *                                  of the prior layout.
+ *
+ *                                      L = argmin ‖L − prior‖²
+ *                                          s.t. L satisfies new constraints
+ *
+ *                                  Trivially tractable via Kiwi.js. By
+ *                                  construction this is the layout the
+ *                                  `stability` policy is *trying* to
+ *                                  reach, so `gap_positional(stability)`
+ *                                  is a sanity check (expected near
+ *                                  zero).
+ *
+ *   • pairwiseDistanceOracle     — the constraint-feasible layout
+ *                                  whose pairwise-distance matrix is
+ *                                  closest to prior's. Liang TOSEM
+ *                                  2026 §3.4 partial-consistency
+ *                                  ("key substructures maintain shape")
+ *                                  realized as a numerical optimum.
+ *                                  Implemented as cola.Layout with one
+ *                                  virtual link per node pair.
+ *
+ * Combinatorial oracles (orthogonal-ordering, k-NN-proximity) are
+ * deferred — see plan Phase 5e.
+ */
+
+import { Layout as ColaLayout } from 'webcola';
+import {
+  isLeftConstraint,
+  isTopConstraint,
+  isAlignmentConstraint,
+  type LayoutConstraint,
+} from '../layout/interfaces';
+import { Solver, Variable, Constraint as KiwiConstraint, Operator, Strength } from 'kiwi.js';
+import type { LayoutState } from '../translators/webcola/webcolatranslator';
+
+/**
+ * Constraint-feasible projection of the prior layout.
+ *
+ *     L_oracle_positional = argmin_L  Σ_n ‖L(n) − prior(n)‖²
+ *                            s.t.     L satisfies new hard constraints
+ *
+ * Returns a `LayoutState` containing one position per persisting node,
+ * with the same `transform` as the input (positions are in the same
+ * pre-transform coordinate space).
+ *
+ * Uses Kiwi.js: persisting nodes become weak edit-variables suggested
+ * at their prior position; constraints are added at `Strength.required`;
+ * Kiwi finds the closest feasible point via squared-deviation
+ * minimization.
+ *
+ * Constraint coverage matches the WebCola translator: `LeftConstraint`,
+ * `TopConstraint`, `AlignmentConstraint`. `BoundingBoxConstraint` and
+ * `GroupBoundaryConstraint` are not Kiwi-translated and are silently
+ * skipped.
+ */
+export function positionalOracle(
+  prev: LayoutState,
+  newConstraints: LayoutConstraint[]
+): LayoutState {
+  if (prev.positions.length === 0) {
+    return { positions: [], transform: { ...prev.transform } };
+  }
+
+  const priorMap = new Map(prev.positions.map(p => [p.id, { x: p.x, y: p.y }]));
+
+  const ids = new Set<string>(priorMap.keys());
+  for (const c of newConstraints) {
+    if (isLeftConstraint(c)) {
+      ids.add(c.left.id);
+      ids.add(c.right.id);
+    } else if (isTopConstraint(c)) {
+      ids.add(c.top.id);
+      ids.add(c.bottom.id);
+    } else if (isAlignmentConstraint(c)) {
+      ids.add(c.node1.id);
+      ids.add(c.node2.id);
+    }
+  }
+
+  const solver = new Solver();
+  const xs = new Map<string, Variable>();
+  const ys = new Map<string, Variable>();
+  for (const id of ids) {
+    xs.set(id, new Variable());
+    ys.set(id, new Variable());
+  }
+
+  for (const c of newConstraints) {
+    if (isLeftConstraint(c)) {
+      const lx = xs.get(c.left.id)!;
+      const rx = xs.get(c.right.id)!;
+      solver.addConstraint(
+        new KiwiConstraint(lx.plus(c.minDistance ?? 0), Operator.Le, rx, Strength.required)
+      );
+    } else if (isTopConstraint(c)) {
+      const ty = ys.get(c.top.id)!;
+      const by = ys.get(c.bottom.id)!;
+      solver.addConstraint(
+        new KiwiConstraint(ty.plus(c.minDistance ?? 0), Operator.Le, by, Strength.required)
+      );
+    } else if (isAlignmentConstraint(c)) {
+      const v1 = c.axis === 'x' ? xs.get(c.node1.id)! : ys.get(c.node1.id)!;
+      const v2 = c.axis === 'x' ? xs.get(c.node2.id)! : ys.get(c.node2.id)!;
+      solver.addConstraint(new KiwiConstraint(v1, Operator.Eq, v2, Strength.required));
+    }
+  }
+
+  for (const [id, p] of priorMap) {
+    solver.addEditVariable(xs.get(id)!, Strength.weak);
+    solver.addEditVariable(ys.get(id)!, Strength.weak);
+    solver.suggestValue(xs.get(id)!, p.x);
+    solver.suggestValue(ys.get(id)!, p.y);
+  }
+
+  solver.updateVariables();
+
+  const projected = prev.positions.map(p => ({
+    id: p.id,
+    x: xs.get(p.id)!.value(),
+    y: ys.get(p.id)!.value(),
+  }));
+
+  return { positions: projected, transform: { ...prev.transform } };
+}
+
+/**
+ * Options for `pairwiseDistanceOracle`.
+ */
+export interface PairwiseDistanceOracleOptions {
+  /**
+   * Cola iteration counts. Default 30 inner / 30 outer. Higher gives a
+   * tighter optimum at proportional cost. Test fixtures find ≥ 30
+   * iterations sufficient for graphs of typical spytial size (≤ 50
+   * nodes).
+   */
+  iterations?: number;
+  /** Figure width passed to cola.Layout. Default 800. */
+  figWidth?: number;
+  /** Figure height passed to cola.Layout. Default 600. */
+  figHeight?: number;
+}
+
+/**
+ * Constraint-feasible layout that minimizes pairwise-distance
+ * deviation from the prior layout.
+ *
+ *     L_oracle_pwd = argmin_L  Σ_{i,j} (d_L(i,j) − d_prior(i,j))²
+ *                    s.t.     L satisfies new hard constraints
+ *
+ * Implementation: cola.Layout's stress majorization minimizes exactly
+ * `Σ w_ij (d_L(i,j) − target_ij)²` subject to its separation
+ * constraints. We configure it with one virtual link per unordered
+ * pair `(i, j)` of persisting nodes, target length = prior Euclidean
+ * distance, and translate `LayoutConstraint`s into cola's
+ * `{type: 'separation', axis, left, right, gap}` form.
+ *
+ * Initialization is at prior positions. Pairwise-distance preservation
+ * is translation/rotation invariant, so the unconstrained optimum is a
+ * manifold; initializing at prior breaks the symmetry by picking the
+ * rigid-frame member closest to the prior layout. Under non-trivial
+ * constraints this initialization also speeds convergence.
+ *
+ * Constraint coverage matches `positionalOracle` —
+ * `LeftConstraint` / `TopConstraint` / `AlignmentConstraint` only.
+ */
+export function pairwiseDistanceOracle(
+  prev: LayoutState,
+  newConstraints: LayoutConstraint[],
+  options: PairwiseDistanceOracleOptions = {}
+): LayoutState {
+  if (prev.positions.length < 2) {
+    return {
+      positions: prev.positions.map(p => ({ ...p })),
+      transform: { ...prev.transform },
+    };
+  }
+
+  const iterations = options.iterations ?? 30;
+  const figWidth = options.figWidth ?? 800;
+  const figHeight = options.figHeight ?? 600;
+
+  // Cola identifies nodes by index. Build the index map first.
+  const idToIndex = new Map<string, number>();
+  prev.positions.forEach((p, i) => idToIndex.set(p.id, i));
+
+  // Cola mutates the node objects in place (sets x, y); make a working
+  // copy so the input LayoutState is not modified.
+  const nodes = prev.positions.map((p, i) => ({
+    index: i,
+    id: p.id,
+    x: p.x,
+    y: p.y,
+  }));
+
+  // One virtual link per unordered pair, target length = prior distance.
+  // Skip degenerate pairs (zero distance) — cola fails on length 0.
+  const links: Array<{ source: number; target: number; length: number }> = [];
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      const dx = nodes[i].x - nodes[j].x;
+      const dy = nodes[i].y - nodes[j].y;
+      const d = Math.hypot(dx, dy);
+      if (d > 0) {
+        links.push({ source: i, target: j, length: d });
+      }
+    }
+  }
+
+  // Translate Layout constraints to Cola separation constraints by
+  // index. Constraints referencing absent nodes are silently dropped
+  // (the oracle restricts to persisting nodes only).
+  const colaConstraints: Array<{
+    type: 'separation';
+    axis: 'x' | 'y';
+    left: number;
+    right: number;
+    gap: number;
+    equality?: boolean;
+  }> = [];
+  for (const c of newConstraints) {
+    if (isLeftConstraint(c)) {
+      const li = idToIndex.get(c.left.id);
+      const ri = idToIndex.get(c.right.id);
+      if (li !== undefined && ri !== undefined) {
+        colaConstraints.push({
+          type: 'separation',
+          axis: 'x',
+          left: li,
+          right: ri,
+          gap: c.minDistance ?? 0,
+        });
+      }
+    } else if (isTopConstraint(c)) {
+      const ti = idToIndex.get(c.top.id);
+      const bi = idToIndex.get(c.bottom.id);
+      if (ti !== undefined && bi !== undefined) {
+        colaConstraints.push({
+          type: 'separation',
+          axis: 'y',
+          left: ti,
+          right: bi,
+          gap: c.minDistance ?? 0,
+        });
+      }
+    } else if (isAlignmentConstraint(c)) {
+      const i1 = idToIndex.get(c.node1.id);
+      const i2 = idToIndex.get(c.node2.id);
+      if (i1 !== undefined && i2 !== undefined) {
+        colaConstraints.push({
+          type: 'separation',
+          axis: c.axis,
+          left: i1,
+          right: i2,
+          gap: 0,
+          equality: true,
+        });
+      }
+    }
+  }
+
+  const colaLayout = new ColaLayout()
+    .convergenceThreshold(0.01)
+    // Pure pairwise-distance preservation — overlap avoidance would
+    // add a competing objective the oracle is not asking for.
+    .avoidOverlaps(false)
+    .handleDisconnected(false)
+    .nodes(nodes as any)
+    .links(links as any)
+    .linkDistance((link: any) => link.length)
+    .constraints(colaConstraints as any[])
+    .size([figWidth, figHeight]);
+
+  // Stress-majorization phase, no descent / shake. The configuration
+  // matches the unconstrained-prior fixed point: starting at prior
+  // with target distances = prior distances, stress is exactly 0 and
+  // the layout is already optimal.
+  colaLayout.start(iterations, 0, 0, 0);
+
+  return {
+    positions: nodes.map(n => ({
+      id: n.id,
+      x: n.x,
+      y: n.y,
+    })),
+    transform: { ...prev.transform },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,10 +211,24 @@ export {
   changeEmphasisSeparation,
   constraintAdherence,
   classifyChangeEmphasisStableSet,
+  // Misue mental-map battery (JVLC 1995)
+  orthogonalOrderingPreservation,
+  knnJaccard,
+  edgeCrossings,
+  edgeCrossingsDelta,
+  directionalCoherence,
+  stableQuietRatio,
+  // Constraint-perturbation moderator
+  constraintPerturbation,
+  // Appropriateness oracles
+  positionalOracle,
+  pairwiseDistanceOracle,
 } from './evaluation';
 export type {
   HeadlessLayoutOptions,
   HeadlessLayoutResult,
   EdgeKey,
+  CrossingEdge,
   ChangeEmphasisSeparation,
+  PairwiseDistanceOracleOptions,
 } from './evaluation';

--- a/src/translators/webcola/sequence-policy.ts
+++ b/src/translators/webcola/sequence-policy.ts
@@ -1,3 +1,39 @@
+/**
+ * Sequence policies and the warm-start appropriateness factor.
+ *
+ * **Research framing.** A sequence policy controls how prior layout
+ * state is fed back into the solver between consecutive frames. The
+ * research question this module supports is:
+ *
+ *   *Choosing an appropriate warm-start position causes the solver to
+ *   converge at a layout that preserves the mental map, modulo hard
+ *   constraints.*
+ *
+ * The four built-in policies below are not unrelated strategies — they
+ * span one experimental factor at four levels:
+ *
+ *   | Level   | Policy              | Reading                                                              |
+ *   |---------|---------------------|----------------------------------------------------------------------|
+ *   | Anti    | `random_positioning`| Prior info actively discarded for noise — lower bound                |
+ *   | None    | `ignore_history`    | No prior info — pure baseline                                        |
+ *   | Partial | `change_emphasis`   | Prior for unchanged; deliberately perturbed for changed (interior contrast) |
+ *   | Full    | `stability`         | Prior for everything persisting — most appropriate                   |
+ *
+ * The claim predicts mental-map metrics (Misue 1995's three criteria,
+ * Penlloy/Liang positional & pairwise-distance) rise monotonically from
+ * anti → none → partial → full. The four policies are chosen so the
+ * gradient is empirically testable; `change_emphasis`'s perturbation is
+ * intentional, not a bug — it is the interior contrast point that makes
+ * "appropriate" non-tautological.
+ *
+ * **Aliases.** Each policy is also registered under its
+ * literature-vocabulary name (Liang TOSEM 2026 §2.6 / §3.4):
+ * `full_consistency` ↔ `stability`,
+ * `partial_consistency` ↔ `change_emphasis`,
+ * `no_consistency` ↔ `ignore_history`,
+ * `anti_consistency` ↔ `random_positioning`.
+ */
+
 import type { LayoutState } from './webcolatranslator';
 import type { IDataInstance } from '../../data-instance/interfaces';
 import type { LayoutSpec } from '../../layout/layoutspec';
@@ -317,6 +353,12 @@ function jitterChangedPosition(
 
 /**
  * Fresh layout every time — no prior state used.
+ *
+ * **Appropriateness level:** None. No warm-start at all.
+ * **Role in the experiment:** Pure baseline. Per Archambault TVCG 2011's
+ * small-multiples comparison, this is what the world looks like when the
+ * mental map is not preserved at all. Differences between any warm-start
+ * policy and `ignoreHistory` measure the contribution of warm-starting.
  */
 export const ignoreHistory: SequencePolicy = {
   name: 'ignore_history',
@@ -328,6 +370,14 @@ export const ignoreHistory: SequencePolicy = {
  *
  * This built-in includes short-lived in-memory recall for ids that
  * disappear briefly and reappear in nearby steps.
+ *
+ * **Appropriateness level:** Full. Verbatim prior positions for every
+ * persisting node, plus brief-recall for transient absences.
+ * **Role in the experiment:** The strongest warm-start the hint-only
+ * interface allows. By construction, this is the policy whose seed is
+ * closest to the *positional* oracle (the constraint-feasible projection
+ * of the prior layout). `gap_positional(stability)` is therefore a
+ * sanity check, expected near zero modulo solver epsilon.
  *
  * ### Behavioural notes
  *
@@ -428,6 +478,16 @@ export const stability: SequencePolicy = {
  *
  * The diff is computed automatically from the provided instances.
  *
+ * **Appropriateness level:** Partial. Verbatim prior for the unchanged
+ * subset, *deliberately perturbed* for the changed subset. The
+ * perturbation is intentional under the appropriateness framing — its
+ * job is to be the interior contrast point between full
+ * (`stability`) and none (`ignoreHistory`).
+ * **Role in the experiment:** Operationalizes Liang TOSEM 2026 §3.4
+ * partial-consistency with focal substructure = unchanged set. Tests
+ * whether *which* persisting nodes are warm-started matters, holding the
+ * hint mechanism constant.
+ *
  * ### Behavioural notes
  *
  * **New atoms receive no solver hint.** `emphasizedPositions` iterates only
@@ -492,6 +552,14 @@ export const changeEmphasis: SequencePolicy = {
 /**
  * Completely randomize positions of all current nodes each step.
  * Positions are sampled uniformly within viewport bounds.
+ *
+ * **Appropriateness level:** Anti. Prior info actively discarded for
+ * uniform noise.
+ * **Role in the experiment:** Lower bound on how badly any policy can
+ * do. Mental-map metric values for `randomPositioning` define the
+ * "no preservation possible" reference; the gap between the warm-start
+ * policies and this baseline upper-bounds the headroom available to
+ * any preservation strategy.
  */
 export const randomPositioning: SequencePolicy = {
   name: 'random_positioning',
@@ -520,10 +588,16 @@ export const randomPositioning: SequencePolicy = {
 // ---------------------------------------------------------------------------
 
 const policyRegistry = new Map<string, SequencePolicy>([
+  // Canonical names
   ['ignore_history', ignoreHistory],
   ['stability', stability],
   ['change_emphasis', changeEmphasis],
   ['random_positioning', randomPositioning],
+  // Literature-vocabulary aliases (Liang TOSEM 2026 §2.6 / §3.4)
+  ['no_consistency', ignoreHistory],
+  ['full_consistency', stability],
+  ['partial_consistency', changeEmphasis],
+  ['anti_consistency', randomPositioning],
 ]);
 
 /**

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -75,6 +75,13 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   private currentLayout!: WebColaLayout;
   private colaLayout!: Layout;
   private readonly lineFunction: d3.Line<{ x: number; y: number }>;
+  /**
+   * Snapshot of the seed positions the most-recent policy resolved
+   * before the solver ran. Captured for the seed-vs-output
+   * decomposition in the appropriateness experiment. `null` when no
+   * policy was applied this render (e.g., first frame, no prior).
+   */
+  private lastSeedState: LayoutState | null = null;
 
   /**
    * Configuration constants for SVG
@@ -1649,6 +1656,12 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       });
       resolvedState = result.effectivePriorState;
       useReducedIterations = result.useReducedIterations;
+      // Capture by reference only — production users who never call
+      // getLastSeedState pay nothing. The policy's effectivePriorState
+      // is a freshly constructed object, so retaining the reference is
+      // safe; the deep-clone for immutability happens lazily in
+      // getLastSeedState below.
+      this.lastSeedState = resolvedState ?? null;
     } else if (options?.priorPositions) {
       // Direct prior-positions path (no policy): warm-start the solver from the
       // caller-supplied positions and use reduced iterations so existing nodes
@@ -2540,6 +2553,30 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     return {
       positions: this.getNodePositions(),
       transform: this.getCurrentTransform()
+    };
+  }
+
+  /**
+   * Return the seed positions the most-recent policy produced before
+   * the solver ran, or `null` if no policy was applied during the last
+   * render.
+   *
+   * Used by the appropriateness-experiment harness to score the policy
+   * seed against the prior frame independently of solver output. The
+   * gap between seed-scored and output-scored metrics attributes the
+   * effect: small gap = policy is the lever; large gap = solver
+   * dominated.
+   *
+   * The stored value is captured by reference during rendering (zero
+   * production cost — callers who never invoke this method pay
+   * nothing). The deep-clone happens here so the returned snapshot is
+   * immutable from the consumer's perspective.
+   */
+  public getLastSeedState(): LayoutState | null {
+    if (!this.lastSeedState) return null;
+    return {
+      positions: this.lastSeedState.positions.map(p => ({ ...p })),
+      transform: { ...this.lastSeedState.transform },
     };
   }
 

--- a/tests/misue-metrics.test.ts
+++ b/tests/misue-metrics.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tabletop unit tests for the Misue mental-map battery.
+ *
+ * Each test uses a 3-4 node fixture with hand-computed expected
+ * values, asserted exactly. Property-based invariants (identity /
+ * translation / shuffle baselines) live in
+ * `sequence-policy-metrics-pbt.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  orthogonalOrderingPreservation,
+  knnJaccard,
+  edgeCrossings,
+  edgeCrossingsDelta,
+  directionalCoherence,
+  stableQuietRatio,
+  type CrossingEdge,
+} from '../src/evaluation/consistency-metrics';
+import type { LayoutState } from '../src/translators/webcola/webcolatranslator';
+
+const IDENTITY_TRANSFORM = { k: 1, x: 0, y: 0 };
+
+function state(entries: Array<[string, number, number]>): LayoutState {
+  return {
+    positions: entries.map(([id, x, y]) => ({ id, x, y })),
+    transform: IDENTITY_TRANSFORM,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────
+// orthogonalOrderingPreservation
+// ──────────────────────────────────────────────────────────────────
+
+describe('orthogonalOrderingPreservation', () => {
+  it('returns 1 when prev == curr (identity)', () => {
+    const s = state([['A', 0, 0], ['B', 10, 0], ['C', 0, 10]]);
+    expect(orthogonalOrderingPreservation(s, s)).toBe(1);
+  });
+
+  it('returns 1 under uniform translation', () => {
+    const prev = state([['A', 0, 0], ['B', 10, 0], ['C', 0, 10]]);
+    const curr = state([['A', 100, 50], ['B', 110, 50], ['C', 100, 60]]);
+    expect(orthogonalOrderingPreservation(prev, curr)).toBe(1);
+  });
+
+  it('counts a swapped pair as un-preserved', () => {
+    // 3 nodes — 3 unordered pairs. Swap A↔B in x: (A,B) breaks,
+    // (A,C) flips its x relation w.r.t. C, (B,C) flips its x relation
+    // — only the (A,C) ↔ B swap matters. Concretely:
+    //   prev:  A(0,0)  B(10,0)  C(0,10)        — 3 pairs ordered
+    //   curr:  A(10,0) B(0,0)   C(0,10)        — A↔B swapped
+    // Pair (A, B): x relation flipped     → broken
+    // Pair (A, C): x flipped (A was =, now > C) → broken
+    // Pair (B, C): x relation flipped     → broken
+    const prev = state([['A', 0, 0], ['B', 10, 0], ['C', 0, 10]]);
+    const curr = state([['A', 10, 0], ['B', 0, 0], ['C', 0, 10]]);
+    // 0 of 3 pairs preserved.
+    expect(orthogonalOrderingPreservation(prev, curr)).toBe(0);
+  });
+
+  it('returns null for fewer than 2 persisting nodes', () => {
+    const prev = state([['A', 0, 0]]);
+    const curr = state([['A', 0, 0]]);
+    expect(orthogonalOrderingPreservation(prev, curr)).toBeNull();
+  });
+
+  it('honors restrictTo by ignoring excluded nodes', () => {
+    // A and B keep their L/R relation; C swaps with A in y.
+    const prev = state([['A', 0, 0], ['B', 10, 0], ['C', 0, 10]]);
+    const curr = state([['A', 0, 100], ['B', 10, 100], ['C', 0, 0]]);
+    // Restrict to {A, B}: only their pair, ordering preserved → 1.
+    expect(orthogonalOrderingPreservation(prev, curr, new Set(['A', 'B']))).toBe(1);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// knnJaccard
+// ──────────────────────────────────────────────────────────────────
+
+describe('knnJaccard', () => {
+  it('returns 1 when prev == curr (identity)', () => {
+    const s = state([
+      ['A', 0, 0], ['B', 1, 0], ['C', 2, 0], ['D', 3, 0], ['E', 4, 0],
+    ]);
+    expect(knnJaccard(s, s, 2)).toBe(1);
+  });
+
+  it('returns 1 under uniform translation', () => {
+    const prev = state([
+      ['A', 0, 0], ['B', 1, 0], ['C', 2, 0], ['D', 3, 0], ['E', 4, 0],
+    ]);
+    const curr = state([
+      ['A', 100, 50], ['B', 101, 50], ['C', 102, 50], ['D', 103, 50], ['E', 104, 50],
+    ]);
+    expect(knnJaccard(prev, curr, 2)).toBe(1);
+  });
+
+  it('returns null when fewer than k+1 persisting nodes exist', () => {
+    const prev = state([['A', 0, 0], ['B', 1, 0]]);
+    expect(knnJaccard(prev, prev, 3)).toBeNull();
+  });
+
+  it('drops to a fraction < 1 when a node moves to a new cluster', () => {
+    // Linear chain. With k=1 each node's nearest neighbor is its
+    // chain-neighbor. Move E from x=4 to x=-1 — now A's NN is E, not B.
+    const prev = state([
+      ['A', 0, 0], ['B', 1, 0], ['C', 2, 0], ['D', 3, 0], ['E', 4, 0],
+    ]);
+    const curr = state([
+      ['A', 0, 0], ['B', 1, 0], ['C', 2, 0], ['D', 3, 0], ['E', -1, 0],
+    ]);
+    const v = knnJaccard(prev, curr, 1);
+    expect(v).toBeGreaterThan(0);
+    expect(v).toBeLessThan(1);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// edgeCrossings / edgeCrossingsDelta
+// ──────────────────────────────────────────────────────────────────
+
+describe('edgeCrossings', () => {
+  it('returns 0 for parallel non-crossing edges', () => {
+    const s = state([['A', 0, 0], ['B', 10, 0], ['C', 0, 10], ['D', 10, 10]]);
+    const edges: CrossingEdge[] = [
+      { source: 'A', target: 'B' },
+      { source: 'C', target: 'D' },
+    ];
+    expect(edgeCrossings(s, edges)).toBe(0);
+  });
+
+  it('detects a single X crossing', () => {
+    const s = state([['A', 0, 0], ['B', 10, 10], ['C', 0, 10], ['D', 10, 0]]);
+    const edges: CrossingEdge[] = [
+      { source: 'A', target: 'B' }, // diagonal /
+      { source: 'C', target: 'D' }, // diagonal \
+    ];
+    expect(edgeCrossings(s, edges)).toBe(1);
+  });
+
+  it('does not count incident edges as crossings', () => {
+    // Two edges share node A. They should not count as crossing each
+    // other even though they meet at A.
+    const s = state([['A', 0, 0], ['B', 10, 0], ['C', 0, 10]]);
+    const edges: CrossingEdge[] = [
+      { source: 'A', target: 'B' },
+      { source: 'A', target: 'C' },
+    ];
+    expect(edgeCrossings(s, edges)).toBe(0);
+  });
+});
+
+describe('edgeCrossingsDelta', () => {
+  it('is 0 when the visual entanglement is unchanged', () => {
+    const s = state([['A', 0, 0], ['B', 10, 0], ['C', 0, 10], ['D', 10, 10]]);
+    const edges: CrossingEdge[] = [
+      { source: 'A', target: 'B' },
+      { source: 'C', target: 'D' },
+    ];
+    expect(edgeCrossingsDelta(s, edges, s, edges)).toBe(0);
+  });
+
+  it('reports the absolute increase when a new crossing appears', () => {
+    const prev = state([['A', 0, 0], ['B', 10, 0], ['C', 0, 10], ['D', 10, 10]]);
+    const curr = state([['A', 0, 0], ['B', 10, 10], ['C', 0, 10], ['D', 10, 0]]);
+    const edges: CrossingEdge[] = [
+      { source: 'A', target: 'B' },
+      { source: 'C', target: 'D' },
+    ];
+    expect(edgeCrossingsDelta(prev, edges, curr, edges)).toBe(1);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// directionalCoherence
+// ──────────────────────────────────────────────────────────────────
+
+describe('directionalCoherence', () => {
+  it('returns 1 when every node moves the same direction', () => {
+    const prev = state([['A', 0, 0], ['B', 10, 0], ['C', 20, 0]]);
+    const curr = state([['A', 5, 0], ['B', 15, 0], ['C', 25, 0]]);
+    const v = directionalCoherence(prev, curr, ['A', 'B', 'C']);
+    expect(v).toBeCloseTo(1, 10);
+  });
+
+  it('returns 0 when two nodes move in exactly opposite directions', () => {
+    const prev = state([['A', 0, 0], ['B', 10, 0]]);
+    const curr = state([['A', -5, 0], ['B', 15, 0]]);
+    // A moves left, B moves right — unit vectors cancel, R = 0.
+    const v = directionalCoherence(prev, curr, ['A', 'B']);
+    expect(v).toBeCloseTo(0, 10);
+  });
+
+  it('excludes zero-drift nodes from the count', () => {
+    const prev = state([['A', 0, 0], ['B', 10, 0], ['C', 20, 0]]);
+    const curr = state([['A', 5, 0], ['B', 10, 0], ['C', 25, 0]]);
+    // Only A and C move — both rightward. Resultant length = 1.
+    const v = directionalCoherence(prev, curr, ['A', 'B', 'C']);
+    expect(v).toBeCloseTo(1, 10);
+  });
+
+  it('returns null when no node in the set moved', () => {
+    const s = state([['A', 0, 0], ['B', 10, 0]]);
+    expect(directionalCoherence(s, s, ['A', 'B'])).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// stableQuietRatio
+// ──────────────────────────────────────────────────────────────────
+
+describe('stableQuietRatio', () => {
+  it('returns 1 when stable nodes really did not move', () => {
+    const prev = state([['A', 0, 0], ['B', 10, 0]]);
+    const curr = state([['A', 0, 0], ['B', 10, 0]]);
+    expect(stableQuietRatio(prev, curr, ['A', 'B'])).toBe(1);
+  });
+
+  it('reports the fraction of stable ids whose drift stays under threshold', () => {
+    const prev = state([['A', 0, 0], ['B', 0, 0], ['C', 0, 0], ['D', 0, 0]]);
+    // A: 0 drift. B: 4 drift (under 5). C: 5 drift (== threshold, counts). D: 100 drift.
+    const curr = state([['A', 0, 0], ['B', 0, 4], ['C', 0, 5], ['D', 0, 100]]);
+    expect(stableQuietRatio(prev, curr, ['A', 'B', 'C', 'D'])).toBe(0.75);
+  });
+
+  it('returns null when no stable id persists', () => {
+    const prev = state([['A', 0, 0]]);
+    const curr = state([['B', 0, 0]]);
+    expect(stableQuietRatio(prev, curr, ['A'])).toBeNull();
+  });
+
+  it('respects a custom threshold', () => {
+    const prev = state([['A', 0, 0], ['B', 0, 0]]);
+    const curr = state([['A', 0, 6], ['B', 0, 8]]);
+    // threshold 7: A passes (6 ≤ 7), B fails (8 > 7) → 0.5
+    expect(stableQuietRatio(prev, curr, ['A', 'B'], 7)).toBe(0.5);
+  });
+});

--- a/tests/oracle-layouts.test.ts
+++ b/tests/oracle-layouts.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for the appropriateness-oracle layouts.
+ *
+ * `positionalOracle` is the constraint-feasible projection of the
+ * prior layout. `pairwiseDistanceOracle` is the constraint-feasible
+ * layout that minimizes pairwise-distance deviation from prior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  positionalOracle,
+  pairwiseDistanceOracle,
+} from '../src/evaluation/oracle-layouts';
+import type { LayoutState } from '../src/translators/webcola/webcolatranslator';
+import type { LayoutConstraint } from '../src/layout/interfaces';
+
+const IDENTITY_TRANSFORM = { k: 1, x: 0, y: 0 };
+
+function state(entries: Array<[string, number, number]>): LayoutState {
+  return {
+    positions: entries.map(([id, x, y]) => ({ id, x, y })),
+    transform: IDENTITY_TRANSFORM,
+  };
+}
+
+function makeNode(id: string, width: number = 50, height: number = 30) {
+  return {
+    id,
+    label: id,
+    color: 'gray',
+    width,
+    height,
+    mostSpecificType: 'Node',
+    types: ['Node'],
+    showLabels: true,
+  } as any;
+}
+
+function leftConstraint(leftId: string, rightId: string, minDistance: number): LayoutConstraint {
+  return {
+    type: 'left',
+    left: makeNode(leftId),
+    right: makeNode(rightId),
+    minDistance,
+  } as unknown as LayoutConstraint;
+}
+
+function topConstraint(topId: string, bottomId: string, minDistance: number): LayoutConstraint {
+  return {
+    type: 'top',
+    top: makeNode(topId),
+    bottom: makeNode(bottomId),
+    minDistance,
+  } as unknown as LayoutConstraint;
+}
+
+function alignmentConstraint(
+  node1Id: string,
+  node2Id: string,
+  axis: 'x' | 'y'
+): LayoutConstraint {
+  return {
+    type: 'alignment',
+    node1: makeNode(node1Id),
+    node2: makeNode(node2Id),
+    axis,
+  } as unknown as LayoutConstraint;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// positionalOracle
+// ──────────────────────────────────────────────────────────────────
+
+describe('positionalOracle', () => {
+  it('returns prior unchanged when constraints are already satisfied', () => {
+    // A.x = 0, B.x = 100. Constraint: A.x + 10 ≤ B.x. Already satisfied
+    // (gap = 100, required = 10). No movement needed.
+    const prev = state([['A', 0, 0], ['B', 100, 0]]);
+    const constraints = [leftConstraint('A', 'B', 10)];
+
+    const oracle = positionalOracle(prev, constraints);
+
+    const aOut = oracle.positions.find(p => p.id === 'A')!;
+    const bOut = oracle.positions.find(p => p.id === 'B')!;
+    expect(aOut.x).toBeCloseTo(0, 5);
+    expect(bOut.x).toBeCloseTo(100, 5);
+    expect(aOut.y).toBeCloseTo(0, 5);
+    expect(bOut.y).toBeCloseTo(0, 5);
+  });
+
+  it('moves the violating node to satisfy a Left constraint', () => {
+    // Prior: A.x = 0, B.x = 5. Constraint: A.x + 20 ≤ B.x. Violated by 15.
+    // The closest feasible point either pulls A left or B right; Kiwi
+    // splits the displacement such that the gap becomes 20 in some
+    // way. The total displacement is at least 15.
+    const prev = state([['A', 0, 0], ['B', 5, 0]]);
+    const constraints = [leftConstraint('A', 'B', 20)];
+
+    const oracle = positionalOracle(prev, constraints);
+
+    const aOut = oracle.positions.find(p => p.id === 'A')!;
+    const bOut = oracle.positions.find(p => p.id === 'B')!;
+
+    // Constraint must now hold (within numerical tolerance).
+    expect(bOut.x - aOut.x).toBeGreaterThanOrEqual(20 - 1e-6);
+    // Y untouched (constraint is x-only).
+    expect(aOut.y).toBeCloseTo(0, 5);
+    expect(bOut.y).toBeCloseTo(0, 5);
+  });
+
+  it('moves only x, leaves y alone, for an x-only constraint', () => {
+    const prev = state([['A', 0, 100], ['B', 0, 200]]);
+    const constraints = [leftConstraint('A', 'B', 50)];
+
+    const oracle = positionalOracle(prev, constraints);
+
+    const aOut = oracle.positions.find(p => p.id === 'A')!;
+    const bOut = oracle.positions.find(p => p.id === 'B')!;
+    // Y should be unchanged regardless of constraint.
+    expect(aOut.y).toBeCloseTo(100, 5);
+    expect(bOut.y).toBeCloseTo(200, 5);
+    // X must satisfy B.x - A.x ≥ 50.
+    expect(bOut.x - aOut.x).toBeGreaterThanOrEqual(50 - 1e-6);
+  });
+
+  it('honors an alignment constraint', () => {
+    // A.y = 10, B.y = 20. Alignment on y. Closest feasible: a.y == b.y.
+    const prev = state([['A', 0, 10], ['B', 0, 20]]);
+    const constraints = [alignmentConstraint('A', 'B', 'y')];
+
+    const oracle = positionalOracle(prev, constraints);
+
+    const aOut = oracle.positions.find(p => p.id === 'A')!;
+    const bOut = oracle.positions.find(p => p.id === 'B')!;
+    expect(aOut.y).toBeCloseTo(bOut.y, 5);
+  });
+
+  it('returns empty positions when prior is empty', () => {
+    const prev = state([]);
+    const oracle = positionalOracle(prev, []);
+    expect(oracle.positions).toEqual([]);
+  });
+
+  it('preserves transform from prior', () => {
+    const prev: LayoutState = {
+      positions: [{ id: 'A', x: 0, y: 0 }],
+      transform: { k: 1.5, x: 10, y: 20 },
+    };
+    const oracle = positionalOracle(prev, []);
+    expect(oracle.transform).toEqual({ k: 1.5, x: 10, y: 20 });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// pairwiseDistanceOracle
+// ──────────────────────────────────────────────────────────────────
+
+describe('pairwiseDistanceOracle', () => {
+  it('preserves pairwise distances exactly when no constraints are present', () => {
+    // Initialize at prior; target distances = prior distances; cola
+    // sees zero stress and should not move anything.
+    const prev = state([
+      ['A', 0, 0],
+      ['B', 100, 0],
+      ['C', 0, 80],
+      ['D', 100, 80],
+    ]);
+
+    const oracle = pairwiseDistanceOracle(prev, []);
+
+    // Compare pairwise-distance matrices.
+    for (let i = 0; i < prev.positions.length; i++) {
+      for (let j = i + 1; j < prev.positions.length; j++) {
+        const ai = prev.positions[i];
+        const aj = prev.positions[j];
+        const bi = oracle.positions.find(p => p.id === ai.id)!;
+        const bj = oracle.positions.find(p => p.id === aj.id)!;
+
+        const dPrev = Math.hypot(aj.x - ai.x, aj.y - ai.y);
+        const dCurr = Math.hypot(bj.x - bi.x, bj.y - bi.y);
+        // Stress majorization should leave the configuration alone
+        // when it's already optimal — small numerical jitter only.
+        expect(Math.abs(dCurr - dPrev)).toBeLessThan(1);
+      }
+    }
+  });
+
+  it('returns the (deep-copied) prior for fewer than 2 nodes', () => {
+    const prev = state([['A', 5, 10]]);
+    const oracle = pairwiseDistanceOracle(prev, []);
+    expect(oracle.positions).toEqual([{ id: 'A', x: 5, y: 10 }]);
+    // Must not be the same reference (we promised a deep copy).
+    expect(oracle.positions[0]).not.toBe(prev.positions[0]);
+  });
+
+  it('respects a Left constraint while keeping pairwise distances close', () => {
+    // Prior has A and B at the same x. Add Left constraint forcing
+    // B.x ≥ A.x + 50. Oracle must satisfy the constraint; the rest of
+    // the configuration adapts to keep pairwise distances close.
+    const prev = state([
+      ['A', 0, 0],
+      ['B', 0, 0.001], // tiny offset to keep the virtual link non-degenerate
+      ['C', 50, 50],
+    ]);
+    const constraints = [leftConstraint('A', 'B', 50)];
+
+    const oracle = pairwiseDistanceOracle(prev, constraints, { iterations: 100 });
+
+    const aOut = oracle.positions.find(p => p.id === 'A')!;
+    const bOut = oracle.positions.find(p => p.id === 'B')!;
+    expect(bOut.x - aOut.x).toBeGreaterThanOrEqual(50 - 1);
+  });
+
+  it('preserves transform from prior', () => {
+    const prev: LayoutState = {
+      positions: [
+        { id: 'A', x: 0, y: 0 },
+        { id: 'B', x: 100, y: 0 },
+      ],
+      transform: { k: 2, x: 5, y: 10 },
+    };
+    const oracle = pairwiseDistanceOracle(prev, []);
+    expect(oracle.transform).toEqual({ k: 2, x: 5, y: 10 });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Oracle ↔ stability sanity check
+// ──────────────────────────────────────────────────────────────────
+
+describe('oracle / stability sanity', () => {
+  it('positional oracle equals prior when no constraints — `stability` will match by construction', () => {
+    const prev = state([
+      ['A', 10, 20],
+      ['B', 50, 60],
+      ['C', -30, 100],
+    ]);
+    const oracle = positionalOracle(prev, []);
+
+    for (const p of prev.positions) {
+      const o = oracle.positions.find(q => q.id === p.id)!;
+      expect(o.x).toBeCloseTo(p.x, 5);
+      expect(o.y).toBeCloseTo(p.y, 5);
+    }
+  });
+});

--- a/tests/sequence-policy.test.ts
+++ b/tests/sequence-policy.test.ts
@@ -456,6 +456,23 @@ describe('getSequencePolicy', () => {
   it('defaults to ignoreHistory for unknown names', () => {
     expect(getSequencePolicy('nonexistent')).toBe(ignoreHistory);
   });
+
+  // Literature-vocabulary aliases (Liang TOSEM 2026 §2.6 / §3.4)
+  it('resolves no_consistency alias to ignoreHistory', () => {
+    expect(getSequencePolicy('no_consistency')).toBe(ignoreHistory);
+  });
+
+  it('resolves full_consistency alias to stability', () => {
+    expect(getSequencePolicy('full_consistency')).toBe(stability);
+  });
+
+  it('resolves partial_consistency alias to changeEmphasis', () => {
+    expect(getSequencePolicy('partial_consistency')).toBe(changeEmphasis);
+  });
+
+  it('resolves anti_consistency alias to randomPositioning', () => {
+    expect(getSequencePolicy('anti_consistency')).toBe(randomPositioning);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/webcola-demo/sequence-metrics-demo.html
+++ b/webcola-demo/sequence-metrics-demo.html
@@ -208,6 +208,65 @@
                 </div>
 
                 <div class="panel mb-3">
+                    <h5>Misue mental-map battery</h5>
+                    <div class="small-help mb-2">
+                        Misue, Eades, Lai &amp; Sugiyama (JVLC 1995). Three operational criteria for mental-map preservation: orthogonal ordering (each pair's L/R + U/D survives), k-NN proximity (each node's neighborhood is preserved), edge crossings stable. Higher = better preserved (except crossings delta — lower better).
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">orthogonal ordering <span class="text-muted small">(higher better, [0–1])</span></span>
+                        <span><span id="oopValue" class="metric-value unknown">—</span></span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">k-NN Jaccard (k=3) <span class="text-muted small">(higher better, [0–1])</span></span>
+                        <span><span id="knnValue" class="metric-value unknown">—</span></span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">edge crossings Δ <span class="text-muted small">(lower better)</span></span>
+                        <span><span id="crossingsDeltaValue" class="metric-value unknown">—</span></span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">directional coherence (changed) <span class="text-muted small">([0–1])</span></span>
+                        <span><span id="dcValue" class="metric-value unknown">—</span></span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">stable quiet ratio (≤5 px) <span class="text-muted small">([0–1])</span></span>
+                        <span><span id="sqrValue" class="metric-value unknown">—</span></span>
+                    </div>
+                </div>
+
+                <div class="panel mb-3">
+                    <h5>appropriateness gap (oracles)</h5>
+                    <div class="small-help mb-2">
+                        Distance from the policy's output to the constraint-feasible mental-map optimum.
+                        Each row shows raw cost (px²/px) plus % of theoretical worst — every persisting node drifting corner-to-corner of the prior-frame bounding box.
+                        Smaller = the policy lands closer to "the actual mental-map-preserving thing."
+                        <code>gap_positional</code> ≈ 0% for <code>stability</code> by construction (sanity check).
+                        <code>gap_pwd</code> measures Liang shape preservation under hard constraints.
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">gap_positional <span class="text-muted small">(px²)</span></span>
+                        <span>
+                            <span id="gapPosValue" class="metric-value unknown">—</span>
+                            <span class="text-muted small">(<span id="gapPosPct">—</span>)</span>
+                        </span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">gap_pwd <span class="text-muted small">(px²)</span></span>
+                        <span>
+                            <span id="gapPwdValue" class="metric-value unknown">—</span>
+                            <span class="text-muted small">(<span id="gapPwdPct">—</span>)</span>
+                        </span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">constraint perturbation <span class="text-muted small">(prior → feasible, px)</span></span>
+                        <span>
+                            <span id="cPerturbValue" class="metric-value unknown">—</span>
+                            <span class="text-muted small">(<span id="cPerturbPct">—</span>)</span>
+                        </span>
+                    </div>
+                </div>
+
+                <div class="panel mb-3">
                     <h5>solver fairness check</h5>
                     <div class="small-help mb-2">Higher is better. A value of 1.000 means all scored constraints are satisfied.</div>
                     <div class="metric-row">
@@ -455,7 +514,70 @@ constraints:
                 ).length;
                 const changedIds = Cnd.classifyChangeEmphasisChangedSet(prevInstance, currInstance);
                 const changeSeparation = Cnd.changeEmphasisSeparation(prevState, newState, changedIds);
-                metrics = { positional, relative, pairwise, adherence, persistingNodes, persistingEdges, changeSeparation };
+
+                // Build the changed/stable atom-id lists for the
+                // directional-coherence and stable-quiet-ratio readouts.
+                const prevIds = new Set(prevState.positions.map(p => p.id));
+                const currIds = new Set(newState.positions.map(p => p.id));
+                const changedIdList = [];
+                const stableIdList = [];
+                for (const id of currIds) {
+                    if (!prevIds.has(id)) continue;
+                    if (changedIds.has(id)) changedIdList.push(id);
+                    else stableIdList.push(id);
+                }
+
+                // Misue battery + appropriateness gaps + perturbation.
+                // Wrapped in try so a transient solver hiccup doesn't
+                // tank the whole frame's metric panel.
+                let oop = null, knn = null, crossingsDelta = null;
+                let dc = null, sqr = null;
+                let gapPositional = null, gapPwd = null, cPerturb = null;
+                try {
+                    oop = Cnd.orthogonalOrderingPreservation(prevState, newState);
+                    knn = Cnd.knnJaccard(prevState, newState);
+                    crossingsDelta = Cnd.edgeCrossingsDelta(prevState, prevEdges, newState, currEdges);
+                    dc = Cnd.directionalCoherence(prevState, newState, changedIdList);
+                    sqr = Cnd.stableQuietRatio(prevState, newState, stableIdList);
+                    cPerturb = Cnd.constraintPerturbation(prevState, layout.constraints);
+                    const oraclePos = Cnd.positionalOracle(prevState, layout.constraints);
+                    const oraclePwd = Cnd.pairwiseDistanceOracle(prevState, layout.constraints);
+                    gapPositional = Cnd.positionalConsistency(oraclePos, newState);
+                    gapPwd = Cnd.positionalConsistency(oraclePwd, newState);
+                } catch (err) {
+                    console.warn('Misue / oracle metric path failed:', err);
+                }
+
+                // Theoretical-worst denominators for the "% from ideal"
+                // companions on the appropriateness panel. Match the
+                // aggregator's normSquared / normLinearPerCount semantics.
+                const priorPositions = prevState.positions;
+                let bboxDiag = 0;
+                if (priorPositions.length > 0) {
+                    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+                    for (const p of priorPositions) {
+                        if (p.x < minX) minX = p.x;
+                        if (p.x > maxX) maxX = p.x;
+                        if (p.y < minY) minY = p.y;
+                        if (p.y > maxY) maxY = p.y;
+                    }
+                    bboxDiag = Math.hypot(maxX - minX, maxY - minY);
+                }
+                const sumSquaredDenom = persistingNodes * bboxDiag * bboxDiag;
+                const sumLinearDenom = persistingNodes * bboxDiag;
+                const fracOf = (value, denom) =>
+                    value == null || !(denom > 0) ? null : value / denom;
+                const gapPositionalPct = fracOf(gapPositional, sumSquaredDenom);
+                const gapPwdPct = fracOf(gapPwd, sumSquaredDenom);
+                const cPerturbPct = fracOf(cPerturb, sumLinearDenom);
+
+                metrics = {
+                    positional, relative, pairwise, adherence,
+                    persistingNodes, persistingEdges, changeSeparation,
+                    oop, knn, crossingsDelta, dc, sqr,
+                    gapPositional, gapPwd, cPerturb,
+                    gapPositionalPct, gapPwdPct, cPerturbPct,
+                };
             } else {
                 // Frame 1: no prior to compare consistency against, but
                 // adherence is still meaningful on the standalone layout.
@@ -467,6 +589,9 @@ constraints:
                     persistingNodes: 0,
                     persistingEdges: 0,
                     changeSeparation: null,
+                    oop: null, knn: null, crossingsDelta: null,
+                    dc: null, sqr: null,
+                    gapPositional: null, gapPwd: null, cPerturb: null,
                 };
             }
 
@@ -498,9 +623,31 @@ constraints:
             const splitOverallMeanDriftEl = document.getElementById('splitOverallMeanDrift');
             const splitChangedMeanDriftEl = document.getElementById('splitChangedMeanDrift');
             const splitStableMeanDriftEl = document.getElementById('splitStableMeanDrift');
+            // Misue + appropriateness panel ids (added in this PR).
+            const oopEl = document.getElementById('oopValue');
+            const knnEl = document.getElementById('knnValue');
+            const crossingsDeltaEl = document.getElementById('crossingsDeltaValue');
+            const dcEl = document.getElementById('dcValue');
+            const sqrEl = document.getElementById('sqrValue');
+            const gapPosEl = document.getElementById('gapPosValue');
+            const gapPwdEl = document.getElementById('gapPwdValue');
+            const cPerturbEl = document.getElementById('cPerturbValue');
+            // % of theoretical worst companions for the appropriateness panel.
+            const gapPosPctEl = document.getElementById('gapPosPct');
+            const gapPwdPctEl = document.getElementById('gapPwdPct');
+            const cPerturbPctEl = document.getElementById('cPerturbPct');
 
             const fmtPx = v => (v == null ? '—' : v.toFixed(1));
             const fmtUnit = v => (v == null ? '—' : v.toFixed(3));
+            const fmtInt = v => (v == null ? '—' : Math.round(v).toString());
+            // Color higher-is-better metrics: green when ≥ 0.95,
+            // yellow in the middle, red below 0.5.
+            const klassUp = v => {
+                if (v == null) return 'metric-value unknown';
+                if (v >= 0.95) return 'metric-value zero';
+                if (v >= 0.5) return 'metric-value';
+                return 'metric-value high';
+            };
             const klassPx = v => {
                 if (v == null) return 'metric-value unknown';
                 if (v < 1) return 'metric-value zero';
@@ -553,6 +700,42 @@ constraints:
             splitOverallMeanDriftEl.textContent = fmtPx(overallMeanDrift);
             splitChangedMeanDriftEl.textContent = fmtPx(change?.changedMeanDrift ?? null);
             splitStableMeanDriftEl.textContent = fmtPx(change?.stableMeanDrift ?? null);
+
+            // Misue mental-map battery readouts.
+            oopEl.textContent = fmtUnit(metrics?.oop ?? null);
+            oopEl.className = klassUp(metrics?.oop ?? null);
+            knnEl.textContent = fmtUnit(metrics?.knn ?? null);
+            knnEl.className = klassUp(metrics?.knn ?? null);
+            crossingsDeltaEl.textContent = fmtInt(metrics?.crossingsDelta ?? null);
+            crossingsDeltaEl.className = metrics?.crossingsDelta == null
+                ? 'metric-value unknown'
+                : metrics.crossingsDelta === 0
+                    ? 'metric-value zero'
+                    : 'metric-value high';
+            dcEl.textContent = fmtUnit(metrics?.dc ?? null);
+            dcEl.className = metrics?.dc == null ? 'metric-value unknown' : 'metric-value';
+            sqrEl.textContent = fmtUnit(metrics?.sqr ?? null);
+            sqrEl.className = klassUp(metrics?.sqr ?? null);
+
+            // Appropriateness gaps + % of theoretical worst.
+            const fmtPct = v => v == null
+                ? '—'
+                : v < 0.0001
+                    ? `${(v * 100).toExponential(1)}% of worst`
+                    : `${(v * 100).toFixed(2)}% of worst`;
+            gapPosEl.textContent = fmtPx(metrics?.gapPositional ?? null);
+            gapPosEl.className = klassPx(metrics?.gapPositional ?? null);
+            gapPosPctEl.textContent = fmtPct(metrics?.gapPositionalPct ?? null);
+            gapPwdEl.textContent = fmtPx(metrics?.gapPwd ?? null);
+            gapPwdEl.className = klassPx(metrics?.gapPwd ?? null);
+            gapPwdPctEl.textContent = fmtPct(metrics?.gapPwdPct ?? null);
+            cPerturbEl.textContent = fmtPx(metrics?.cPerturb ?? null);
+            cPerturbEl.className = metrics?.cPerturb == null
+                ? 'metric-value unknown'
+                : metrics.cPerturb < 1
+                    ? 'metric-value zero'
+                    : 'metric-value';
+            cPerturbPctEl.textContent = fmtPct(metrics?.cPerturbPct ?? null);
         }
 
         function updateSparkline() {

--- a/webcola-demo/sequence-metrics-demo.html
+++ b/webcola-demo/sequence-metrics-demo.html
@@ -94,6 +94,72 @@
             layout spec, so it is shown separately from consistency.
         </p>
 
+        <details class="panel mb-3" id="metricsGuide">
+            <summary style="cursor:pointer; font-weight:600;">How to read all the metrics on this page</summary>
+            <div class="small-help mt-2">
+                <p>
+                    There are a lot of numbers in the right-hand panels. The smallest mental model that covers them
+                    is <strong>three families, three questions</strong>:
+                </p>
+                <table class="metric-table" aria-label="Metric families">
+                    <thead>
+                        <tr>
+                            <th>Family</th>
+                            <th>The question it answers</th>
+                            <th>Which metrics</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><strong>Consistency</strong></td>
+                            <td><em>Did the layout stay similar?</em> &mdash; how preserved is X across this transition?</td>
+                            <td>
+                                <code>positional</code>, <code>relative</code>, <code>pairwise distance</code>,
+                                <code>orthogonal ordering</code>, <code>k-NN Jaccard</code>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><strong>Salience</strong></td>
+                            <td><em>Did the right things move?</em> &mdash; is the changed bit emphasized and the stable bit quiet?</td>
+                            <td>
+                                <code>change separation AUC</code>, <code>directional coherence</code>,
+                                <code>stable quiet ratio</code>, <code>edge crossings &Delta;</code>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><strong>Appropriateness</strong></td>
+                            <td><em>Is the policy close to optimal?</em> &mdash; how far from the constraint-feasible mental-map ideal?</td>
+                            <td>
+                                <code>gap_positional</code>, <code>gap_pwd</code>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Moderator</td>
+                            <td><em>How forced was the change at all?</em></td>
+                            <td><code>constraint perturbation</code></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p class="mt-2">
+                    <strong>What to look at first.</strong> The headline metric is <code>gap_pwd</code> &mdash;
+                    distance from the policy's output to the constraint-feasible shape-preservation optimum,
+                    shown as <em>% of theoretical worst</em>. Smaller = more appropriate.
+                </p>
+                <p>
+                    Everything else is supporting evidence:
+                </p>
+                <ul>
+                    <li><code>gap_positional</code> is a sanity check &mdash; <code>stability</code> should land at &asymp; 0% by construction.</li>
+                    <li>The <strong>Misue battery</strong> tells you <em>which dimension</em> of the mental map a policy preserves. Useful when <code>gap_pwd</code> doesn't separate policies but, say, ordering does.</li>
+                    <li>The <strong>salience</strong> metrics answer a different question and only really matter for <code>change_emphasis</code>.</li>
+                    <li><code>constraint perturbation</code> is a regressor &mdash; when high, no policy can help much. Use it to bin transitions into easy / hard before comparing.</li>
+                </ul>
+                <p>
+                    <strong>What "% of theoretical worst" means.</strong> The denominator is the value the metric would take if every persisting element contributed its theoretical maximum (every node corner-to-corner, etc.). 0 = ideal, 1 = worst possible. Real values are usually small fractions of 1 because random positioning typically uses ~30&ndash;50% of the bounding box, not 100%; the compression is intentional and self-anchored.
+                </p>
+            </div>
+        </details>
+
         <div class="row g-3 mb-3">
             <div class="col-lg-7">
                 <label class="form-label form-label-sm" for="alloyInput">Alloy XML Sequence</label>


### PR DESCRIPTION
## Summary

Turns the warm-start research question — *does an appropriate warm-start preserve the mental map under spytial's hard constraints?* — into a runnable experiment. Adds the evaluation pieces the existing four policies need to be scored as a graded appropriateness factor against literature criteria. **No new policies are introduced.** The four existing canonical policies (`ignore_history`, `random_positioning`, `change_emphasis`, `stability`) span the appropriateness axis cleanly already; what was missing was the measurement scaffolding to score them.

## What's new

- **Vocabulary realignment** — the four policies are documented as a graded experimental factor (anti / none / partial / full) with Liang TOSEM 2026 aliases (`full_consistency`, `partial_consistency`, `no_consistency`, `anti_consistency`). No behavior change.
- **Misue mental-map battery** (JVLC 1995) added to `consistency-metrics.ts`: `orthogonalOrderingPreservation`, `knnJaccard`, `edgeCrossings` / `edgeCrossingsDelta`, `directionalCoherence`, `stableQuietRatio`.
- **`constraintPerturbation`** moderator — distance from the prior layout to the closest feasible point under the new hard constraints (via Kiwi.js soft-anchor projection).
- **Oracle layouts** in new `src/evaluation/oracle-layouts.ts`:
  - `positionalOracle` — Kiwi quadratic projection. By construction `stability` should land near it (`gap_positional ≈ 0` is the sanity check).
  - `pairwiseDistanceOracle` — cola stress majorization with virtual links per persisting node pair, target distance = prior pairwise distance. The numerical realization of Liang TOSEM 2026 §3.4 shape preservation.
  - `gap(policy) = positionalConsistency(policy_output, oracle)` is appropriateness in absolute units. Demo shows raw px² and "% of theoretical worst" companions.
- **Seed-vs-output decomposition** — `HeadlessLayoutResult.seed` and `WebColaCnDGraph.getLastSeedState()` capture the pre-solver seed positions. Production users pay nothing: capture is by-reference; the deep-clone is deferred to the public getter.
- **Demo panels** in `webcola-demo/sequence-metrics-demo.html` — two new panels (Misue battery; appropriateness gap) populate live as the user steps frames, with raw values plus "% of theoretical worst" companions.
- **Complexity doc** at `docs/MENTAL_MAP_ORACLE_COMPLEXITY.md` explains why orthogonal-ordering / k-NN / edge-crossings oracles are deferred (NP-hard).

## How to read all the metrics

There are a lot of new numbers, so here is the smallest mental model that covers them.

### Three families, three questions

| Family | The question it answers | Which metrics |
|---|---|---|
| **Consistency** — did the layout stay similar? | "How preserved is X across this transition?" | `positional`, `relative`, `pairwise_distance`, `orthogonal_ordering_preservation`, `knn_jaccard` |
| **Salience** — did the right things move? | "Is the changed bit emphasized and the stable bit quiet?" | `changed_vs_stable_auc`, `directional_coherence`, `stable_quiet_ratio`, `edge_crossings_delta` |
| **Appropriateness** — is the policy close to optimal? | "How far from the constraint-feasible mental-map ideal?" | `gap_positional`, `gap_pwd` |
| Moderator | "How forced was the change at all?" | `constraint_perturbation` |

### What to look at first

The research question is sub-claim 3: *appropriate warm-start preserves the mental map under hard constraints*. The metric that answers it directly is **`gap_pwd`** — distance from the policy's output to the constraint-feasible shape-preservation optimum, shown in the demo as "% of theoretical worst."

Everything else is supporting evidence:

- **`gap_positional`** is the sanity check (`stability` should land at ≈ 0%; if not, something is wrong with the harness, not the claim).
- **The Misue battery** (OOP, k-NN, etc.) tells you *which dimension* of the mental map a policy preserves. Useful when `gap_pwd` does not separate policies but Misue OOP does.
- **The salience metrics** answer a different question ("did the right things change?") and only matter for `change_emphasis`-style policies.
- **`constraint_perturbation`** is a regressor — when high, *no* policy can help, so use it to bin transitions into easy / hard regimes before comparing policies.

### What "% of theoretical worst" means

Each `_norm` column in `aggregate.csv` is `value / theoretical_worst`, where `theoretical_worst` is the value the metric would take if every persisting element contributed its maximum (e.g., every node drifted corner-to-corner of the prior bounding box). 0 = ideal, 1 = worst possible.

Real numbers are usually small fractions of 1 because random positioning typically uses ~30–50% of the bounding box, not 100%. The compression is intentional: theoretical worst is deterministic and self-anchored. Empirical-worst (random-baseline) normalization can be computed downstream from `random_positioning` rows.

## What's deliberately out of scope

- New policies (deferred until matrix data justifies them — see plan).
- Soft-bias / constraint-injection variants of the SequencePolicy interface.
- Empirical-worst (random-baseline) normalization. The `_norm` columns use theoretical worst.
- The `spytial-sequence-analysis/runner/` companion edits (aggregator + `run.ts`) — that is a separate (untracked) repo, not part of this PR.

## Test plan

- [x] `npm run build:all` clean
- [x] `npm run test:run` — 1540 pass, 5 pre-existing skips, 6 new test files (misue-metrics + oracle-layouts; alias additions)
- [x] Demo renders with new panels live; both raw and "% of worst" populate; no console errors
- [x] `getLastSeedState()` deep-clone test (snapshot is immutable)
- [x] Oracle invariants (positional oracle returns prior unchanged when constraints already satisfied; pwd oracle preserves pairwise distances when initialized at prior with zero stress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)