### PR TITLE
Bump simple-graph-query to ^2.7.0 (spytial-core 2.6.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "2.6.1",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "2.6.1",
+      "version": "2.6.3",
       "license": "MIT",
       "dependencies": {
         "@types/d3": "^4.13.12",
@@ -27,7 +27,7 @@
         "lodash": "^4.17.21",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "simple-graph-query": "^2.6.0",
+        "simple-graph-query": "^2.7.0",
         "webcola": "^3.4.0"
       },
       "devDependencies": {
@@ -8926,10 +8926,9 @@
       "peer": true
     },
     "node_modules/simple-graph-query": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/simple-graph-query/-/simple-graph-query-2.6.0.tgz",
-      "integrity": "sha512-SSeIySc/+urjHe4yA7D1/ez5wzGPTFEpeXqYdcQafA0wYYCnQwENCajJ7pMoSRQkZuKypi9WkBqCJBzdZdpT2A==",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/simple-graph-query/-/simple-graph-query-2.7.0.tgz",
+      "integrity": "sha512-sPt77bAY0YItIGQwPfOYBj32OUAD7jTHnOpLC90g04UvtixsmJ7ShDt6uYiUnhMyI/+M5QZrSKov3z8s1lCzsQ==",
       "dependencies": {
         "@types/lodash": "^4.17.16",
         "@types/node": "^22.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",
@@ -112,7 +112,7 @@
     "lodash": "^4.17.21",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "simple-graph-query": "^2.6.0",
+    "simple-graph-query": "^2.7.0",
     "webcola": "^3.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `simple-graph-query` from `^2.6.0` to `^2.7.0` (latest on npm).
- Bump `spytial-core` patch version `2.6.2` → `2.6.3`.
- `package-lock.json` regenerated.

## Test plan
- [x] `npm run build:all` succeeds locally
- [ ] CI passes on a supported Node version (local node 16 is below the `>=18` engine requirement, so `npm run test:run` cannot be run here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)