### PR TITLE
feat(alloy-instance): looplength loopback + visualizer cnd/theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "@types/d3": "^4.13.12",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,28 @@
   "types": "./dist/browser/spytial-core-complete.global.d.ts",
   "files": [
     "dist/browser",
-    "dist/components"
+    "dist/components",
+    "dist/alloy-instance.js",
+    "dist/alloy-instance.mjs",
+    "dist/alloy-instance.d.ts",
+    "dist/alloy-instance.d.mts",
+    "dist/alloy-instance.js.map",
+    "dist/alloy-instance.mjs.map"
   ],
   "exports": {
     ".": {
       "import": "./dist/browser/spytial-core-complete.global.js",
       "require": "./dist/browser/spytial-core-complete.global.js"
+    },
+    "./alloy-instance": {
+      "import": {
+        "types": "./dist/alloy-instance.d.mts",
+        "default": "./dist/alloy-instance.mjs"
+      },
+      "require": {
+        "types": "./dist/alloy-instance.d.ts",
+        "default": "./dist/alloy-instance.js"
+      }
     },
     "./components/*": {
       "import": "./dist/components/*.global.js",
@@ -21,9 +37,10 @@
   "scripts": {
     "build": "npm run build:all",
     "build:parser": "peggy --plugin ts-pegjs -o src/evaluators/layout/layout-query-parser.ts src/evaluators/layout/layout-query.pegjs",
+    "build:lib": "tsup --config tsup.alloy-instance.config.ts",
     "build:browser": "tsup --config tsup.browser.config.ts",
     "build:components": "tsup --config tsup.components.config.ts",
-    "build:all": "npm run build:parser && npm run build:browser && npm run build:components",
+    "build:all": "npm run build:parser && npm run build:browser && npm run build:components && npm run build:lib",
     "dev": "tsup --watch",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/data-instance/alloy/alloy-instance/src/datum.ts
+++ b/src/data-instance/alloy/alloy-instance/src/datum.ts
@@ -3,6 +3,8 @@ import { AlloyInstance } from './instance';
 
 export interface VisualizerConfig {
   script?: string
+  theme?: string
+  cnd?: string
 }
 
 export interface AlloyDatum {

--- a/src/data-instance/alloy/alloy-instance/src/xml.ts
+++ b/src/data-instance/alloy/alloy-instance/src/xml.ts
@@ -9,24 +9,57 @@ export function parseAlloyXML(xml: string): AlloyDatum {
   const instances = Array.from(document.querySelectorAll('instance'));
   if (!instances.length) throw new Error(`No Alloy instance in XML: ${xml}`);
   
-  const maybeVisualizer = document.querySelector('visualizer');
-  const maybeVizScriptText = maybeVisualizer === null ? 
-                               undefined : 
-                               parseStringAttribute(maybeVisualizer, 'script');
+  // A provider may attach visualizer configuration (script / theme / cnd) to the instance XML as
+  // <visualizer ...> elements. This is not part of the Alloy instance XML spec, but Sterling/Forge
+  // use it — e.g. Forge embeds the Cope and Drag spec as a `cnd` attribute.
+  const visualizerElements = document.querySelectorAll('visualizer');
+  let maybeScriptText: string | undefined;
+  let maybeThemeText: string | undefined;
+  let maybeCnDText: string | undefined;
+  for (const vis of Array.from(visualizerElements)) {
+    // The last visualizer element for a given attribute wins.
+    maybeScriptText = parseStringAttribute(vis as globalThis.Element, 'script') ?? maybeScriptText;
+    maybeThemeText = parseStringAttribute(vis as globalThis.Element, 'theme') ?? maybeThemeText;
+    maybeCnDText = parseStringAttribute(vis as globalThis.Element, 'cnd') ?? maybeCnDText;
+  }
+
   return {
     instances: instances.map((element) => instanceFromElement(element as globalThis.Element)),
     bitwidth: parseNumericAttribute(instances[0], 'bitwidth'),
     command: parseStringAttribute(instances[0], 'command'),
-    loopBack:
-      parseNumericAttribute(instances[0], 'backloop') ??
-      // TODO: Remove this hack once forge is fixed
-      parseNumericAttribute(instances[0], 'loop'),
+    loopBack: parseLoopBack(instances[0]),
     maxSeq: parseNumericAttribute(instances[0], 'maxseq'),
     maxTrace: parseNumericAttribute(instances[0], 'maxtrace'),
     minTrace: parseNumericAttribute(instances[0], 'mintrace'),
     traceLength: parseNumericAttribute(instances[0], 'tracelength'),
-    visualizerConfig: {script: deEscape(maybeVizScriptText)}
+    visualizerConfig: {
+      script: deEscape(maybeScriptText),
+      theme: deEscape(maybeThemeText),
+      cnd: deEscape(maybeCnDText)
+    }
   };
+}
+
+/**
+ * The loop-back state index of a temporal trace. Providers express the lasso differently:
+ *  - `backloop` (Alloy/Sterling) or `loop` (Forge): the loop-back index directly;
+ *  - `looplength` (Alloy's own instance XML): the *length* of the loop, so the index is
+ *    `tracelength - looplength`.
+ *
+ * The `looplength` form is only honoured when `tracelength > 1`, so a static instance — which
+ * Alloy writes as `tracelength="1" looplength="1"` — is not mistaken for a one-state trace.
+ */
+function parseLoopBack(element: globalThis.Element): number | undefined {
+  const backloop = parseNumericAttribute(element, 'backloop');
+  if (backloop !== undefined) return backloop;
+  const loop = parseNumericAttribute(element, 'loop');
+  if (loop !== undefined) return loop;
+  const tracelength = parseNumericAttribute(element, 'tracelength');
+  const looplength = parseNumericAttribute(element, 'looplength');
+  if (tracelength !== undefined && looplength !== undefined && tracelength > 1) {
+    return tracelength - looplength;
+  }
+  return undefined;
 }
 
 function parseNumericAttribute(

--- a/tests/alloy-xml-parse.test.ts
+++ b/tests/alloy-xml-parse.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { parseAlloyXML } from '../src/data-instance/alloy/alloy-instance/src/xml';
+
+// Minimal builtin sigs so instanceFromElement can populate the Int type.
+const SIGS =
+  '<sig label="Int" ID="1" parentID="2" builtin="yes"></sig><sig label="univ" ID="2" builtin="yes"></sig>';
+const inst = (attrs: string) => `<instance bitwidth="4" ${attrs}>${SIGS}</instance>`;
+const trace = (attrs: string) => `<alloy>${inst(attrs)}${inst(attrs)}</alloy>`;
+
+describe('parseAlloyXML loopBack derivation', () => {
+  it('derives loopBack = tracelength - looplength from Alloy-native XML (no backloop/loop)', () => {
+    expect(parseAlloyXML(trace('tracelength="4" looplength="2"')).loopBack).toBe(2);
+    expect(parseAlloyXML(trace('tracelength="5" looplength="2"')).loopBack).toBe(3);
+  });
+
+  it('prefers backloop, then loop, over looplength', () => {
+    expect(parseAlloyXML(trace('tracelength="4" looplength="2" backloop="3"')).loopBack).toBe(3);
+    expect(parseAlloyXML(trace('tracelength="4" looplength="2" loop="1"')).loopBack).toBe(1);
+  });
+
+  it('does not treat a static instance (tracelength=1 looplength=1) as a trace', () => {
+    expect(
+      parseAlloyXML(`<alloy>${inst('tracelength="1" looplength="1"')}</alloy>`).loopBack
+    ).toBeUndefined();
+  });
+});
+
+describe('parseAlloyXML visualizer config', () => {
+  it('reads script, theme and cnd attributes from <visualizer>', () => {
+    const xml = `<alloy>${inst('tracelength="1"')}<visualizer script="s1" theme="t1" cnd="c1"></visualizer></alloy>`;
+    const cfg = parseAlloyXML(xml).visualizerConfig!;
+    expect(cfg.script).toBe('s1');
+    expect(cfg.theme).toBe('t1');
+    expect(cfg.cnd).toBe('c1');
+  });
+
+  it('leaves missing visualizer attributes undefined', () => {
+    const cfg = parseAlloyXML(`<alloy>${inst('tracelength="1"')}</alloy>`).visualizerConfig!;
+    expect(cfg.script).toBeUndefined();
+    expect(cfg.theme).toBeUndefined();
+    expect(cfg.cnd).toBeUndefined();
+  });
+});

--- a/tsup.alloy-instance.config.ts
+++ b/tsup.alloy-instance.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'tsup'
+
+// Builds ONLY the alloy-instance parser as an importable cjs/esm module (+ d.ts) for external
+// consumers (e.g. Cope and Drag, which uses spytial-core as the canonical Alloy XML parser).
+//
+// Scoped to this subtree on purpose: the full `tsup.config.ts` runs dts over `index`, which pulls
+// in unrelated modules whose type errors break the dts build. `clean: false` so this coexists with
+// the browser (dist/browser) and components (dist/components) bundles in `dist`.
+export default defineConfig({
+  entry: { 'alloy-instance': 'src/data-instance/alloy/alloy-instance/index.ts' },
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: false,
+  minify: true,
+  target: 'es2020',
+  outDir: 'dist',
+  external: ['react', 'react-dom'],
+  bundle: true,
+  treeshake: true,
+  platform: 'browser',
+  noExternal: [
+    'graphlib',
+    'kiwi.js',
+    'chroma-js',
+    'js-yaml',
+    'lodash',
+    '@xmldom/xmldom',
+    'forge-expr-evaluator'
+  ],
+})


### PR DESCRIPTION
Makes spytial-core's Alloy XML parser the **canonical superset** so Cope and Drag can consume it instead of maintaining a diverging copy (`packages/alloy-instance`).

## Changes
- **`loopBack`** now falls back to `tracelength - looplength` when neither `backloop` (Alloy/Sterling) nor `loop` (Forge) is present — Alloy's own instance XML writes `looplength` (the loop *length*, not the index). Guarded by `tracelength > 1` so a static instance (`tracelength="1" looplength="1"`) isn't mistaken for a one-state trace. (This is what makes Alloy temporal traces render — without it `loopBack` is undefined and the trace looks static.)
- **`<visualizer>`** parsing now reads `theme` and `cnd` in addition to `script`, and iterates all `<visualizer>` elements (last value wins). `cnd` is how Forge (and an Alloy bridge) ship a Cope and Drag spec.
- `VisualizerConfig` gains optional `theme` and `cnd`.

## Tests
New `tests/alloy-xml-parse.test.ts` (5 tests: looplength derivation, backloop/loop precedence, static-not-a-trace, visualizer cnd/theme/script). Existing `alloy-skolem-labels` parser tests still pass (13/13).

## Context
Part of consolidating Cope and Drag's duplicate Alloy parser onto spytial-core as the single source of truth. Once released, copeanddrag's `packages/alloy-instance` will re-export this parser and drop its copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)