### PR TITLE
fix(cnd-graph): teardown safety — no throw on disconnect, no stale tick handlers

### DIFF
--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -2308,6 +2308,10 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       // Start the layout with specific iteration counts and proper event handling
       layout
         .on('tick', () => {
+          // A tick queued before clear()/dispose() can land after the
+          // selections were nulled — bail out instead of crashing.
+          if (!this.currentLayout || !this.svgNodes) return;
+
           if (isInitialSolve) {
             tickCount++;
             if (tickCount % 20 === 0) {
@@ -2331,6 +2335,9 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
           }
         })
         .on('end', () => {
+          // Same teardown race as the tick handler above.
+          if (!this.currentLayout || !this.svgNodes) return;
+
           isInitialSolve = false;
           if (shouldShowLoadingOverlay) {
             this.updateLoadingProgress('Finalizing...');
@@ -2886,6 +2893,11 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       } catch (e) {
         // Ignore errors when stopping layout
       }
+      // Mirror dispose(): stop() doesn't cancel an already-queued tick, so
+      // detach the handlers or a stale tick would fire against the nulled
+      // selections below.
+      (this.colaLayout as any).on?.('tick', null);
+      (this.colaLayout as any).on?.('end', null);
     }
 
     // Clear the SVG container
@@ -4318,27 +4330,20 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    * Positions them at the arrow/marker positions of edges
    */
   private updateEdgeEndpointMarkers(): void {
-    if (!this.svgLinkGroups) return;
+    // Skip when detached (e.g. dispose() via disconnectedCallback): path
+    // geometry reads throw on non-rendered elements, and there is nothing
+    // visible to update anyway.
+    if (!this.svgLinkGroups || !this.isConnected) return;
 
     // Update target markers (at the arrow end)
     this.svgLinkGroups.select('.target-marker')
       .attr('cx', (d: EdgeWithMetadata) => {
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
-        if (pathElement) {
-          const pathLength = pathElement.getTotalLength();
-          const point = pathElement.getPointAtLength(pathLength);
-          return point.x;
-        }
-        return d.target.x || 0;
+        const point = this.getEdgePathPoint(d.id, 'end');
+        return point ? point.x : (d.target.x || 0);
       })
       .attr('cy', (d: EdgeWithMetadata) => {
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
-        if (pathElement) {
-          const pathLength = pathElement.getTotalLength();
-          const point = pathElement.getPointAtLength(pathLength);
-          return point.y;
-        }
-        return d.target.y || 0;
+        const point = this.getEdgePathPoint(d.id, 'end');
+        return point ? point.y : (d.target.y || 0);
       })
       .attr('opacity', this.isInputModeActive ? 0.8 : 0)
       .style('pointer-events', this.isInputModeActive ? 'all' : 'none')
@@ -4347,24 +4352,33 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     // Update source markers (at the start)
     this.svgLinkGroups.select('.source-marker')
       .attr('cx', (d: EdgeWithMetadata) => {
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
-        if (pathElement) {
-          const point = pathElement.getPointAtLength(0);
-          return point.x;
-        }
-        return d.source.x || 0;
+        const point = this.getEdgePathPoint(d.id, 'start');
+        return point ? point.x : (d.source.x || 0);
       })
       .attr('cy', (d: EdgeWithMetadata) => {
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
-        if (pathElement) {
-          const point = pathElement.getPointAtLength(0);
-          return point.y;
-        }
-        return d.source.y || 0;
+        const point = this.getEdgePathPoint(d.id, 'start');
+        return point ? point.y : (d.source.y || 0);
       })
       .attr('opacity', this.isInputModeActive ? 0.8 : 0)
       .style('pointer-events', this.isInputModeActive ? 'all' : 'none')
       .raise(); // Always on top
+  }
+
+  /**
+   * Read the start or end point of a rendered edge path.
+   *
+   * Returns null when the path is missing or not rendered:
+   * getTotalLength()/getPointAtLength() throw InvalidStateError on detached
+   * or hidden paths, so callers fall back to layout coordinates.
+   */
+  private getEdgePathPoint(linkId: string, position: 'start' | 'end'): { x: number; y: number } | null {
+    const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${linkId}"]`) as SVGPathElement | null;
+    if (!pathElement) return null;
+    try {
+      return pathElement.getPointAtLength(position === 'end' ? pathElement.getTotalLength() : 0);
+    } catch {
+      return null;
+    }
   }
 
   private gridUpdatePositions() {
@@ -10276,7 +10290,14 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    * Performs cleanup to prevent memory leaks.
    */
   disconnectedCallback(): void {
-    this.dispose();
+    // Never let cleanup throw into the host's removeChild — an exception
+    // here propagates into the caller's unmount (e.g. React's commit
+    // phase) and can break the entire teardown.
+    try {
+      this.dispose();
+    } catch (e) {
+      console.warn('WebColaCnDGraph: error during disconnect cleanup', e);
+    }
   }
 
   /**

--- a/tests/webcola-teardown.test.ts
+++ b/tests/webcola-teardown.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
+
+/**
+ * Regression tests for the teardown bugs in issue #474:
+ *
+ * 1. disconnectedCallback → dispose() → updateEdgeEndpointMarkers() threw
+ *    InvalidStateError (getTotalLength()/getPointAtLength() on a detached
+ *    path), which escaped into the host's removeChild and broke unmounts.
+ * 2. clear() stopped the layout but left WebCola tick/end handlers attached,
+ *    so a tick queued before clear() ran against the nulled selections.
+ */
+
+const proto = WebColaCnDGraph.prototype as any;
+
+/** Chainable d3-selection stub that records resolved attr values. */
+function markerSelection(datum: any) {
+  const applied: Record<string, any> = {};
+  const sel: any = {
+    attr(name: string, value: any) {
+      applied[name] = typeof value === 'function' ? value(datum) : value;
+      return sel;
+    },
+    style() { return sel; },
+    raise() { return sel; },
+  };
+  return { sel, applied };
+}
+
+/** SVGPathElement stub behaving like a non-rendered path in a browser. */
+const throwingPath = {
+  getTotalLength() { throw new DOMException('non-rendered path', 'InvalidStateError'); },
+  getPointAtLength() { throw new DOMException('non-rendered path', 'InvalidStateError'); },
+};
+
+describe('WebColaCnDGraph teardown (#474)', () => {
+  describe('updateEdgeEndpointMarkers', () => {
+    it('is a no-op when the element is detached from the DOM', () => {
+      const select = vi.fn();
+      const fakeThis: any = {
+        isConnected: false,
+        svgLinkGroups: { select },
+      };
+
+      expect(() => proto.updateEdgeEndpointMarkers.call(fakeThis)).not.toThrow();
+      expect(select).not.toHaveBeenCalled();
+    });
+
+    it('falls back to layout coordinates when path geometry reads throw', () => {
+      const datum = { id: 'e1', source: { x: 1, y: 2 }, target: { x: 30, y: 40 } };
+      const target = markerSelection(datum);
+      const source = markerSelection(datum);
+      const fakeThis: any = {
+        isConnected: true,
+        isInputModeActive: false,
+        svgLinkGroups: {
+          select: (selector: string) =>
+            selector === '.target-marker' ? target.sel : source.sel,
+        },
+        shadowRoot: { querySelector: () => throwingPath },
+        getEdgePathPoint: proto.getEdgePathPoint,
+      };
+
+      expect(() => proto.updateEdgeEndpointMarkers.call(fakeThis)).not.toThrow();
+      expect(target.applied.cx).toBe(30);
+      expect(target.applied.cy).toBe(40);
+      expect(source.applied.cx).toBe(1);
+      expect(source.applied.cy).toBe(2);
+    });
+  });
+
+  describe('getEdgePathPoint', () => {
+    it('returns the path point when the path is rendered', () => {
+      const fakeThis: any = {
+        shadowRoot: {
+          querySelector: () => ({
+            getTotalLength: () => 10,
+            getPointAtLength: (length: number) => ({ x: length, y: 5 }),
+          }),
+        },
+      };
+
+      expect(proto.getEdgePathPoint.call(fakeThis, 'e1', 'end')).toEqual({ x: 10, y: 5 });
+      expect(proto.getEdgePathPoint.call(fakeThis, 'e1', 'start')).toEqual({ x: 0, y: 5 });
+    });
+
+    it('returns null when the path is missing or not rendered', () => {
+      const missing: any = { shadowRoot: { querySelector: () => null } };
+      expect(proto.getEdgePathPoint.call(missing, 'e1', 'end')).toBeNull();
+
+      const detached: any = { shadowRoot: { querySelector: () => throwingPath } };
+      expect(proto.getEdgePathPoint.call(detached, 'e1', 'end')).toBeNull();
+      expect(proto.getEdgePathPoint.call(detached, 'e1', 'start')).toBeNull();
+    });
+  });
+
+  describe('disconnectedCallback', () => {
+    it('never lets dispose() errors escape into the host', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const fakeThis: any = {
+          dispose: () => { throw new DOMException('detached', 'InvalidStateError'); },
+        };
+
+        expect(() => proto.disconnectedCallback.call(fakeThis)).not.toThrow();
+        expect(warn).toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe('clear', () => {
+    function clearableThis(colaLayout: any) {
+      return {
+        colaLayout,
+        container: null,
+        svg: null,
+        morphSlideTimer: null,
+        morphOldPositions: null,
+        currentLayout: {},
+        svgNodes: {},
+        svgLinks: {},
+        svgGroups: {},
+        edgeRoutingCache: { edgesBetweenNodes: new Map(), alignmentEdges: new Map() },
+        dragStartPositions: new Map(),
+        hideLoading: vi.fn(),
+      } as any;
+    }
+
+    it('detaches tick/end handlers before nulling the layout', () => {
+      const on = vi.fn();
+      const stop = vi.fn();
+      const fakeThis = clearableThis({ stop, on });
+
+      proto.clear.call(fakeThis);
+
+      expect(stop).toHaveBeenCalled();
+      expect(on).toHaveBeenCalledWith('tick', null);
+      expect(on).toHaveBeenCalledWith('end', null);
+      expect(fakeThis.colaLayout).toBeNull();
+      expect(fakeThis.svgNodes).toBeNull();
+    });
+
+    it('still detaches handlers when stop() throws', () => {
+      const on = vi.fn();
+      const fakeThis = clearableThis({ stop: () => { throw new Error('boom'); }, on });
+
+      expect(() => proto.clear.call(fakeThis)).not.toThrow();
+      expect(on).toHaveBeenCalledWith('tick', null);
+      expect(on).toHaveBeenCalledWith('end', null);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #474.

## Bug 1: `disconnectedCallback` → `dispose()` threw `InvalidStateError`

`dispose()` → `deactivateInputMode()` → `updateEdgeEndpointMarkers()` called `getTotalLength()`/`getPointAtLength()` on edge paths that are already detached by the time `disconnectedCallback` runs — these throw `InvalidStateError` on non-rendered paths. The exception escaped the lifecycle callback into the host's `removeChild` and broke the entire unmount (observed in React's `commitDeletionEffectsOnFiber`).

All three layers suggested in the issue are applied:
- `updateEdgeEndpointMarkers()` early-returns when `!this.isConnected` — nothing visible to update on a detached element.
- Path geometry reads moved into a `getEdgePathPoint()` helper that try/catches and returns `null`, falling back to the existing layout-coordinate branch (`d.target.x || 0` etc.). This also covers paths hidden inside a connected tree, and deduplicates the four copies of the query/measure logic.
- `disconnectedCallback` wraps `dispose()` in try/catch — lifecycle callbacks never throw into the host.

## Bug 2: `clear()` left WebCola `tick`/`end` handlers attached

`clear()` called `colaLayout.stop()` and nulled the selections, but WebCola's `stop()` doesn't cancel an already-queued tick, so a tick landing just after `clear()` ran the still-registered handler (`updatePositions()` etc.) against nulled selections → `TypeError`.

- `clear()` now detaches the `tick`/`end` handlers, mirroring what `dispose()` already did (detach runs even if `stop()` throws).
- Belt-and-braces: the `tick`/`end` handlers themselves bail out early if `currentLayout`/`svgNodes` are gone, protecting any other teardown race. Both fields are assigned before the layout starts, so the guard never skips legitimate events.

## Tests

`tests/webcola-teardown.test.ts` (prototype-call pattern, as in `loading-indicator-behavior.test.ts`):
- `updateEdgeEndpointMarkers` is a no-op when detached; falls back to layout coordinates when geometry reads throw `InvalidStateError`
- `getEdgePathPoint` returns the path point when rendered, `null` when missing/non-rendered
- `disconnectedCallback` never lets `dispose()` errors escape
- `clear()` detaches `tick`/`end` handlers before nulling the layout, including when `stop()` throws

Full suite passes (107 files, 1637 tests) and `build:all` succeeds. This should let copeanddrag drop the app-side workarounds from [copeanddrag#122](https://github.com/sidprasad/copeanddrag/pull/122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)