### PR TITLE
Pyret structural reify/replit + fidelity harness

### DIFF
--- a/src/data-instance/pyret/canon.ts
+++ b/src/data-instance/pyret/canon.ts
@@ -1,0 +1,123 @@
+/**
+ * Canonicalization of a data instance.
+ *
+ * Atom ids (`tno_3`, `num_7`, ...) are arbitrary gensyms, so two instances that
+ * are equal *up to renaming* must be made byte-identical before comparison.
+ * `canon` produces a stable string with:
+ *   - atom ids renamed to integers via a deterministic traversal from the roots,
+ *   - primitive atoms keyed by (type, label) — the label IS the data and is kept;
+ *     object atoms keyed by type only — their labels are display gensyms and are
+ *     dropped,
+ *   - relations keyed by `rel.id` (the field name), tuples sorted lexicographically.
+ *
+ * Field ORDER is intentionally not part of canon: each field is a distinctly
+ * named relation, so the field->value binding is already unambiguous. Order only
+ * matters for positional string rendering (replit), not structural fidelity.
+ *
+ * This is the substrate for the self-contained (Tier A) fidelity oracles
+ * (see tests/pyret/oracles.ts).
+ */
+
+import { IDataInstance } from '../interfaces';
+
+const PRIMITIVE_TYPES = new Set(['Number', 'String', 'Boolean']);
+
+interface OutEdge {
+  rel: string;
+  tuple: string[];
+}
+
+export function canon(di: IDataInstance): string {
+  const atoms = di.getAtoms();
+  const relations = di.getRelations();
+  const atomsById = new Map(atoms.map((a) => [a.id, a] as const));
+
+  const outBySrc = new Map<string, OutEdge[]>();
+  const targetSet = new Set<string>();
+
+  for (const rel of relations) {
+    for (const tup of rel.tuples) {
+      if (tup.atoms.length < 2) continue;
+      const src = tup.atoms[0];
+      for (let i = 1; i < tup.atoms.length; i++) targetSet.add(tup.atoms[i]);
+      const arr = outBySrc.get(src) ?? [];
+      arr.push({ rel: rel.id, tuple: tup.atoms.slice() });
+      outBySrc.set(src, arr);
+    }
+  }
+
+  const keyOf = (id: string): string => {
+    const a = atomsById.get(id);
+    if (!a) return `?`;
+    return PRIMITIVE_TYPES.has(a.type) ? `${a.type}=${a.label}` : a.type;
+  };
+
+  // Canonical numbering: DFS from roots, children ordered by (relation, target keys).
+  const roots = atoms.map((a) => a.id).filter((id) => !targetSet.has(id));
+  const seeds = (roots.length ? roots : atoms.map((a) => a.id)).slice().sort((x, y) => {
+    const k = keyOf(x).localeCompare(keyOf(y));
+    return k !== 0 ? k : x.localeCompare(y);
+  });
+
+  const num = new Map<string, number>();
+  let counter = 0;
+
+  const visit = (start: string): void => {
+    const stack = [start];
+    while (stack.length) {
+      const id = stack.pop()!;
+      if (num.has(id)) continue;
+      num.set(id, counter++);
+      const outs = (outBySrc.get(id) ?? []).slice().sort((a, b) => {
+        const k = a.rel.localeCompare(b.rel);
+        if (k !== 0) return k;
+        const ak = a.tuple.slice(1).map(keyOf).join('|');
+        const bk = b.tuple.slice(1).map(keyOf).join('|');
+        return ak.localeCompare(bk);
+      });
+      // push in reverse so the first edge is processed first (stack = LIFO)
+      for (let e = outs.length - 1; e >= 0; e--) {
+        const t = outs[e].tuple;
+        for (let i = t.length - 1; i >= 1; i--) stack.push(t[i]);
+      }
+    }
+  };
+
+  for (const s of seeds) visit(s);
+  // any atoms unreachable from the roots get numbered last, in id order
+  atoms
+    .map((a) => a.id)
+    .sort()
+    .forEach((id) => {
+      if (!num.has(id)) num.set(id, counter++);
+    });
+
+  const canonAtoms = atoms
+    .map((a) => ({
+      id: num.get(a.id)!,
+      type: a.type,
+      label: PRIMITIVE_TYPES.has(a.type) ? a.label : undefined,
+    }))
+    .sort((x, y) => x.id - y.id);
+
+  const canonRels = relations
+    .map((rel) => {
+      const tuples = rel.tuples
+        .filter((t) => t.atoms.length >= 2)
+        .map((t) => t.atoms.map((x) => num.get(x) ?? -1));
+      tuples.sort((p, q) => {
+        const n = Math.min(p.length, q.length);
+        for (let i = 0; i < n; i++) if (p[i] !== q[i]) return p[i] - q[i];
+        return p.length - q.length;
+      });
+      return { name: rel.id, tuples };
+    })
+    .filter((r) => r.tuples.length > 0)
+    .sort(
+      (a, b) =>
+        a.name.localeCompare(b.name) ||
+        JSON.stringify(a.tuples).localeCompare(JSON.stringify(b.tuples)),
+    );
+
+  return JSON.stringify({ atoms: canonAtoms, relations: canonRels });
+}

--- a/src/data-instance/pyret/reify.ts
+++ b/src/data-instance/pyret/reify.ts
@@ -1,0 +1,196 @@
+/**
+ * Structural reify for PyretDataInstance.
+ *
+ * This is the *inverse of relationalization*: given a data instance (atoms +
+ * relations only — NO live Pyret value, NO runtime), reconstruct a value.
+ *
+ * The key design choice (see the fidelity design notes): reify reconstructs a
+ * **synthetic `PyretObject`** — the exact `{ dict, brands/$name }` shape that
+ * `PyretDataInstance.parseObjectIteratively` already consumes. That makes the
+ * round-trip self-contained: we can feed the reified value straight back into
+ * `new PyretDataInstance(...)` and compare, with no Pyret runtime in the loop.
+ *
+ * Sharing and cycles are carried by **real JS object identity** in the
+ * reconstructed graph (a memo keyed by atom id), so a shared atom becomes one
+ * shared JS object and a cyclic atom becomes a real JS back-reference — exactly
+ * mirroring how the relationalizer's `WeakMap` captured them in the first place.
+ *
+ * NOTE: this is a *structural* reify (the analog of Python's live-object
+ * `reify`). The string form (the analog of Python's `repl`/`repr(reify(...))`)
+ * is `replit` in ./replit.ts.
+ */
+
+import { IDataInstance, IAtom } from '../interfaces';
+import { PyretObject, PyretDataInstance } from './pyret-data-instance';
+
+/** A value reconstructed from a data instance. Either a synthetic Pyret object,
+ * a JS array (for multi-target fields = Pyret arrays/list-likes), or a primitive. */
+export type ReifiedValue = PyretObject | ReifiedValue[] | number | string | boolean | null;
+
+const PRIMITIVE_TYPES = new Set(['Number', 'String', 'Boolean']);
+
+interface RelIndex {
+  /** source atom id -> field name (relation id) -> ordered target atom ids */
+  fields: Map<string, Map<string, string[]>>;
+  /** atom ids that appear at index >= 1 in some tuple (i.e. are pointed-to) */
+  targets: Set<string>;
+}
+
+/** Build a source-keyed view of the relations. Field name = relation `id`
+ * (the dict key the relationalizer stored), which for binary object fields is
+ * exactly the Pyret field name. */
+function buildIndex(di: IDataInstance): RelIndex {
+  const fields = new Map<string, Map<string, string[]>>();
+  const targets = new Set<string>();
+
+  for (const rel of di.getRelations()) {
+    for (const tup of rel.tuples) {
+      if (tup.atoms.length < 2) continue;
+      const src = tup.atoms[0];
+      for (let i = 1; i < tup.atoms.length; i++) targets.add(tup.atoms[i]);
+
+      let byField = fields.get(src);
+      if (!byField) {
+        byField = new Map();
+        fields.set(src, byField);
+      }
+      const arr = byField.get(rel.id) ?? [];
+      // binary fields contribute one target; n-ary (e.g. nested array intermediates)
+      // contribute their non-source atoms in order.
+      for (let i = 1; i < tup.atoms.length; i++) arr.push(tup.atoms[i]);
+      byField.set(rel.id, arr);
+    }
+  }
+  return { fields, targets };
+}
+
+/** Parse a primitive atom's label back into a JS primitive. */
+function reifyPrimitiveAtom(atom: IAtom): ReifiedValue {
+  switch (atom.type) {
+    case 'Number': {
+      const n = Number(atom.label);
+      return Number.isNaN(n) ? atom.label : n;
+    }
+    case 'Boolean':
+      return atom.label === 'true';
+    case 'String':
+      return atom.label;
+    default:
+      return atom.label;
+  }
+}
+
+/** Numeric-aware comparison so "2" sorts before "10". */
+function numericAwareCompare(a: string, b: string): number {
+  const na = /^\d+$/.test(a);
+  const nb = /^\d+$/.test(b);
+  if (na && nb) return parseInt(a, 10) - parseInt(b, 10);
+  return a.localeCompare(b);
+}
+
+/**
+ * Determine constructor field order for a type.
+ *
+ * Field order is NOT part of the relational form — it lives in the static
+ * `globalConstructorCache` (populated at relationalization time from the live
+ * object's dict key order). We consult it here. This only affects *positional*
+ * rendering (replit); structural fidelity does not depend on it because each
+ * field is a distinctly-named relation.
+ */
+function fieldOrderFor(type: string, present: string[]): string[] {
+  const cache = PyretDataInstance.getGlobalConstructorCache();
+  const cached = cache.get(type);
+  if (cached && cached.length) {
+    const inCache = cached.filter((f) => present.includes(f));
+    const extras = present.filter((f) => !cached.includes(f));
+    return [...inCache, ...extras.sort(numericAwareCompare)];
+  }
+  return [...present].sort(numericAwareCompare);
+}
+
+/** True if all field names look like array indices (0,1,2,...). */
+function isListLike(fieldNames: string[]): boolean {
+  return fieldNames.length > 0 && fieldNames.every((k) => /^\d+$/.test(k));
+}
+
+/**
+ * Reconstruct a value from a data instance.
+ *
+ * @param di      the data instance (atoms + relations)
+ * @param rootId  optional explicit root atom id; otherwise inferred
+ * @returns a synthetic, re-relationalizable value (PyretObject / array / primitive)
+ */
+export function reifyToValue(di: IDataInstance, rootId?: string): ReifiedValue {
+  const atomsById = new Map(di.getAtoms().map((a) => [a.id, a] as const));
+  const { fields, targets } = buildIndex(di);
+  const memo = new Map<string, ReifiedValue>();
+
+  const reifyAtom = (id: string): ReifiedValue => {
+    if (memo.has(id)) return memo.get(id)!;
+
+    const atom = atomsById.get(id);
+    if (!atom) return null;
+
+    if (PRIMITIVE_TYPES.has(atom.type)) {
+      const v = reifyPrimitiveAtom(atom);
+      memo.set(id, v);
+      return v;
+    }
+
+    const byField = fields.get(id) ?? new Map<string, string[]>();
+    const present = Array.from(byField.keys());
+
+    // Pure list-like object (numeric field names) -> JS array.
+    if (isListLike(present)) {
+      const arr: ReifiedValue[] = [];
+      memo.set(id, arr);
+      const ordered = present.slice().sort(numericAwareCompare);
+      for (const k of ordered) {
+        const tgts = byField.get(k) ?? [];
+        // One target at index k -> scalar element; multiple targets -> the
+        // element at index k was itself an array (the relationalizer emits one
+        // tuple per inner element under the SAME numeric field), so nest it.
+        arr.push(tgts.length === 1 ? reifyAtom(tgts[0]) : tgts.map((t) => reifyAtom(t)));
+      }
+      return arr;
+    }
+
+    // Object/data-variant: create the shell and memoize BEFORE recursing so
+    // shared/cyclic references resolve to this exact JS object.
+    const obj: PyretObject = { dict: {}, $name: atom.type };
+    memo.set(id, obj);
+
+    const order = fieldOrderFor(atom.type, present);
+    for (const f of order) {
+      const tgts = byField.get(f) ?? [];
+      if (tgts.length === 1) {
+        // single target -> scalar field value (one binary tuple round-trips identically)
+        obj.dict![f] = reifyAtom(tgts[0]) as unknown;
+      } else {
+        // multiple targets under one field -> a Pyret array (the relationalizer's
+        // array path emits one tuple per element, which is exactly this shape).
+        obj.dict![f] = tgts.map((t) => reifyAtom(t)) as unknown;
+      }
+    }
+    return obj;
+  };
+
+  // Root resolution: prefer explicit; else the unique in-degree-0 atom; else
+  // (cycles / multiple roots) fall back deterministically.
+  const allIds = di.getAtoms().map((a) => a.id);
+  if (allIds.length === 0) return null;
+
+  if (rootId && atomsById.has(rootId)) return reifyAtom(rootId);
+
+  const roots = allIds.filter((id) => !targets.has(id));
+  if (roots.length === 1) return reifyAtom(roots[0]);
+  if (roots.length === 0) {
+    // fully cyclic: no in-degree-0 atom. Use the last atom as an entry point.
+    return reifyAtom(allIds[allIds.length - 1]);
+  }
+
+  // Multiple roots -> wrap them in a synthetic list (mirrors reify()'s [list-set:]).
+  // (Structural round-trip of multi-root instances is intentionally not claimed.)
+  const arr: ReifiedValue[] = roots.map((r) => reifyAtom(r));
+  return arr;
+}

--- a/src/data-instance/pyret/replit.ts
+++ b/src/data-instance/pyret/replit.ts
@@ -1,0 +1,77 @@
+/**
+ * replit — the REPL-equivalent string form of a reified value.
+ *
+ * The Pyret analog of Python's `repr(reify(...))` / Rust's
+ * `format!("{:?}", from_datum(...))`: reconstruct the value (./reify.ts), then
+ * render it to the source/REPL string a programmer would read.
+ *
+ * Rendering rules:
+ *   - primitives:     5     "hi"    true     nothing
+ *   - arrays:         [list: a, b, c]
+ *   - data variants:  type(field0, field1, ...)   (fields in reconstructed order)
+ *
+ * Field ORDER here comes from the reconstructed object's dict order, which reify
+ * takes from the constructor cache (declared order) — so positional rendering is
+ * faithful when the cache is populated.
+ *
+ * LIMITATION: a flat torepr-style string cannot express sharing or cycles. DAGs
+ * are re-printed (matching `torepr`); cycles emit a `<cyclic>` marker instead of
+ * looping forever. The cyclic bind-and-backpatch source form (block:/var) is
+ * future work and is documented in the fidelity design notes.
+ */
+
+import { IDataInstance } from '../interfaces';
+import { PyretObject } from './pyret-data-instance';
+import { reifyToValue, ReifiedValue } from './reify';
+
+function isPyretObject(v: unknown): v is PyretObject {
+  return typeof v === 'object' && v !== null && !Array.isArray(v) && 'dict' in v;
+}
+
+function pyretStringLiteral(s: string): string {
+  return (
+    '"' +
+    s
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t') +
+    '"'
+  );
+}
+
+function render(v: ReifiedValue, onPath: Set<object>): string {
+  if (v === null || v === undefined) return 'nothing';
+  if (typeof v === 'number') return String(v);
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (typeof v === 'string') return pyretStringLiteral(v);
+
+  if (Array.isArray(v)) {
+    if (onPath.has(v)) return '<cyclic>';
+    onPath.add(v);
+    const out = `[list: ${v.map((e) => render(e, onPath)).join(', ')}]`;
+    onPath.delete(v);
+    return out;
+  }
+
+  if (isPyretObject(v)) {
+    if (onPath.has(v)) return '<cyclic>';
+    onPath.add(v);
+    const type = (v.$name as string) || 'object';
+    const dict = (v.dict as Record<string, unknown>) || {};
+    const keys = Object.keys(dict);
+    const out = keys.length
+      ? `${type}(${keys.map((k) => render(dict[k] as ReifiedValue, onPath)).join(', ')})`
+      : type;
+    onPath.delete(v);
+    return out;
+  }
+
+  return String(v);
+}
+
+/** Reconstruct the value from the data instance and render it as a Pyret string. */
+export function replit(di: IDataInstance, rootId?: string): string {
+  return render(reifyToValue(di, rootId), new Set());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,12 @@ export { DotDataInstance } from './data-instance/dot/dot-data-instance';
 export type { DotTypeConfig, DotTypeDescriptor, DotDataInstanceOptions } from './data-instance/dot/dot-data-instance';
 export { RacketGDataInstance } from './data-instance/racket/racket-g-data-instance';
 export { PyretDataInstance } from './data-instance/pyret/pyret-data-instance';
+// Pyret structural reify / replit + data-instance canonical form (building blocks;
+// the fidelity measurement harness that exercises these lives in tests/pyret/).
+export { reifyToValue } from './data-instance/pyret/reify';
+export type { ReifiedValue } from './data-instance/pyret/reify';
+export { replit } from './data-instance/pyret/replit';
+export { canon } from './data-instance/pyret/canon';
 export { TlaDataInstance, createTlaDataInstance, isTlaDataInstance } from './data-instance/tla/tla-data-instance';
 
 // Export schema descriptor functions for generating descriptions of data instances

--- a/tests/pyret/corpus.ts
+++ b/tests/pyret/corpus.ts
@@ -1,0 +1,256 @@
+/**
+ * Fidelity test corpus (T0-T5).
+ *
+ * Values are synthetic Pyret runtime objects ({ dict, brands }) — the exact
+ * shape the runtime hands to PyretDataInstance — so the whole corpus runs with
+ * NO Pyret runtime. Data variants use `brands` (exercising the real brand->type
+ * logic); sharing/cycles use shared/back-referencing JS objects.
+ */
+
+import {
+  PyretObject,
+  PyretInstanceOptions,
+} from '../../src/data-instance/pyret/pyret-data-instance';
+import { Reifiable } from './oracles';
+
+export interface CorpusItem {
+  name: string;
+  category: string; // T0..T5
+  value: Reifiable;
+}
+
+export interface DiscriminatorPair {
+  name: string;
+  category: string;
+  a: Reifiable;
+  b: Reifiable;
+  /** expected outcome of rel-injectivity (true = the two are distinguished) */
+  expectDistinct: boolean;
+  /** relationalization options to use for this pair (defaults if omitted) */
+  options?: PyretInstanceOptions;
+  note?: string;
+}
+
+/** Build a single-brand data-variant object. */
+function variant(name: string, brandNum: number, dict: Record<string, unknown>): PyretObject {
+  return { dict, brands: { [`$brand${name}${brandNum}`]: true } };
+}
+
+const point = (x: number, y: number): PyretObject => variant('point', 7, { x, y });
+const line = (p: PyretObject, q: PyretObject): PyretObject =>
+  variant('line', 8, { start: p, end: q });
+const node = (val: number, left: unknown, right: unknown): PyretObject =>
+  variant('node', 9, { val, left, right });
+const leaf = (val: number): PyretObject => variant('leaf', 10, { val });
+
+// ----------------------------------------------------------------------------
+// T0 — primitives & flat containers
+// ----------------------------------------------------------------------------
+const T0: CorpusItem[] = [
+  { name: 'int', category: 'T0', value: 5 },
+  { name: 'negative', category: 'T0', value: -42 },
+  { name: 'float', category: 'T0', value: 3.5 },
+  { name: 'string', category: 'T0', value: 'hi' },
+  { name: 'string-with-escapes', category: 'T0', value: 'line1\nline2\t"q"' },
+  { name: 'empty-string', category: 'T0', value: '' },
+  { name: 'bool-true', category: 'T0', value: true },
+  { name: 'bool-false', category: 'T0', value: false },
+  { name: 'array', category: 'T0', value: [1, 2, 3] },
+  { name: 'empty-array', category: 'T0', value: [] },
+  { name: 'array-of-strings', category: 'T0', value: ['a', 'b'] },
+];
+
+// ----------------------------------------------------------------------------
+// T2 — user data types (flat and nested)
+// ----------------------------------------------------------------------------
+const T2: CorpusItem[] = [
+  { name: 'point', category: 'T2', value: point(1, 2) },
+  { name: 'point-zero', category: 'T2', value: point(0, 0) },
+  { name: 'line', category: 'T2', value: line(point(1, 2), point(3, 4)) },
+  {
+    name: 'nested-record',
+    category: 'T2',
+    value: variant('box', 11, { contents: point(9, 9), tag: 'p' }),
+  },
+];
+
+// ----------------------------------------------------------------------------
+// T3a — sharing / DAG (the SAME object in two slots)
+// ----------------------------------------------------------------------------
+function sharedPair(): PyretObject {
+  const p = point(1, 2);
+  return variant('pair', 12, { fst: p, snd: p }); // same JS object reference
+}
+function sharedDeep(): PyretObject {
+  const shared = point(5, 5);
+  return variant('twolines', 13, {
+    a: line(shared, point(0, 0)),
+    b: line(shared, point(1, 1)),
+  });
+}
+const T3a: CorpusItem[] = [
+  { name: 'shared-point', category: 'T3a', value: sharedPair() },
+  { name: 'shared-deep', category: 'T3a', value: sharedDeep() },
+];
+
+// ----------------------------------------------------------------------------
+// T3b — cycles (real JS back-references)
+// ----------------------------------------------------------------------------
+function selfCycle(): PyretObject {
+  const n: PyretObject = variant('cell', 14, {});
+  (n.dict as Record<string, unknown>).next = n; // n.next = n
+  return n;
+}
+function twoCycle(): PyretObject {
+  const a: PyretObject = variant('cell', 14, {});
+  const b: PyretObject = variant('cell', 14, {});
+  (a.dict as Record<string, unknown>).next = b;
+  (b.dict as Record<string, unknown>).next = a;
+  return a;
+}
+const T3b: CorpusItem[] = [
+  { name: 'self-cycle', category: 'T3b', value: selfCycle() },
+  { name: 'two-cycle', category: 'T3b', value: twoCycle() },
+];
+
+// ----------------------------------------------------------------------------
+// T4 — trees (sharing of leaf values via idempotency)
+// ----------------------------------------------------------------------------
+const T4: CorpusItem[] = [
+  {
+    name: 'binary-tree',
+    category: 'T4',
+    value: node(5, node(1, leaf(0), leaf(0)), node(6, leaf(0), leaf(0))),
+  },
+];
+
+// ----------------------------------------------------------------------------
+// T5 — fuzz (deterministic generator; no Math.random)
+// ----------------------------------------------------------------------------
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    // xorshift32
+    s ^= s << 13;
+    s ^= s >>> 17;
+    s ^= s << 5;
+    return (s >>> 0) / 0xffffffff;
+  };
+}
+
+function fuzzValue(rng: () => number, depth: number): Reifiable {
+  if (depth <= 0 || rng() < 0.3) {
+    const which = rng();
+    if (which < 0.4) return Math.floor(rng() * 100);
+    if (which < 0.7) return `s${Math.floor(rng() * 1000)}`;
+    return rng() < 0.5;
+  }
+  const which = rng();
+  if (which < 0.4) {
+    return point(Math.floor(rng() * 10), Math.floor(rng() * 10));
+  }
+  if (which < 0.7) {
+    const len = 1 + Math.floor(rng() * 3);
+    return Array.from({ length: len }, () => fuzzValue(rng, depth - 1));
+  }
+  return variant('rec', 15, {
+    head: fuzzValue(rng, depth - 1),
+    tail: fuzzValue(rng, depth - 1),
+  });
+}
+
+export function fuzzCorpus(count: number, baseSeed = 1): CorpusItem[] {
+  const items: CorpusItem[] = [];
+  for (let i = 0; i < count; i++) {
+    const rng = makeRng(baseSeed + i * 2654435761);
+    items.push({ name: `fuzz-${i}`, category: 'T5', value: fuzzValue(rng, 4) });
+  }
+  return items;
+}
+
+/** All structural (fixed-point) corpus items. */
+export const STRUCTURAL_CORPUS: CorpusItem[] = [
+  ...T0,
+  ...T2,
+  ...T3a,
+  ...T3b,
+  ...T4,
+];
+
+// ----------------------------------------------------------------------------
+// T1 — discriminator pairs (rel-injectivity)
+// ----------------------------------------------------------------------------
+export const DISCRIMINATOR_PAIRS: DiscriminatorPair[] = [
+  {
+    name: 'number-vs-string',
+    category: 'T1',
+    a: 5,
+    b: '5',
+    expectDistinct: true,
+    note: 'type tag must distinguish 5 from "5"',
+  },
+  {
+    name: 'bool-vs-string',
+    category: 'T1',
+    a: true,
+    b: 'true',
+    expectDistinct: true,
+  },
+  {
+    name: 'field-binding-swap',
+    category: 'T1',
+    a: point(1, 2),
+    b: point(2, 1),
+    expectDistinct: true,
+    note: 'x/y bindings differ; distinguished by named relations (not order)',
+  },
+  {
+    name: 'field-value-change',
+    category: 'T1',
+    a: point(1, 2),
+    b: point(1, 3),
+    expectDistinct: true,
+  },
+  {
+    name: 'list-length',
+    category: 'T1',
+    a: [1, 2],
+    b: [1],
+    expectDistinct: true,
+  },
+  {
+    name: 'list-multiplicity',
+    category: 'T1',
+    a: [1, 1],
+    b: [1],
+    expectDistinct: true,
+    note: 'KNOWN RISK: idempotent primitives + tuple-dedup may collapse [1,1] to [1]',
+  },
+  {
+    name: 'distinct-variants',
+    category: 'T1',
+    a: point(1, 2),
+    b: variant('vec', 16, { x: 1, y: 2 }),
+    expectDistinct: true,
+    note: 'same fields, different constructor name',
+  },
+  {
+    name: 'object-field-multiplicity (idempotent default)',
+    category: 'T1',
+    a: variant('bag', 17, { items: [1, 1] }),
+    b: variant('bag', 17, { items: [1] }),
+    expectDistinct: false,
+    note:
+      'KNOWN LOSS: with numbers idempotent, [1,1] under one field dedups to a ' +
+      'single tuple (addRelationTuple drops duplicate (src,tgt)) — collapses to [1]',
+  },
+  {
+    name: 'object-field-multiplicity (idempotent OFF)',
+    category: 'T1',
+    a: variant('bag', 17, { items: [1, 1] }),
+    b: variant('bag', 17, { items: [1] }),
+    expectDistinct: true,
+    options: { numbersIdempotent: false },
+    note: 'with idempotency off, the two 1s are distinct atoms -> multiplicity preserved',
+  },
+];

--- a/tests/pyret/oracles.ts
+++ b/tests/pyret/oracles.ts
@@ -1,0 +1,123 @@
+/**
+ * Fidelity oracles — Tier A (self-contained, no Pyret runtime).
+ *
+ * These run entirely inside spytial-core because:
+ *   - `relationalize` is the existing PyretDataInstance relationalizer,
+ *   - `reifyToValue` emits a synthetic value the relationalizer can re-consume,
+ *   - `canon` compares the two data instances up to atom-id renaming.
+ *
+ * So `canon(rel(v)) == canon(rel(reify(rel(v))))` is computable end-to-end with
+ * no language runtime. That is the measurable answer to "how faithful is the
+ * round trip?".
+ *
+ * Tier B oracles (R-eq via equal-always, R-inspect via torepr) require a live
+ * Pyret runtime and belong in an IDE-side harness — they are NOT here.
+ */
+
+import {
+  PyretDataInstance,
+  PyretObject,
+  PyretInstanceOptions,
+} from '../../src/data-instance/pyret/pyret-data-instance';
+import { reifyToValue, ReifiedValue } from '../../src/data-instance/pyret/reify';
+import { canon } from '../../src/data-instance/pyret/canon';
+
+/** Anything we can relationalize: a Pyret object graph, an array, or a primitive. */
+export type Reifiable = PyretObject | ReifiedValue;
+
+function isPrimitive(v: unknown): v is number | string | boolean {
+  const t = typeof v;
+  return t === 'number' || t === 'string' || t === 'boolean';
+}
+
+function primitiveType(v: number | string | boolean): string {
+  return typeof v === 'number' ? 'Number' : typeof v === 'string' ? 'String' : 'Boolean';
+}
+
+/**
+ * Relationalize a value into a PyretDataInstance.
+ *
+ * Mirrors `PyretDataInstance.fromExpression`'s handling of primitive roots
+ * (the constructor expects an object, so a bare primitive is added directly).
+ * Arrays at the root are wrapped in a synthetic indexed object so the existing
+ * array path produces relations.
+ */
+export function relationalize(
+  v: Reifiable,
+  options: PyretInstanceOptions = {},
+): PyretDataInstance {
+  if (v === null || v === undefined) return new PyretDataInstance(null, options);
+
+  if (isPrimitive(v)) {
+    const di = new PyretDataInstance(null, options);
+    di.addAtom({
+      id: `prim_${primitiveType(v)}_${String(v)}`,
+      type: primitiveType(v),
+      label: String(v),
+    });
+    return di;
+  }
+
+  if (Array.isArray(v)) {
+    const dict: Record<string, unknown> = {};
+    v.forEach((el, i) => {
+      dict[String(i)] = el;
+    });
+    return new PyretDataInstance({ dict, $name: 'RawArray' } as PyretObject, options);
+  }
+
+  return new PyretDataInstance(v as PyretObject, options);
+}
+
+export interface RoundTripResult {
+  pass: boolean;
+  canonA: string;
+  canonB: string;
+}
+
+/**
+ * Fixed-Point oracle: does `rel -> reify -> rel` reach a fixed point?
+ *
+ * Catches reify drift (dropped fields, mangled sharing, cycle crashes) without
+ * any external notion of "truth". It is the only oracle that survives cycles.
+ *
+ * Note: it is a fixed point *of rel*, so information `rel` never captured is
+ * invisible to it. rel-injectivity (below) covers known collapses.
+ */
+export function fixedPoint(
+  v: Reifiable,
+  options: PyretInstanceOptions = {},
+): RoundTripResult {
+  // Reset the static field-order cache so each case is self-contained.
+  PyretDataInstance.clearGlobalConstructorCache();
+
+  const di1 = relationalize(v, options); // populates the cache from v's field order
+  const reified = reifyToValue(di1); // reads the cache
+  const di2 = relationalize(reified, options); // repopulates with the same order
+
+  const canonA = canon(di1);
+  const canonB = canon(di2);
+  return { pass: canonA === canonB, canonA, canonB };
+}
+
+/**
+ * rel-injectivity oracle: do two genuinely distinct values relationalize to
+ * distinct (canonicalized) data instances?
+ *
+ * The only oracle that catches *collapses* — distinct values that `rel` maps to
+ * the same graph (type/value confusions, multiplicity loss, etc.). No reify in
+ * the loop, so it tests `rel` head-on.
+ *
+ * @returns true if the two values are distinguished (the desirable outcome).
+ */
+export function relInjective(
+  a: Reifiable,
+  b: Reifiable,
+  options: PyretInstanceOptions = {},
+): boolean {
+  PyretDataInstance.clearGlobalConstructorCache();
+  const ca = canon(relationalize(a, options));
+  PyretDataInstance.clearGlobalConstructorCache();
+  const cb = canon(relationalize(b, options));
+  return ca !== cb;
+}

--- a/tests/pyret/pyret-fidelity.test.ts
+++ b/tests/pyret/pyret-fidelity.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { fixedPoint, relInjective, relationalize } from './oracles';
+import { replit } from '../../src/data-instance/pyret/replit';
+import { STRUCTURAL_CORPUS, DISCRIMINATOR_PAIRS, fuzzCorpus } from './corpus';
+
+/**
+ * Tier A fidelity measurement — self-contained, no Pyret runtime.
+ *
+ *   Fixed-Point:   canon(rel(v)) == canon(rel(reify(rel(v))))
+ *   rel-injective: canon(rel(a)) != canon(rel(b))  for distinct a, b
+ *
+ * Tier B (R-eq via equal-always, R-inspect via torepr) needs a live Pyret
+ * runtime and lives in an IDE-side harness — not here.
+ */
+
+const FUZZ_COUNT = 2000;
+
+describe('Tier A — Fixed-Point (rel -> reify -> rel)', () => {
+  for (const item of STRUCTURAL_CORPUS) {
+    it(`${item.category} ${item.name} round-trips`, () => {
+      const res = fixedPoint(item.value);
+      if (!res.pass) {
+        // eslint-disable-next-line no-console
+        console.error(`FAIL ${item.name}\n  A: ${res.canonA}\n  B: ${res.canonB}`);
+      }
+      expect(res.pass).toBe(true);
+    });
+  }
+
+  it(`T5 fuzz (${FUZZ_COUNT} cases) all round-trip`, () => {
+    const items = fuzzCorpus(FUZZ_COUNT);
+    const failures = items
+      .map((item) => ({ item, res: fixedPoint(item.value) }))
+      .filter(({ res }) => !res.pass);
+    if (failures.length) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Fuzz failures (${failures.length}/${FUZZ_COUNT}):\n` +
+          failures
+            .slice(0, 5)
+            .map(({ item, res }) => `  ${item.name}\n    A:${res.canonA}\n    B:${res.canonB}`)
+            .join('\n'),
+      );
+    }
+    expect(failures.length).toBe(0);
+  });
+});
+
+describe('Tier A — rel-injectivity (distinct values stay distinct)', () => {
+  for (const pair of DISCRIMINATOR_PAIRS) {
+    it(`${pair.name}${pair.note ? ` — ${pair.note}` : ''}`, () => {
+      const distinct = relInjective(pair.a, pair.b, pair.options);
+      if (distinct !== pair.expectDistinct) {
+        // eslint-disable-next-line no-console
+        console.error(`${pair.name}: distinct=${distinct} expected=${pair.expectDistinct}`);
+      }
+      expect(distinct).toBe(pair.expectDistinct);
+    });
+  }
+});
+
+describe('replit — REPL-equivalent rendering', () => {
+  const cases: Array<[string, unknown, string]> = [
+    ['number', 5, '5'],
+    ['string', 'hi', '"hi"'],
+    ['string-escape', 'a\nb', '"a\\nb"'],
+    ['bool', true, 'true'],
+    ['array', [1, 2, 3], '[list: 1, 2, 3]'],
+    // KNOWN AMBIGUITY: an empty array has zero relations, so it is structurally
+    // indistinguishable from an empty object — reify cannot recover "array-ness".
+    ['empty-array (ambiguous)', [], 'RawArray'],
+    [
+      'point',
+      { dict: { x: 1, y: 2 }, brands: { $brandpoint7: true } },
+      'point(1, 2)',
+    ],
+    [
+      'nested',
+      {
+        dict: {
+          start: { dict: { x: 1, y: 2 }, brands: { $brandpoint7: true } },
+          end: { dict: { x: 3, y: 4 }, brands: { $brandpoint7: true } },
+        },
+        brands: { $brandline8: true },
+      },
+      'line(point(1, 2), point(3, 4))',
+    ],
+  ];
+
+  for (const [name, value, expected] of cases) {
+    it(`renders ${name}`, () => {
+      const di = relationalize(value as never);
+      expect(replit(di)).toBe(expected);
+    });
+  }
+
+  it('does not loop on cycles', () => {
+    const n: any = { dict: {}, brands: { $brandcell14: true } };
+    n.dict.next = n;
+    const di = relationalize(n);
+    const s = replit(di);
+    expect(s).toContain('cell');
+    expect(s).toContain('<cyclic>');
+  });
+});

--- a/tests/pyret/report.ts
+++ b/tests/pyret/report.ts
@@ -1,0 +1,125 @@
+/**
+ * Tier A fidelity report — computes a score matrix + violation list.
+ *
+ * This is the programmatic form of the headline "fidelity number": per-oracle,
+ * per-category pass rates over the corpus, plus every concrete violation. Use it
+ * from a script or CI step to emit a JSON artifact, or to print a summary.
+ *
+ * Tier B (R-eq / R-inspect via the live Pyret runtime) is intentionally absent —
+ * it requires an IDE/runtime-backed harness.
+ */
+
+import { fixedPoint, relInjective } from './oracles';
+import {
+  STRUCTURAL_CORPUS,
+  DISCRIMINATOR_PAIRS,
+  fuzzCorpus,
+  CorpusItem,
+} from './corpus';
+
+export interface Violation {
+  oracle: 'fixed-point' | 'rel-injectivity';
+  name: string;
+  category: string;
+  detail: string;
+}
+
+export interface CategoryScore {
+  category: string;
+  oracle: string;
+  pass: number;
+  total: number;
+  rate: number;
+}
+
+export interface FidelityReport {
+  scores: CategoryScore[];
+  violations: Violation[];
+  /** headline: overall fixed-point pass rate */
+  fixedPointRate: number;
+  /** overall rel-injectivity pass rate (matches-expectation) */
+  relInjectivityRate: number;
+}
+
+export function runTierA(fuzzCount = 1000): FidelityReport {
+  const violations: Violation[] = [];
+  const byKey = new Map<string, { pass: number; total: number }>();
+
+  const bump = (category: string, oracle: string, ok: boolean) => {
+    const key = `${oracle}::${category}`;
+    const e = byKey.get(key) ?? { pass: 0, total: 0 };
+    e.total += 1;
+    if (ok) e.pass += 1;
+    byKey.set(key, e);
+  };
+
+  const structural: CorpusItem[] = [...STRUCTURAL_CORPUS, ...fuzzCorpus(fuzzCount)];
+  for (const item of structural) {
+    const res = fixedPoint(item.value);
+    bump(item.category, 'fixed-point', res.pass);
+    if (!res.pass) {
+      violations.push({
+        oracle: 'fixed-point',
+        name: item.name,
+        category: item.category,
+        detail: `A=${res.canonA} B=${res.canonB}`,
+      });
+    }
+  }
+
+  for (const pair of DISCRIMINATOR_PAIRS) {
+    const distinct = relInjective(pair.a, pair.b, pair.options);
+    const ok = distinct === pair.expectDistinct;
+    bump(pair.category, 'rel-injectivity', ok);
+    if (!ok) {
+      violations.push({
+        oracle: 'rel-injectivity',
+        name: pair.name,
+        category: pair.category,
+        detail: `distinct=${distinct} expected=${pair.expectDistinct}`,
+      });
+    }
+  }
+
+  const scores: CategoryScore[] = Array.from(byKey.entries())
+    .map(([key, e]) => {
+      const [oracle, category] = key.split('::');
+      return { oracle, category, pass: e.pass, total: e.total, rate: e.pass / e.total };
+    })
+    .sort((a, b) => a.oracle.localeCompare(b.oracle) || a.category.localeCompare(b.category));
+
+  const sum = (oracle: string) =>
+    scores.filter((s) => s.oracle === oracle).reduce(
+      (acc, s) => ({ pass: acc.pass + s.pass, total: acc.total + s.total }),
+      { pass: 0, total: 0 },
+    );
+  const fp = sum('fixed-point');
+  const ri = sum('rel-injectivity');
+
+  return {
+    scores,
+    violations,
+    fixedPointRate: fp.total ? fp.pass / fp.total : 1,
+    relInjectivityRate: ri.total ? ri.pass / ri.total : 1,
+  };
+}
+
+/** Render the report as a compact text matrix. */
+export function formatReport(report: FidelityReport): string {
+  const lines: string[] = [];
+  lines.push('=== Tier A fidelity report (self-contained, no Pyret runtime) ===');
+  for (const s of report.scores) {
+    lines.push(`  ${s.oracle.padEnd(16)} ${s.category.padEnd(6)} ${s.pass}/${s.total} (${(s.rate * 100).toFixed(1)}%)`);
+  }
+  lines.push(`  fixed-point overall:     ${(report.fixedPointRate * 100).toFixed(2)}%`);
+  lines.push(`  rel-injectivity overall: ${(report.relInjectivityRate * 100).toFixed(2)}%`);
+  if (report.violations.length) {
+    lines.push(`  violations: ${report.violations.length}`);
+    for (const v of report.violations.slice(0, 10)) {
+      lines.push(`    [${v.oracle}] ${v.category} ${v.name}: ${v.detail}`);
+    }
+  } else {
+    lines.push('  violations: none');
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## What

Adds a **structural `reify`/`replit`** for `PyretDataInstance` and a **self-contained fidelity harness** that measures how faithfully a value survives the relationalize → reify round-trip — with **no Pyret runtime required**.

`reify` is the inverse of relationalization: it reconstructs a value from the data instance's `atoms` + `relations` (not a reprint of the live value). The key move is that it emits a **synthetic `PyretObject`** — the same `{ dict, brands/$name }` shape the relationalizer already consumes — so the reified value can be fed straight back into `new PyretDataInstance(...)` and compared. That closes the measurement loop entirely inside spytial-core.

## Layout

**Building blocks** — `src/data-instance/pyret/` (exported from `src/index.ts`):
- `reify.ts` — `reifyToValue(di, rootId?)` → synthetic value; sharing/cycles preserved via JS object identity (memo keyed by atom id).
- `replit.ts` — `replit(di)` → REPL-equivalent string (the `repr(reify(...))` analog).
- `canon.ts` — `canon(di)` → rename-invariant canonical form of a data instance.

**Measurement** — `tests/pyret/` (not shipped):
- `oracles.ts` — Tier A: `fixedPoint` = `canon(rel(v)) == canon(rel(reify(rel(v))))` (survives cycles); `relInjective` = `canon(rel(a)) != canon(rel(b))` for distinct `a,b` (catches collapses).
- `corpus.ts` — T0–T5 values + discriminator pairs. `report.ts` — score matrix + violations. `pyret-fidelity.test.ts` — the spec.

## Results

`fixed-point 2020/2020` (incl. 2000 fuzz cases, sharing DAGs, and cycles), `rel-injectivity 9/9`.

Run (vitest needs Node 22):
```
npx vitest run tests/pyret/pyret-fidelity.test.ts
```

## What measuring it revealed

- Relationalization already captures **sharing and cycles** correctly (the `objectToAtomId` WeakMap + back-edges); the old `reify()` *printer* was what duplicated shared subtrees / bailed on cycles.
- Found & fixed a reify bug: nested arrays were being flattened.
- **Field order** is a side-channel (`globalConstructorCache`), so it only affects positional rendering (replit), not structural fidelity — each field is a distinctly-named relation.
- Honest, pinned-down limitations: empty containers are ambiguous (no relations); list multiplicity collapses under primitive idempotency; tables don't round-trip yet (`processTableSemantics` drops column names / table↔row linkage).

## Scope / notes

- Purely additive; the existing `PyretDataInstance.reify()` method is untouched.
- **Tier B** (ground truth: `R-eq` via `equal-always`, `R-inspect` via `torepr`) needs a live Pyret runtime and is intentionally **not** here — it belongs in an IDE-side harness. `replit` is already runtime-free, so that harness is mostly wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)