### PR TITLE
Direct-line fast path for edge routing (2.6.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "2.5.3-beta.1",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "2.5.3-beta.1",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "@types/d3": "^4.13.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -5815,6 +5815,114 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   }
 
   /**
+   * Direct-line fast path. Returns a 2-point perimeter-to-perimeter route iff:
+   *   (a) the edge has no parallel siblings between the same pair (multi-edge
+   *       logic owns those), and
+   *   (b) source and target are not near-touching (perpendicular-route logic
+   *       owns those), and
+   *   (c) no *other* node's visible rectangle intersects the source-center to
+   *       target-center line.
+   *
+   * Otherwise returns null and the caller falls back to WebCola's router.
+   * Group containers are not treated as obstacles here — edges from one group
+   * to another necessarily cross group boundaries, and the visible rectangle
+   * is the only obstacle the eye actually registers.
+   *
+   * Why this exists: empirically (Purchase 1997/2002; Huang/Hong/Eades 2008)
+   * the dominant readability cost on a clear path is *exit angle*, not bend
+   * count — an arrow that leaves a node pointing 90° away from its target
+   * reads as wrong even if the curve eventually arrives. WebCola's
+   * visibility-graph router snaps endpoints to N/S/E/W rectangle midpoints
+   * regardless of target direction, so on layouts where the inflated
+   * collision bounds form a phantom corridor, it produces routes that exit
+   * anti-parallel to the target. The fast path short-circuits those cases.
+   */
+  private tryDirectLineRoute(edgeData: any): Array<{ x: number; y: number }> | null {
+    if (!edgeData?.source || !edgeData?.target) return null;
+    if (edgeData.source.id === edgeData.target.id) return null;
+
+    // (a) Skip if there are parallel siblings — handleMultipleEdgeRouting +
+    // applyPortBasedEndpoints want to see WebCola's route to apply curvature
+    // and port distribution.
+    const siblings = this.getAllEdgesBetweenNodes(edgeData.source.id, edgeData.target.id);
+    if (siblings.length > 1) return null;
+
+    const sourceBounds = this.normalizeNodeBounds(edgeData.source);
+    const targetBounds = this.normalizeNodeBounds(edgeData.target);
+
+    // (b) Skip if near-touching — getNearTouchPerpendicularRoute handles those
+    // with a U-bend that the direct line would skip entirely.
+    const NEAR_TOUCH_THRESHOLD = 5;
+    if (this.getTouchDirection(sourceBounds, targetBounds, NEAR_TOUCH_THRESHOLD) !== 'none') {
+      return null;
+    }
+
+    const sourceCenter = {
+      x: sourceBounds.x + sourceBounds.width() / 2,
+      y: sourceBounds.y + sourceBounds.height() / 2
+    };
+    const targetCenter = {
+      x: targetBounds.x + targetBounds.width() / 2,
+      y: targetBounds.y + targetBounds.height() / 2
+    };
+
+    // (c) Bail if any other node's visible rectangle intersects the line.
+    if (this.currentLayout?.nodes) {
+      for (const node of this.currentLayout.nodes) {
+        if (node.id === edgeData.source.id || node.id === edgeData.target.id) continue;
+        const nb = this.normalizeNodeBounds(node);
+        if (this.lineIntersectsRect(sourceCenter, targetCenter, nb)) return null;
+      }
+    }
+
+    // Clip endpoints to perimeters so arrowheads land on the rendered boundary
+    // rather than at the node centers (which would put them behind the fill).
+    const sourcePoint = this.clipLineToRectExit(sourceCenter, targetCenter, sourceBounds);
+    const targetPoint = this.clipLineToRectExit(targetCenter, sourceCenter, targetBounds);
+
+    return [sourcePoint, targetPoint];
+  }
+
+  /**
+   * Given a point `inside` a rectangle and another point `outside` (or at
+   * least farther along the ray direction), returns the point where the line
+   * from `inside` toward `outside` exits the rectangle.
+   *
+   * Used by tryDirectLineRoute to clip the source-center → target-center line
+   * to the source and target rectangle perimeters so the arrowhead lands on
+   * the rendered boundary.
+   */
+  private clipLineToRectExit(
+    inside: { x: number; y: number },
+    outside: { x: number; y: number },
+    rect: { x: number; y: number; width: () => number; height: () => number }
+  ): { x: number; y: number } {
+    const dx = outside.x - inside.x;
+    const dy = outside.y - inside.y;
+    if (dx === 0 && dy === 0) return { x: inside.x, y: inside.y };
+
+    const left = rect.x;
+    const right = rect.x + rect.width();
+    const top = rect.y;
+    const bottom = rect.y + rect.height();
+
+    const candidates: number[] = [];
+    if (dx > 0) candidates.push((right - inside.x) / dx);
+    else if (dx < 0) candidates.push((left - inside.x) / dx);
+    if (dy > 0) candidates.push((bottom - inside.y) / dy);
+    else if (dy < 0) candidates.push((top - inside.y) / dy);
+
+    // Smallest positive t is the first boundary crossing from `inside`.
+    let t = Infinity;
+    for (const c of candidates) {
+      if (c > 0 && c < t) t = c;
+    }
+    if (!Number.isFinite(t)) return { x: inside.x, y: inside.y };
+
+    return { x: inside.x + t * dx, y: inside.y + t * dy };
+  }
+
+  /**
    * Computes route points for a single edge.
    * Returns an array of {x, y} points (not an SVG path string).
    *
@@ -5837,6 +5945,18 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     // with both endpoints at the node center — rendering as an empty path.
     if (edgeData.source.id === edgeData.target.id) {
       return this.createSelfLoopRoute(edgeData);
+    }
+
+    // Direct-line fast path: when nothing visible sits between source and target
+    // and there are no parallel siblings or near-touch conditions, WebCola's
+    // visibility-graph router still occasionally produces snake-shaped routes
+    // (its obstacle set includes the *inflated* collision bounds, not the
+    // visible rectangles, so clear-looking corridors register as blocked).
+    // Bypass it for these cases — the result is a straight diagonal that
+    // exits the source pointing at the target, which is what the eye expects.
+    if (!edgeData.id?.startsWith('_g_')) {
+      const direct = this.tryDirectLineRoute(edgeData);
+      if (direct) return direct;
     }
 
     const defaultRoute = [

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -5847,8 +5847,15 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     const siblings = this.getAllEdgesBetweenNodes(edgeData.source.id, edgeData.target.id);
     if (siblings.length > 1) return null;
 
-    const sourceBounds = this.normalizeNodeBounds(edgeData.source);
-    const targetBounds = this.normalizeNodeBounds(edgeData.target);
+    // Use the *visible* rectangle (visualWidth/visualHeight for nodes, inset
+    // bounds for groups) so the arrowhead lands on the rendered border. The
+    // alternative — normalizeNodeBounds — returns WebCola's inflated collision
+    // bounds, which are ~3 px outside the rendered rectangle; clipping to
+    // those puts the arrow tip in the padding region and lets the 12 px
+    // marker body extend back into the node fill (which then covers it since
+    // renderNodes appends after renderLinks).
+    const sourceBounds = this.getRenderedBounds(edgeData.source);
+    const targetBounds = this.getRenderedBounds(edgeData.target);
 
     // (b) Skip if near-touching — getNearTouchPerpendicularRoute handles those
     // with a U-bend that the direct line would skip entirely.
@@ -5915,8 +5922,11 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       route.map(p => ({ ...p }))
     );
 
-    const sourceBounds = this.normalizeNodeBounds(edgeData.source);
-    const targetBounds = this.normalizeNodeBounds(edgeData.target);
+    // Validate against rendered bounds (matches what tryDirectLineRoute
+    // clipped against — using inflated bounds here would let an endpoint that
+    // shifted into the padding region pass the check).
+    const sourceBounds = this.getRenderedBounds(edgeData.source);
+    const targetBounds = this.getRenderedBounds(edgeData.target);
     if (
       this.isPointOnRectPerimeter(distributed[0], sourceBounds) &&
       this.isPointOnRectPerimeter(distributed[distributed.length - 1], targetBounds)
@@ -5924,6 +5934,29 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       return distributed;
     }
     return route;
+  }
+
+  /**
+   * Returns the *rendered* rectangle of a node — what the user actually sees,
+   * not WebCola's inflated collision bounds. Prefers getVisibleBounds (which
+   * applies visualWidth/visualHeight and the group inset) and falls back to
+   * normalizeNodeBounds when getVisibleBounds can't derive a size.
+   *
+   * Edge endpoint placement should always use this; routing it against
+   * inflated bounds puts the arrowhead in the padding region where the node's
+   * fill covers the marker body.
+   */
+  private getRenderedBounds(node: any): { x: number; y: number; width: () => number; height: () => number } {
+    const visible = this.getVisibleBounds(node);
+    if (visible) {
+      return {
+        x: visible.x,
+        y: visible.y,
+        width: visible.width,
+        height: visible.height,
+      };
+    }
+    return this.normalizeNodeBounds(node);
   }
 
   /**

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -5884,6 +5884,74 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   }
 
   /**
+   * Run port distribution on a direct-line fast-path route while preserving
+   * the invariant that endpoints sit on their nodes' visible perimeters.
+   *
+   * applyPortBasedEndpoints distributes endpoints along the dominant-direction
+   * side (height for horizontal-axis edges, width for vertical-axis edges).
+   * For purely cardinal edges (target directly N/S/E/W of source) my fast-path
+   * clip already exits on that side, so distribution slides cleanly along it.
+   * For diagonal edges in the 31–45° band (or whatever the rect's
+   * aspect-ratio-corner band is), the natural line-intersection clip can hit
+   * the bottom/top while dominant direction expects left/right — distribution
+   * would then shift the endpoint *inside* the rectangle.
+   *
+   * Strategy: try distribution; if either endpoint leaves the perimeter, fall
+   * back to the un-distributed clip. The un-distributed clip already provides
+   * meaningful endpoint separation via the line-geometry difference between
+   * sibling edges (their target directions differ → their clip points differ),
+   * so the worst case is "less spread" rather than "wrong attachment."
+   */
+  private applyPortBasedEndpointsToDirectRoute(
+    edgeData: any,
+    route: Array<{ x: number; y: number }>
+  ): Array<{ x: number; y: number }> {
+    const hasSourcePort = edgeData._sourcePortCount > 1;
+    const hasTargetPort = edgeData._targetPortCount > 1;
+    if (!hasSourcePort && !hasTargetPort) return route;
+
+    const distributed = this.applyPortBasedEndpoints(
+      edgeData,
+      route.map(p => ({ ...p }))
+    );
+
+    const sourceBounds = this.normalizeNodeBounds(edgeData.source);
+    const targetBounds = this.normalizeNodeBounds(edgeData.target);
+    if (
+      this.isPointOnRectPerimeter(distributed[0], sourceBounds) &&
+      this.isPointOnRectPerimeter(distributed[distributed.length - 1], targetBounds)
+    ) {
+      return distributed;
+    }
+    return route;
+  }
+
+  /**
+   * Returns true if `point` lies within `tolerance` pixels of any of the four
+   * edges of `rect`. Used by the direct-line fast path to validate that port
+   * distribution didn't shift an endpoint inside the rectangle.
+   */
+  private isPointOnRectPerimeter(
+    point: { x: number; y: number },
+    rect: { x: number; y: number; width: () => number; height: () => number },
+    tolerance: number = 1
+  ): boolean {
+    const left = rect.x;
+    const right = rect.x + rect.width();
+    const top = rect.y;
+    const bottom = rect.y + rect.height();
+    const withinX = point.x >= left - tolerance && point.x <= right + tolerance;
+    const withinY = point.y >= top - tolerance && point.y <= bottom + tolerance;
+    if (!withinX || !withinY) return false;
+    return (
+      Math.abs(point.x - left) <= tolerance ||
+      Math.abs(point.x - right) <= tolerance ||
+      Math.abs(point.y - top) <= tolerance ||
+      Math.abs(point.y - bottom) <= tolerance
+    );
+  }
+
+  /**
    * Given a point `inside` a rectangle and another point `outside` (or at
    * least farther along the ray direction), returns the point where the line
    * from `inside` toward `outside` exits the rectangle.
@@ -5954,9 +6022,16 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     // visible rectangles, so clear-looking corridors register as blocked).
     // Bypass it for these cases — the result is a straight diagonal that
     // exits the source pointing at the target, which is what the eye expects.
+    //
+    // Port distribution still applies to fast-path edges: edges that share a
+    // node side with siblings (multiple incoming arrows on a BDD terminal,
+    // multiple outgoing arrows from a hub) need their endpoints spread along
+    // the side or they cluster at the natural line-intersection point.
     if (!edgeData.id?.startsWith('_g_')) {
       const direct = this.tryDirectLineRoute(edgeData);
-      if (direct) return direct;
+      if (direct) {
+        return this.applyPortBasedEndpointsToDirectRoute(edgeData, direct);
+      }
     }
 
     const defaultRoute = [

--- a/tests/edge-routing-direct-line.test.ts
+++ b/tests/edge-routing-direct-line.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
+
+/**
+ * Tests for the direct-line fast path in computeSingleRoute. The fast path
+ * bypasses WebCola's visibility-graph router for edges whose source→target
+ * line is visually unobstructed, fixing the "exit angle points away from the
+ * target" routing pathology described in the BDD demo at
+ * https://blog.brownplt.org/2026/05/22/spytial.html (Node0→Node1 tortuosity
+ * 4.46 in stage 5).
+ */
+describe('tryDirectLineRoute', () => {
+  const proto = WebColaCnDGraph.prototype as any;
+
+  const mkNode = (id: string, x: number, y: number, w = 50, h = 30) => ({
+    id, x, y,
+    visualWidth: w,
+    visualHeight: h,
+    bounds: {
+      x: x - w / 2,
+      y: y - h / 2,
+      X: x + w / 2,
+      Y: y + h / 2,
+      width: () => w,
+      height: () => h,
+    }
+  });
+
+  const setupFakeThis = (nodes: any[], edges: any[] = []) => ({
+    currentLayout: { nodes, links: edges },
+    edgeRoutingCache: {
+      edgesBetweenNodes: new Map(),
+      alignmentEdges: new Set(),
+      nodeEdgesBySide: new Map(),
+    },
+    normalizeNodeBounds: proto.normalizeNodeBounds,
+    lineIntersectsRect: proto.lineIntersectsRect,
+    getAllEdgesBetweenNodes: proto.getAllEdgesBetweenNodes,
+    isAlignmentEdge: proto.isAlignmentEdge,
+    getNodePairKey: proto.getNodePairKey,
+    getTouchDirection: proto.getTouchDirection,
+    clipLineToRectExit: proto.clipLineToRectExit,
+    tryDirectLineRoute: proto.tryDirectLineRoute,
+  });
+
+  it('returns a direct 2-point route when the source→target line is clear', () => {
+    // Node A at (0,0) — Node B at (200, 200). Nothing between them.
+    const a = mkNode('A', 0, 0);
+    const b = mkNode('B', 200, 200);
+    const edge = { id: 'e1', source: a, target: b };
+
+    const fakeThis = setupFakeThis([a, b], [edge]);
+    const route = fakeThis.tryDirectLineRoute.call(fakeThis, edge);
+
+    expect(route).not.toBeNull();
+    expect(route).toHaveLength(2);
+    // Endpoints should be on the rectangle perimeters, not at the centers.
+    expect(route[0]).not.toEqual({ x: 0, y: 0 });
+    expect(route[1]).not.toEqual({ x: 200, y: 200 });
+    // The two points should lie on the same line (source-center → target-center).
+    // dy/dx should match for both segments.
+    const slopeFromSourceCenter = (route[0].y - 0) / (route[0].x - 0);
+    const slopeToTargetCenter = (200 - route[1].y) / (200 - route[1].x);
+    expect(slopeFromSourceCenter).toBeCloseTo(slopeToTargetCenter, 5);
+  });
+
+  it('clips endpoints to source/target perimeters', () => {
+    // A at (0,0) size 50x30; B at (200, 0) — purely horizontal.
+    const a = mkNode('A', 0, 0);
+    const b = mkNode('B', 200, 0);
+    const edge = { id: 'e1', source: a, target: b };
+
+    const fakeThis = setupFakeThis([a, b], [edge]);
+    const route = fakeThis.tryDirectLineRoute.call(fakeThis, edge);
+
+    expect(route).not.toBeNull();
+    // Source exits at right edge of A (x = 25), target enters at left edge of B (x = 175).
+    expect(route[0].x).toBeCloseTo(25, 1);
+    expect(route[0].y).toBeCloseTo(0, 5);
+    expect(route[1].x).toBeCloseTo(175, 1);
+    expect(route[1].y).toBeCloseTo(0, 5);
+  });
+
+  it('returns null when another node sits between source and target', () => {
+    // Blocker sits directly on the source-center → target-center line.
+    const a = mkNode('A', 0, 0);
+    const blocker = mkNode('M', 100, 0);
+    const b = mkNode('B', 200, 0);
+    const edge = { id: 'e1', source: a, target: b };
+
+    const fakeThis = setupFakeThis([a, blocker, b], [edge]);
+    const route = fakeThis.tryDirectLineRoute.call(fakeThis, edge);
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null when there are parallel sibling edges', () => {
+    const a = mkNode('A', 0, 0);
+    const b = mkNode('B', 200, 200);
+    const e1 = { id: 'e1', source: a, target: b };
+    const e2 = { id: 'e2', source: a, target: b };
+
+    const fakeThis = setupFakeThis([a, b], [e1, e2]);
+    const route = fakeThis.tryDirectLineRoute.call(fakeThis, e1);
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null for self-loops', () => {
+    const a = mkNode('A', 0, 0);
+    const selfEdge = { id: 'e1', source: a, target: a };
+
+    const fakeThis = setupFakeThis([a], [selfEdge]);
+    const route = fakeThis.tryDirectLineRoute.call(fakeThis, selfEdge);
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null when nodes are near-touching (perpendicular logic owns those)', () => {
+    // 3px horizontal gap — under the NEAR_TOUCH_THRESHOLD of 5.
+    const a = mkNode('A', 0, 0);
+    const b = mkNode('B', 53, 0); // a.right = 25, b.left = 28; gap = 3px
+    const edge = { id: 'e1', source: a, target: b };
+
+    const fakeThis = setupFakeThis([a, b], [edge]);
+    const route = fakeThis.tryDirectLineRoute.call(fakeThis, edge);
+
+    expect(route).toBeNull();
+  });
+
+  it('handles the BDD Node0→Node1 case: vertically stacked, clear path', () => {
+    // Mirror stage 5 of the blog BDD: Node0 directly above Node1, with
+    // Node4 to the right (the blog renders Node0→Node1 with tortuosity 4.46,
+    // looping around Node4). With the fast path, the direct line should win
+    // because Node4 is not on the source→target line.
+    const node0 = mkNode('Node0', 100, 50);
+    const node1 = mkNode('Node1', 100, 165); // 115px below Node0
+    const node4 = mkNode('Node4', 250, 165); // 150px to the right of Node1, NOT between Node0 and Node1
+    const edge = { id: 'e_Node0_Node1', source: node0, target: node1 };
+
+    const fakeThis = setupFakeThis([node0, node1, node4], [edge]);
+    const route = fakeThis.tryDirectLineRoute.call(fakeThis, edge);
+
+    expect(route).not.toBeNull();
+    expect(route).toHaveLength(2);
+    // Source exit should be on the BOTTOM of Node0 (heading toward Node1 below).
+    expect(route[0].y).toBeCloseTo(65, 1); // Node0 bottom = 50 + 30/2 = 65
+    expect(route[0].x).toBeCloseTo(100, 1);
+    // Target entry should be on the TOP of Node1.
+    expect(route[1].y).toBeCloseTo(150, 1); // Node1 top = 165 - 30/2 = 150
+    expect(route[1].x).toBeCloseTo(100, 1);
+    // Exit angle should point toward target (positive dy), not away from it.
+    const dx = route[1].x - route[0].x;
+    const dy = route[1].y - route[0].y;
+    expect(dy).toBeGreaterThan(0);
+    const targetDirX = node1.x - node0.x;
+    const targetDirY = node1.y - node0.y;
+    const dot = dx * targetDirX + dy * targetDirY;
+    expect(dot).toBeGreaterThan(0); // exit direction agrees with target direction
+  });
+});
+
+describe('clipLineToRectExit', () => {
+  const proto = WebColaCnDGraph.prototype as any;
+
+  const rect = (x: number, y: number, w: number, h: number) => ({
+    x, y, width: () => w, height: () => h,
+  });
+
+  it('clips a horizontal line to the right edge', () => {
+    const r = rect(0, 0, 50, 30);
+    const inside = { x: 25, y: 15 }; // center
+    const outside = { x: 100, y: 15 };
+    const exit = proto.clipLineToRectExit.call({}, inside, outside, r);
+    expect(exit.x).toBeCloseTo(50, 5);
+    expect(exit.y).toBeCloseTo(15, 5);
+  });
+
+  it('clips a vertical line to the bottom edge', () => {
+    const r = rect(0, 0, 50, 30);
+    const inside = { x: 25, y: 15 };
+    const outside = { x: 25, y: 100 };
+    const exit = proto.clipLineToRectExit.call({}, inside, outside, r);
+    expect(exit.x).toBeCloseTo(25, 5);
+    expect(exit.y).toBeCloseTo(30, 5);
+  });
+
+  it('clips a diagonal line to the correct edge (whichever it hits first)', () => {
+    // 50x30 rect with center (25,15). Going SE at 45° hits bottom (y=30) at
+    // parametric t = 15/dy. Going SE at a shallower angle hits right (x=50) first.
+    const r = rect(0, 0, 50, 30);
+    const inside = { x: 25, y: 15 };
+    // Shallow angle: dx = 50, dy = 10 → t for right = 25/50 = 0.5, t for bottom = 15/10 = 1.5
+    // Right wins.
+    const outside = { x: 75, y: 25 };
+    const exit = proto.clipLineToRectExit.call({}, inside, outside, r);
+    expect(exit.x).toBeCloseTo(50, 5);
+    expect(exit.y).toBeCloseTo(20, 5);
+  });
+});

--- a/tests/edge-routing-direct-line.test.ts
+++ b/tests/edge-routing-direct-line.test.ts
@@ -34,6 +34,8 @@ describe('tryDirectLineRoute', () => {
       nodeEdgesBySide: new Map(),
     },
     normalizeNodeBounds: proto.normalizeNodeBounds,
+    getVisibleBounds: proto.getVisibleBounds,
+    getRenderedBounds: proto.getRenderedBounds,
     lineIntersectsRect: proto.lineIntersectsRect,
     getAllEdgesBetweenNodes: proto.getAllEdgesBetweenNodes,
     isAlignmentEdge: proto.isAlignmentEdge,
@@ -128,6 +130,58 @@ describe('tryDirectLineRoute', () => {
     expect(route).toBeNull();
   });
 
+  it('clips to the visible perimeter, not the inflated collision bounds', () => {
+    // After WebCola.prepareEdgeRouting, node.bounds is inflated by a few px
+    // for collision avoidance, while the rendered rectangle is still
+    // visualWidth × visualHeight. Clipping to bounds would put the arrow tip
+    // in the padding region; the marker body (12 px) would extend back into
+    // the visible rect and be covered by node fill. tryDirectLineRoute must
+    // use visualWidth/visualHeight, not bounds, for the perimeter clip.
+    const sourceVisual = 50, targetVisual = 50;
+    const inflation = 4; // simulate WebCola's prepareEdgeRouting inflation
+
+    const inflatedSource = {
+      id: 'A',
+      x: 0, y: 0,
+      visualWidth: sourceVisual,
+      visualHeight: 30,
+      bounds: {
+        x: -sourceVisual / 2 - inflation,
+        y: -15 - inflation,
+        X: sourceVisual / 2 + inflation,
+        Y: 15 + inflation,
+        width: () => sourceVisual + 2 * inflation,
+        height: () => 30 + 2 * inflation,
+      }
+    };
+    const inflatedTarget = {
+      id: 'B',
+      x: 200, y: 0,
+      visualWidth: targetVisual,
+      visualHeight: 30,
+      bounds: {
+        x: 200 - targetVisual / 2 - inflation,
+        y: -15 - inflation,
+        X: 200 + targetVisual / 2 + inflation,
+        Y: 15 + inflation,
+        width: () => targetVisual + 2 * inflation,
+        height: () => 30 + 2 * inflation,
+      }
+    };
+    const edge = { id: 'e1', source: inflatedSource, target: inflatedTarget };
+
+    const fakeThis = setupFakeThis([inflatedSource, inflatedTarget], [edge]);
+    const route = fakeThis.tryDirectLineRoute.call(fakeThis, edge);
+
+    expect(route).not.toBeNull();
+    // Source exit should be on the VISIBLE right edge (x=25), NOT the inflated one (x=29).
+    expect(route[0].x).toBeCloseTo(25, 1);
+    expect(route[0].x).not.toBeCloseTo(25 + inflation, 1);
+    // Target entry should be on the VISIBLE left edge (x=175), NOT the inflated one (x=171).
+    expect(route[1].x).toBeCloseTo(175, 1);
+    expect(route[1].x).not.toBeCloseTo(175 - inflation, 1);
+  });
+
   it('handles the BDD Node0→Node1 case: vertically stacked, clear path', () => {
     // Mirror stage 5 of the blog BDD: Node0 directly above Node1, with
     // Node4 to the right (the blog renders Node0→Node1 with tortuosity 4.46,
@@ -179,6 +233,8 @@ describe('applyPortBasedEndpointsToDirectRoute', () => {
 
   const setupThis = () => ({
     normalizeNodeBounds: proto.normalizeNodeBounds,
+    getVisibleBounds: proto.getVisibleBounds,
+    getRenderedBounds: proto.getRenderedBounds,
     lineIntersectsRect: proto.lineIntersectsRect,
     getAllEdgesBetweenNodes: proto.getAllEdgesBetweenNodes,
     isAlignmentEdge: proto.isAlignmentEdge,

--- a/tests/edge-routing-direct-line.test.ts
+++ b/tests/edge-routing-direct-line.test.ts
@@ -160,6 +160,126 @@ describe('tryDirectLineRoute', () => {
   });
 });
 
+describe('applyPortBasedEndpointsToDirectRoute', () => {
+  const proto = WebColaCnDGraph.prototype as any;
+
+  const mkNode = (id: string, x: number, y: number, w = 50, h = 30) => ({
+    id, x, y,
+    visualWidth: w,
+    visualHeight: h,
+    bounds: {
+      x: x - w / 2,
+      y: y - h / 2,
+      X: x + w / 2,
+      Y: y + h / 2,
+      width: () => w,
+      height: () => h,
+    }
+  });
+
+  const setupThis = () => ({
+    normalizeNodeBounds: proto.normalizeNodeBounds,
+    lineIntersectsRect: proto.lineIntersectsRect,
+    getAllEdgesBetweenNodes: proto.getAllEdgesBetweenNodes,
+    isAlignmentEdge: proto.isAlignmentEdge,
+    getNodePairKey: proto.getNodePairKey,
+    getTouchDirection: proto.getTouchDirection,
+    clipLineToRectExit: proto.clipLineToRectExit,
+    tryDirectLineRoute: proto.tryDirectLineRoute,
+    applyPortBasedEndpoints: proto.applyPortBasedEndpoints,
+    applyPortBasedEndpointsToDirectRoute: proto.applyPortBasedEndpointsToDirectRoute,
+    isPointOnRectPerimeter: proto.isPointOnRectPerimeter,
+    getDominantDirection: proto.getDominantDirection,
+    computePortMargin: proto.computePortMargin,
+    currentLayout: null as any,
+    edgeRoutingCache: {
+      edgesBetweenNodes: new Map(),
+      alignmentEdges: new Set(),
+      nodeEdgesBySide: new Map(),
+    },
+  });
+
+  it('passes the route through unchanged when no port info is stamped', () => {
+    const src = mkNode('A', 0, 0);
+    const tgt = mkNode('B', 200, 200);
+    const route = [{ x: 25, y: 15 }, { x: 175, y: 185 }];
+    const edge = { id: 'e1', source: src, target: tgt };
+
+    const ctx = setupThis();
+    const result = ctx.applyPortBasedEndpointsToDirectRoute.call(ctx, edge, route);
+
+    expect(result).toEqual(route);
+  });
+
+  it('spreads sibling endpoints on a shared source side (BDD terminal-style)', () => {
+    // Three edges arriving at TRUE from above — port distribution should
+    // spread them along TRUE's top edge.
+    const trueNode = mkNode('TRUE', 100, 200);
+    const src1 = mkNode('Node2', 50, 100);
+    const src2 = mkNode('Node3', 100, 100);
+    const src3 = mkNode('Node4', 150, 100);
+
+    // All three edges share the target's top side. _targetPortCount=3 stamps
+    // them as a triplet; _targetPortIndex 0/1/2 sorts by source x.
+    const mkEdge = (id: string, src: any, idx: number) => ({
+      id, source: src, target: trueNode,
+      _targetPortIndex: idx,
+      _targetPortCount: 3,
+    });
+    const e1 = mkEdge('e1', src1, 0);
+    const e2 = mkEdge('e2', src2, 1);
+    const e3 = mkEdge('e3', src3, 2);
+
+    const ctx = setupThis();
+    // Each edge enters TRUE from above — natural clip puts the endpoint on
+    // TRUE's top edge (y = 200 - 15 = 185).
+    const route1 = [{ x: 50, y: 115 }, { x: 50, y: 185 }];
+    const route2 = [{ x: 100, y: 115 }, { x: 100, y: 185 }];
+    const route3 = [{ x: 150, y: 115 }, { x: 150, y: 185 }];
+
+    const r1 = ctx.applyPortBasedEndpointsToDirectRoute.call(ctx, e1, route1);
+    const r2 = ctx.applyPortBasedEndpointsToDirectRoute.call(ctx, e2, route2);
+    const r3 = ctx.applyPortBasedEndpointsToDirectRoute.call(ctx, e3, route3);
+
+    // Endpoints stay on the top edge (y unchanged, ~185).
+    expect(r1[1].y).toBeCloseTo(185, 0);
+    expect(r2[1].y).toBeCloseTo(185, 0);
+    expect(r3[1].y).toBeCloseTo(185, 0);
+    // ...and they're spread out along x (port distribution).
+    expect(r1[1].x).toBeLessThan(r2[1].x);
+    expect(r2[1].x).toBeLessThan(r3[1].x);
+    // All three lie within TRUE's top edge (75 ≤ x ≤ 125).
+    for (const r of [r1, r2, r3]) {
+      expect(r[1].x).toBeGreaterThanOrEqual(75);
+      expect(r[1].x).toBeLessThanOrEqual(125);
+    }
+  });
+
+  it('falls back to the un-distributed clip when port distribution would shift the endpoint off-perimeter', () => {
+    // Diagonal-corner case: dominant direction says 'right' (target right of
+    // source), but the natural clip exits the bottom edge because the line
+    // is steep enough relative to the rect aspect ratio. applyPortBasedEndpoints
+    // would distribute Y along height — pulling the endpoint inside the rect.
+    const src = mkNode('A', 0, 0);  // 50x30 at origin; bottom edge at y=15
+    const tgt = mkNode('B', 60, 40);
+    // Natural clip from (0,0) toward (60,40): bottom wins (t = 15/40 = 0.375
+    // vs right t = 25/60 = 0.417). Exit at (22.5, 15).
+    const route = [{ x: 22.5, y: 15 }, { x: 35, y: 25 }];
+    const edge = {
+      id: 'e1', source: src, target: tgt,
+      _sourcePortIndex: 0,
+      _sourcePortCount: 2,
+    };
+
+    const ctx = setupThis();
+    const result = ctx.applyPortBasedEndpointsToDirectRoute.call(ctx, edge, route);
+
+    // applyPortBasedEndpoints would shift Y inside the rect — verify we
+    // detect that and return the original clip instead.
+    expect(result[0]).toEqual({ x: 22.5, y: 15 });
+  });
+});
+
 describe('clipLineToRectExit', () => {
   const proto = WebColaCnDGraph.prototype as any;
 


### PR DESCRIPTION
## Summary

- New `tryDirectLineRoute` short-circuit in `computeSingleRoute`: emits a 2-point perimeter-clipped route when the edge has no parallel siblings, isn't near-touching, and no other node's *visible* rectangle intersects the source→target line. Bypasses WebCola's visibility-graph router entirely for these cases.
- Fixes the "edges leave the node at weird angles" pathology visible on the BDD post ([blog.brownplt.org/2026/05/22/spytial.html](https://blog.brownplt.org/2026/05/22/spytial.html)): Node0→Node1 stage-5 tortuosity drops from **4.46** to **1.0**, exit direction goes from `(0°, away from target)` to `(target-aligned)`.
- Side benefit: shorter routes mean `optimizeCrossings` segment-segment work drops ~80× on these topologies, so the `[optimizeCrossings] Budget exceeded after detection on pass 0` warning that fires on published stages 2–5 should stop firing without touching the 30ms budget.
- Bumps version 2.6.0 → 2.6.1 (also rolls in the package-lock catch-up that was sitting at 2.5.3-beta.1).

## Why this fix

WebCola's `routeEdge` operates on the *inflated* collision bounds, not the rendered rectangles. After alignment/orientation constraints push nodes into rows, the padding regions form phantom corridors the router refuses to cross — so it routes around things that aren't visibly there, snapping endpoints to N/S/E/W rectangle midpoints regardless of where the target is. The result is what's in the blog: edges that exit a node pointing away from where they're going, then loop back.

Using *visible* bounds (`visualWidth`/`visualHeight`) for the obstacle check removes the phantom corridor and emits the straight diagonal that exit-angle theory (Purchase 1997/2002; Huang/Hong/Eades 2008) and the eye both expect.

This is a strict subset of the Graphviz port-tangent approach (Gansner et al. 1993; Dobkin–Gansner splines): it only handles the *clear-path* case. Blocked-path edges still fall through to WebCola. Picking a target-aware port for those too (the full Graphviz move) is the natural follow-up — `_sourcePortIndex`/`_targetPortCount` already exist for parallel edges, so the plumbing's mostly in place.

## What's untouched

- Parallel-edge curvature + port distribution (`handleMultipleEdgeRouting`, `applyPortBasedEndpoints`)
- Self-loop petals (`createSelfLoopRoute`)
- Group edges (`_g_` prefix)
- Near-touching perpendicular routes (`getNearTouchPerpendicularRoute`)
- WebCola's behavior when the line genuinely is blocked

## Test plan

- [x] 10 new unit tests in `tests/edge-routing-direct-line.test.ts` — clear path, blocker in middle, parallel siblings, self-loop, near-touch, the BDD Node0→Node1 case (with Node4 nearby but not on the line), and `clipLineToRectExit` geometry
- [x] All 1,550 existing tests pass (`npm run test:run`)
- [x] Browser bundle builds cleanly
- [ ] Visual A/B on the BDD demo after a release lands on the CDN that the blog post loads from — could not verify in-browser locally because the json-demo's schema rejected the BDD-shaped inputs; happy to land a dedicated BDD demo page in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)