### PR TITLE
ci: bump checkout/setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -23,7 +23,7 @@ jobs:
   solver-oracle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: steps.changes.outputs.run == 'true'
         with:
           node-version: '20'


### PR DESCRIPTION
## What

Bumps `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5` across the `test`, `publish`, and `deploy-guide` workflows.

## Why

The v2.8.0 publish run flagged both actions as running on the **deprecated Node 20 runtime** — GitHub forces these to Node 24 after **2026-06-16** and removes Node 20 from runners on **2026-09-16**. `v5` is the major that moves both actions to the Node 24 runtime, resolving the warning ahead of the deadline.

## Scope / risk

- Drop-in runtime bump — usage here is basic (`fetch-depth`, `node-version`, `registry-url`), all stable across v4→v5. No behavior change.
- Chose `v5` (the Node-24 major) over the latest `v6`, which additionally changes credential handling (`checkout@v6` persists creds to a separate file) — not needed here, so kept the change minimal and reviewable.
- `node-version` inputs left as-is (`'20'` for tests, `'24'` for publish) — the deprecation is about the action's bundled runtime, not the project's Node version.

Not touched: the GitHub Pages actions (`configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`) — not flagged in the run. Happy to bump those in a follow-up if they trip the same warning when `deploy-guide` next runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)