### PR TITLE
Add highlight color to edge style directive

### DIFF
--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -404,6 +404,7 @@ Customizes the appearance of edges for a specific field/relation.
     filter: <n-ary-selector>     # Optional: Filter which tuples apply
     style: <line-style>          # Optional: Line style
     weight: <number>             # Optional: Line thickness
+    highlight: <color>           # Optional: Highlight color (underlay)
     showLabel: <boolean>         # Optional: Show edge label
     hidden: <boolean>            # Optional: Hide the edge entirely
 ```
@@ -418,6 +419,7 @@ Customizes the appearance of edges for a specific field/relation.
 | `filter` | ❌ No | string | - | N-ary selector to filter specific tuples |
 | `style` | ❌ No | string | `solid` | `solid`, `dashed`, or `dotted` |
 | `weight` | ❌ No | number | - | Line thickness in pixels |
+| `highlight` | ❌ No | string | - | CSS color drawn as a wider, translucent underlay beneath the edge. Orthogonal to `style`/`value` — combine with any line style or color. Omit for no highlight. |
 | `showLabel` | ❌ No | boolean | `true` | Whether to display the edge label |
 | `hidden` | ❌ No | boolean | `false` | Hide the edge from display |
 
@@ -442,6 +444,12 @@ Customizes the appearance of edges for a specific field/relation.
     field: internal
     value: gray
     hidden: true
+
+# Yellow highlight glow under black edges
+- edgeColor:
+    field: critical_path
+    value: black
+    highlight: "#ffeb3b"
 ```
 
 ---
@@ -671,6 +679,7 @@ Creates visual edges based on a selector expression (edges that don't exist in t
     color: <color>               # Optional: Edge color
     style: <line-style>          # Optional: Line style
     weight: <number>             # Optional: Line thickness
+    highlight: <color>           # Optional: Highlight color (underlay)
 ```
 
 **Fields:**
@@ -682,6 +691,7 @@ Creates visual edges based on a selector expression (edges that don't exist in t
 | `color` | ❌ No | string | `#000000` | CSS color value |
 | `style` | ❌ No | string | `solid` | `solid`, `dashed`, or `dotted` |
 | `weight` | ❌ No | number | - | Line thickness in pixels |
+| `highlight` | ❌ No | string | - | CSS color drawn as a wider, translucent underlay beneath the edge. Omit for no highlight. |
 
 **Examples:**
 

--- a/src/components/NoCodeView/Selectors/ColorEdgeSelector.tsx
+++ b/src/components/NoCodeView/Selectors/ColorEdgeSelector.tsx
@@ -12,7 +12,7 @@ interface ColorEdgeSelectorProps {
 
 /**
  * Minimal React component for edge style directive.
- * Includes field input, color picker, line style, weight, label visibility, and edge visibility.
+ * Includes field input, color picker, highlight color, line style, weight, label visibility, and edge visibility.
  */
 export const ColorEdgeSelector: React.FC<ColorEdgeSelectorProps> = ({
   directiveData,
@@ -26,6 +26,7 @@ export const ColorEdgeSelector: React.FC<ColorEdgeSelectorProps> = ({
   const weight = directiveData.params.weight as number | undefined;
   const showLabel = directiveData.params.showLabel as boolean | undefined;
   const hidden = directiveData.params.hidden as boolean | undefined;
+  const highlight = (directiveData.params.highlight as string) || '';
 
   const handleSelectorChange = (event: SelectorChangeEvent) => {
     const { name, value } = event.target;
@@ -75,6 +76,28 @@ export const ColorEdgeSelector: React.FC<ColorEdgeSelectorProps> = ({
           onChange={(e) => onUpdate({ params: { ...directiveData.params, value: e.target.value } })}
           required
         />
+      </div>
+      <div className="field-group">
+        <label className="field-label" title="Optional highlight color drawn as a wider underlay beneath the edge">
+          Highlight
+        </label>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <input
+            type="color"
+            name="highlight"
+            value={highlight || '#ffeb3b'}
+            disabled={!highlight}
+            onChange={(e) => onUpdate({ params: { ...directiveData.params, highlight: e.target.value } })}
+          />
+          <label className="inline-toggle" style={{ margin: 0 }}>
+            <input
+              type="checkbox"
+              checked={!!highlight}
+              onChange={(e) => onUpdate({ params: { ...directiveData.params, highlight: e.target.checked ? '#ffeb3b' : undefined } })}
+            />
+            <span>Enabled</span>
+          </label>
+        </div>
       </div>
       <div className="field-group">
         <label className="field-label">Style</label>

--- a/src/components/NoCodeView/Selectors/HelperEdgeSelector.tsx
+++ b/src/components/NoCodeView/Selectors/HelperEdgeSelector.tsx
@@ -23,6 +23,7 @@ export const HelperEdgeSelector: React.FC<HelperEdgeSelectorProps> = ({
   const color = (directiveData.params.color as string) || '#000000';
   const style = (directiveData.params.style as string) || '';
   const weight = directiveData.params.weight as number | undefined;
+  const highlight = (directiveData.params.highlight as string) || '';
 
   const handleSelectorChange = (event: SelectorChangeEvent) => {
     onUpdate({ params: { ...directiveData.params, selector: event.target.value } });
@@ -59,6 +60,28 @@ export const HelperEdgeSelector: React.FC<HelperEdgeSelectorProps> = ({
           defaultValue={color}
           onChange={(e) => onUpdate({ params: { ...directiveData.params, color: e.target.value } })}
         />
+      </div>
+      <div className="field-group">
+        <label className="field-label" title="Optional highlight color drawn as a wider underlay beneath the edge">
+          Highlight
+        </label>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <input
+            type="color"
+            name="highlight"
+            value={highlight || '#ffeb3b'}
+            disabled={!highlight}
+            onChange={(e) => onUpdate({ params: { ...directiveData.params, highlight: e.target.value } })}
+          />
+          <label className="inline-toggle" style={{ margin: 0 }}>
+            <input
+              type="checkbox"
+              checked={!!highlight}
+              onChange={(e) => onUpdate({ params: { ...directiveData.params, highlight: e.target.checked ? '#ffeb3b' : undefined } })}
+            />
+            <span>Enabled</span>
+          </label>
+        </div>
       </div>
       <div className="field-group">
         <label className="field-label">Style</label>

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -62,6 +62,8 @@ export interface LayoutEdge {
     weight?: number;
     showLabel?: boolean;
     hidden?: boolean;
+    /** Highlight color rendered as a wider underlay beneath the edge. Undefined = no highlight. */
+    highlight?: string;
     /**
      * For group edges (_g_ prefix), the name of the group this edge was created for.
      * Matches `group.id` in the WebCola translator so routing can look up the group

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -2336,6 +2336,7 @@ export class LayoutInstance {
             let style = this.getEdgeStyle(relName, edge.v, edge.w, edgeId);
             let weight = this.getEdgeWeight(relName, edge.v, edge.w, edgeId);
             let showLabel = this.getEdgeShowLabel(relName, edge.v, edge.w, edgeId);
+            let highlight = this.getEdgeHighlight(relName, edge.v, edge.w, edgeId);
 
             // Skip edges with missing source or target nodes
             if (!source || !target || !edgeId) {
@@ -2352,6 +2353,7 @@ export class LayoutInstance {
                 style: style,
                 weight: weight,
                 showLabel: showLabel,
+                highlight: highlight,
                 // For group edges the graphlib edge label IS the group name (see constructGroupEdgeID).
                 // Carry it forward so the renderer can look up the group directly by ID
                 // without re-parsing the edge ID string or matching fragile leaf indices.
@@ -2648,6 +2650,16 @@ export class LayoutInstance {
 
         const directive = this.findEdgeDirective(relName, sourceAtom, targetAtom);
         return normalizeEdgeStyle(directive?.style);
+    }
+
+    private getEdgeHighlight(relName: string, sourceAtom: string, targetAtom: string, edgeId?: string): string | undefined {
+        const inferredDirective = this.getInferredEdgeDirective(edgeId);
+        if (inferredDirective?.highlight) {
+            return inferredDirective.highlight;
+        }
+
+        const directive = this.findEdgeDirective(relName, sourceAtom, targetAtom);
+        return directive?.highlight;
     }
 
     private getEdgeWeight(relName: string, sourceAtom: string, targetAtom: string, edgeId?: string): number | undefined {

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -244,6 +244,8 @@ export interface InferredEdgeDirective extends VisualManipulation {
     color?: string;
     style?: EdgeStyle;
     weight?: number;
+    /** Optional highlight color drawn as a wider underlay beneath the edge. */
+    highlight?: string;
 }
 
 export interface AtomHidingDirective extends VisualManipulation {
@@ -299,6 +301,8 @@ export interface EdgeStyleDirective extends FieldDirective {
     weight?: number;
     showLabel?: boolean;
     hidden?: boolean;
+    /** Optional highlight color drawn as a wider underlay beneath the edge. */
+    highlight?: string;
 }
 
 /**
@@ -814,7 +818,8 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
                         style: d.edgeColor.style,
                         weight: d.edgeColor.weight,
                         showLabel: d.edgeColor.showLabel,
-                        hidden: d.edgeColor.hidden
+                        hidden: d.edgeColor.hidden,
+                        highlight: d.edgeColor.highlight
                     }
                 });
 
@@ -844,7 +849,8 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
             selector: d.inferredEdge.selector,
             color: d.inferredEdge.color,
             style: d.inferredEdge.style,
-            weight: d.inferredEdge.weight
+            weight: d.inferredEdge.weight,
+            highlight: d.inferredEdge.highlight
         }
     });
 

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -2162,7 +2162,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     // Animate exiting edge paths with stroke-dashoffset (draw-out effect).
     snapshotSel.selectAll('g.link-group, g.inferredLinkGroup, g.alignmentLinkGroup')
       .each(function(this: SVGGElement) {
-        const pathEl = this.querySelector('path') as SVGPathElement | null;
+        const pathEl = this.querySelector('path[data-link-id]') as SVGPathElement | null;
         if (!pathEl) return;
         const totalLength = pathEl.getTotalLength();
         if (!totalLength || totalLength <= 0) return;
@@ -2268,7 +2268,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
           return enterNodeIds.has(srcId) || enterNodeIds.has(tgtId);
         })
         .each(function(this: SVGGElement) {
-          const pathEl = this.querySelector('path') as SVGPathElement | null;
+          const pathEl = this.querySelector('path[data-link-id]') as SVGPathElement | null;
           if (!pathEl) return;
           const totalLength = pathEl.getTotalLength();
           if (!totalLength || totalLength <= 0) return;
@@ -2287,7 +2287,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         .duration(this.morphEnterDurationMs)
         .ease(d3.easeCubicOut)
         .tween('draw-in', function(this: SVGGElement) {
-          const pathEl = this.querySelector('path') as SVGPathElement | null;
+          const pathEl = this.querySelector('path[data-link-id]') as SVGPathElement | null;
           if (!pathEl) return () => {};
           const totalLength = pathEl.getTotalLength();
           if (!totalLength || totalLength <= 0) return () => {};
@@ -2298,7 +2298,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         })
         .on('end', function(this: SVGGElement) {
           // Clean up dash attributes and show labels/arrows
-          const pathEl = this.querySelector('path');
+          const pathEl = this.querySelector('path[data-link-id]');
           if (pathEl) {
             pathEl.removeAttribute('stroke-dasharray');
             pathEl.removeAttribute('stroke-dashoffset');
@@ -2694,6 +2694,24 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       .style('cursor', () => {
         return this.isInputModeActive ? 'pointer' : 'default';
       });
+
+    // Highlight underlay: a wider, translucent path drawn beneath the main edge.
+    // Only created for edges that actually set `highlight`, so non-highlighted
+    // edges pay zero extra cost. Inserted as the first child of the link-group
+    // so SVG painter's order renders it underneath the main edge.
+    linkGroups
+      .filter((d: any) => !!d.highlight && !this.isAlignmentEdge(d))
+      .insert("path", ":first-child")
+      .attr("class", "highlight-underlay")
+      .attr("stroke", (d: any) => d.highlight)
+      .attr("fill", "none")
+      .attr("stroke-linecap", "round")
+      .style("stroke-width", (d: any) => {
+        const base = d.weight != null ? d.weight : 2;
+        return `${base + 8}px`;
+      })
+      .attr("opacity", 0.45)
+      .style("pointer-events", "none");
   }
 
   private getEdgeDasharray(style?: string): string | null {
@@ -3771,9 +3789,10 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       })
       .raise();
 
-    // Update link paths with stable anchor-based routing to prevent jitter during dragging
-    // Select 'path' to include all edge types: .link, .inferredLink, and .alignmentLink
-    this.svgLinkGroups.select('path')
+    // Update link paths with stable anchor-based routing to prevent jitter during dragging.
+    // Select the main path (identified by data-link-id) so any highlight underlay sibling
+    // is not picked up here — markers and .raise() apply only to the main edge.
+    this.svgLinkGroups.select('path[data-link-id]')
       .attr('d', (d: EdgeWithMetadata) => {
         // Resolve group-edge endpoints (group boundary instead of member node center).
         const { source, target } = this.resolveGroupEdgeEndpoints(d);
@@ -3794,6 +3813,15 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         return 'url(#start-arrow)';
       })
       .raise();
+
+    // Mirror the main path's `d` onto the highlight underlay sibling.
+    // Cheap: one getAttribute + setAttribute per highlighted edge per tick.
+    this.svgLinkGroups.select('path.highlight-underlay')
+      .attr('d', function () {
+        const parent = (this as SVGPathElement).parentNode as Element | null;
+        const main = parent?.querySelector('path[data-link-id]');
+        return main?.getAttribute('d') ?? null;
+      });
 
     // Update link labels using path midpoint calculation
     this.svgLinkGroups.select('.linklabel')

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -64,6 +64,8 @@ type EdgeWithMetadata = Link<NodeWithMetadata> & {
   color: string,
   style?: EdgeStyle,
   weight?: number,
+  /** Highlight color rendered as a wider underlay beneath the edge. Undefined = no highlight. */
+  highlight?: string,
   showLabel?: boolean, // Whether to show the edge label (default: true)
   bidirectional?: boolean, // Flag to indicate if this edge represents a bidirectional relationship
   /**
@@ -701,6 +703,7 @@ export class WebColaLayout {
       color: edge.color,
       style: edge.style,
       weight: edge.weight,
+      highlight: edge.highlight,
       showLabel: edge.showLabel,
       groupId: edge.groupId,
       keyNodeId: edge.keyNodeId,


### PR DESCRIPTION
## Summary

- Adds an optional `highlight` color to `edgeColor` and `inferredEdge` directives. The highlight is rendered as a wider, translucent SVG `<path>` underneath the main edge, so it stacks on top of any existing `style`/`weight`/`value`.
- Designed to be perf-cheap: the underlay is only inserted into the DOM for edges that actually set a highlight color, and the per-tick position update is one `getAttribute` + `setAttribute` on the sibling underlay. Non-highlighted edges pay zero extra cost (no extra path, no extra work).
- Wires the new field through `EdgeStyleDirective` / `InferredEdgeDirective` → `LayoutEdge` → `EdgeWithMetadata`, with a matching `getEdgeHighlight` resolver in `LayoutInstance`.
- Adds a color picker + enable toggle for the highlight color in the no-code editor (`ColorEdgeSelector` and `HelperEdgeSelector`).
- Documents the field in `docs/YAML_SPECIFICATION.md` with examples.

### YAML usage

```yaml
directives:
  - edgeColor:
      field: critical_path
      value: black
      highlight: "#ffeb3b"     # yellow glow under black edges

  - inferredEdge:
      name: reaches
      selector: "^parent"
      color: gray
      style: dashed
      highlight: "rgba(0, 200, 255, 0.6)"
```

## Implementation notes

- The highlight underlay is inserted as the first child of each `link-group` (`linkGroups.insert('path', ':first-child')`), so SVG painter's order renders it underneath the main edge.
- Main-path selectors in `webcola-cnd-graph.ts` were tightened from `path` / `querySelector('path')` to `path[data-link-id]` so layout updates and morph animations only touch the main edge, not the underlay.
- The underlay has no marker, no dasharray, and `pointer-events: none` (it never intercepts clicks).
- Underlay width = base weight + 8px, opacity 0.45, round line caps.

## Test plan

- [x] `npm run build:all` passes.
- [x] `npm run test:run -- tests/edge-style-filter.test.ts tests/field-selectors.test.ts tests/field-selectors-integration.test.ts` — all 17 tests pass.
- [ ] Manual: open the demo (`npm run serve`, port 8080), add a YAML directive with `highlight: '#ffeb3b'`, confirm the highlight is drawn beneath the edge and tracks routing during drag.
- [ ] Manual: confirm no-code editor's new Highlight color picker + Enabled toggle round-trips to YAML correctly.
- [ ] Manual: confirm highlighted dashed edges still render with dashes on top of the solid highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)