### PR TITLE
Reject size constraints with non-positive dimensions

### DIFF
--- a/src/components/NoCodeView/Selectors/SizeSelector.tsx
+++ b/src/components/NoCodeView/Selectors/SizeSelector.tsx
@@ -51,8 +51,15 @@ export const SizeSelector: React.FC<SizeSelectorProps> = ({
         <input
           type="number"
           name="width"
+          min={1}
+          step={1}
           defaultValue={width}
-          onChange={(e) => onUpdate({ params: { ...data.params, width: Number(e.target.value) } })}
+          onChange={(e) => {
+            const next = Number(e.target.value);
+            if (Number.isFinite(next) && next > 0) {
+              onUpdate({ params: { ...data.params, width: next } });
+            }
+          }}
           required
         />
       </div>
@@ -61,8 +68,15 @@ export const SizeSelector: React.FC<SizeSelectorProps> = ({
         <input
           type="number"
           name="height"
+          min={1}
+          step={1}
           defaultValue={height}
-          onChange={(e) => onUpdate({ params: { ...data.params, height: Number(e.target.value) } })}
+          onChange={(e) => {
+            const next = Number(e.target.value);
+            if (Number.isFinite(next) && next > 0) {
+              onUpdate({ params: { ...data.params, height: next } });
+            }
+          }}
           required
         />
       </div>

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -343,7 +343,7 @@ interface DirectivesBlock {
 
 function assertPositiveSizeDimension(value: unknown, label: string): void {
     if (value === undefined || value === null) {
-        return;
+        throw new Error(`Size ${label} is required and must be greater than 0`);
     }
 
     if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {

--- a/tests/size-hideatom-dual-syntax.test.ts
+++ b/tests/size-hideatom-dual-syntax.test.ts
@@ -223,4 +223,62 @@ directives:
       expect(layoutSpec.directives.atomColors).toHaveLength(1);
     });
   });
+
+  describe('size validation rejects non-positive values', () => {
+    const invalidSizes: { label: string; height: unknown; width: unknown }[] = [
+      { label: 'zero width', height: 100, width: 0 },
+      { label: 'zero height', height: 0, width: 100 },
+      { label: 'negative width', height: 100, width: -50 },
+      { label: 'negative height', height: -25, width: 100 },
+      { label: 'both zero', height: 0, width: 0 },
+    ];
+
+    for (const { label, height, width } of invalidSizes) {
+      it(`rejects size with ${label} in directives block`, () => {
+        const yaml = `
+constraints: []
+directives:
+  - size:
+      selector: Type1
+      height: ${height}
+      width: ${width}
+`;
+        expect(() => parseLayoutSpec(yaml)).toThrow(/must be greater than 0/);
+      });
+
+      it(`rejects size with ${label} in constraints block`, () => {
+        const yaml = `
+constraints:
+  - size:
+      selector: Type1
+      height: ${height}
+      width: ${width}
+directives: []
+`;
+        expect(() => parseLayoutSpec(yaml)).toThrow(/must be greater than 0/);
+      });
+    }
+
+    it('rejects size with missing width in directives block', () => {
+      const yaml = `
+constraints: []
+directives:
+  - size:
+      selector: Type1
+      height: 100
+`;
+      expect(() => parseLayoutSpec(yaml)).toThrow(/width/);
+    });
+
+    it('rejects size with missing height in constraints block', () => {
+      const yaml = `
+constraints:
+  - size:
+      selector: Type1
+      width: 100
+directives: []
+`;
+      expect(() => parseLayoutSpec(yaml)).toThrow(/height/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Tighten `assertPositiveSizeDimension` in `src/layout/layoutspec.ts`: missing width/height now throw instead of silently passing through. The `<= 0` check already existed, but `undefined`/`null` slipped past and could produce an `AtomSizeDirective` with `width: undefined`.
- Add `min={1}`, `step={1}`, and an onChange guard to the NoCodeView `SizeSelector` so the UI can no longer emit a non-positive size.
- Add 12 new tests covering zero/negative width and height in both constraint and directive YAML blocks, plus missing-dimension cases.

Paired with [spytial-lean-formalization#12](https://github.com/sidprasad/spytial-lean-formalization/pull/12), which makes positive Box dimensions a type-level invariant in the mechanization.

## Test plan
- [x] `npx vitest run tests/size-hideatom-dual-syntax.test.ts` — 20/20 pass (12 new)
- [x] `npx vitest run tests/yaml-generation-size-hideatom.test.ts tests/layout-instance.test.ts` — 23/23 pass
- [x] `npx tsc --noEmit` — no new errors in touched files (pre-existing errors in `webcola-cnd-graph.ts` and `webcolatranslator.ts` are unrelated)
- [ ] CI green on this branch