### PR TITLE
fix(layout): explain UNSAT counterfactuals via user constraints, not redundant group separations

### DIFF
--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -2267,6 +2267,77 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         return true;
     }
 
+    /**
+     * Rank how strongly an alternative is already entailed by the current graphs:
+     *   0 = directly entailed   — every ordering it would impose already exists
+     *       as a direct edge (and every alignment already holds). The separation
+     *       is *explicitly asserted* by existing constraints, not merely derived.
+     *   1 = transitively entailed — every ordering holds via reachability, but at
+     *       least one only transitively (no direct edge).
+     *   2 = not entailed — it would introduce at least one new ordering/alignment.
+     *
+     * The maximal-feasible-subset builder prefers lower ranks so a node stays on
+     * the side it *already* sits, favouring the side asserted by direct user
+     * constraints. Without this it picks the first merely-addable side in
+     * [left, right, top, bottom] order — which both mis-renders (e.g. a BDD root
+     * shoved right of its children) and pollutes the conflict explanation: a
+     * redundant group-separation edge short-circuits the real orientation cycle
+     * during IIS path tracing, so the reported conflict names an auto-generated
+     * group constraint instead of the user's own orientation constraints.
+     *
+     * Mirrors the edge enumeration of `addEdgeToGraphsExpanded`, but inspects
+     * `hasEdge`/`isOrdered`/`areAligned` instead of mutating the graphs.
+     */
+    private static alternativeEntailmentRank(
+        alternative: LayoutConstraint[],
+        hGraph: DifferenceConstraintGraph,
+        vGraph: DifferenceConstraintGraph,
+    ): 0 | 1 | 2 {
+        // Orderings (graph, from, to) this alternative would impose.
+        const edges: { g: DifferenceConstraintGraph; from: string; to: string }[] = [];
+        for (const constraint of alternative) {
+            if (isBoundingBoxConstraint(constraint)) {
+                const bc = constraint as BoundingBoxConstraint;
+                for (const m of bc.group.nodeIds) {
+                    switch (bc.side) {
+                        case 'left':   edges.push({ g: hGraph, from: bc.node.id, to: m }); break;
+                        case 'right':  edges.push({ g: hGraph, from: m, to: bc.node.id }); break;
+                        case 'top':    edges.push({ g: vGraph, from: bc.node.id, to: m }); break;
+                        case 'bottom': edges.push({ g: vGraph, from: m, to: bc.node.id }); break;
+                    }
+                }
+            } else if (isGroupBoundaryConstraint(constraint)) {
+                const gc = constraint as GroupBoundaryConstraint;
+                for (const aId of gc.groupA.nodeIds) {
+                    for (const bId of gc.groupB.nodeIds) {
+                        switch (gc.side) {
+                            case 'left':   edges.push({ g: hGraph, from: aId, to: bId }); break;
+                            case 'right':  edges.push({ g: hGraph, from: bId, to: aId }); break;
+                            case 'top':    edges.push({ g: vGraph, from: aId, to: bId }); break;
+                            case 'bottom': edges.push({ g: vGraph, from: bId, to: aId }); break;
+                        }
+                    }
+                }
+            } else if (isLeftConstraint(constraint)) {
+                edges.push({ g: hGraph, from: constraint.left.id, to: constraint.right.id });
+            } else if (isTopConstraint(constraint)) {
+                edges.push({ g: vGraph, from: constraint.top.id, to: constraint.bottom.id });
+            } else if (isAlignmentConstraint(constraint)) {
+                const ac = constraint as AlignmentConstraint;
+                const graph = ac.axis === 'x' ? hGraph : vGraph;
+                // An alignment that doesn't already hold introduces a new constraint.
+                if (ac.node1.id !== ac.node2.id && !graph.areAligned(ac.node1.id, ac.node2.id)) return 2;
+            }
+        }
+        let allDirect = true;
+        for (const e of edges) {
+            if (e.g.hasEdge(e.from, e.to)) continue;   // directly asserted
+            allDirect = false;
+            if (!e.g.isOrdered(e.from, e.to)) return 2; // not even reachable → new
+        }
+        return allDirect ? 0 : 1;
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Maximal feasible subset
     // ═══════════════════════════════════════════════════════════════════════════
@@ -2317,7 +2388,19 @@ class QualitativeConstraintValidator implements IConstraintValidator {
 
         for (const disj of sortedDisjunctions) {
             let added = false;
-            for (const alternative of disj.alternatives) {
+            // Prefer an alternative whose separation already holds in the current
+            // graphs (adds no new ordering) over the first merely-addable one, and
+            // among those prefer the side asserted by *direct* edges. This keeps a
+            // node on the side it already sits — e.g. a BDD root that is already
+            // above its children stays "top" instead of being shoved "right" — and
+            // matches presolve's already-separated behaviour. Picking the directly
+            // -entailed side also avoids adding a redundant separation edge that
+            // would short-circuit the real orientation cycle when the conflict is
+            // later explained. Stable sort by rank, original order within a rank.
+            const orderedAlternatives = disj.alternatives
+                .map((alt, i) => ({ alt, i, rank: QualitativeConstraintValidator.alternativeEntailmentRank(alt, freshH, freshV) }))
+                .sort((a, b) => a.rank - b.rank || a.i - b.i);
+            for (const { alt: alternative } of orderedAlternatives) {
                 const hClone = freshH.clone();
                 const vClone = freshV.clone();
                 let ok = true;


### PR DESCRIPTION
## Problem

On an UNSAT layout (surfaced on a shared-node BDD where lo-left/hi-right can't hold without a crossing), the counterfactual reported the conflict as an **auto-generated group-separation constraint** instead of the user's own orientation constraints.

For the BDD root `Node0` with children grouped by variable, the reported conflict was:

```
{ Node0 left-of Node5,  Node0 right-of group[x2] }   ← includes an implicit group constraint
```

when the genuine, minimal conflict is the **4-node orientation cycle**:

```
Node0 → Node5   (root hi edge)
Node5 → Node2   (n6 hi edge)
Node2 → Node1   (n0 lo edge)
Node1 → Node0   (root lo edge)
```

## Root cause

When the conjunctive constraints are themselves cyclic, `computeMaximalFeasibleSubset()` resolves each group non-overlap disjunction by taking the **first feasible** side in `[left, right, top, bottom]` order. When a node is already separated from a group on more than one axis — here `Node0` is both *above* its children and, via the broken cycle remnant `n6→n1→n0→obj_23`, *right* of them — it picked "right" and added a redundant direct edge `n6 → obj_23`.

That redundant 1-hop edge then **short-circuited IIS path tracing**: `findPath` is a BFS, so it took the 1-hop group edge instead of the real 3-hop orientation path, and reported the group constraint's provenance.

## Fix

Rank each disjunction alternative by how strongly it is **already entailed** by the current graphs:

- `0` — directly entailed (every ordering already exists as a direct edge)
- `1` — transitively entailed (holds via reachability)
- `2` — not entailed (introduces a new ordering)

Prefer the lowest rank. The node stays on the side it already sits, favouring the side asserted by *direct* user constraints. No redundant separation edge is added, so the conflict is explained by the constraints that actually cause it.

**After the fix**, the conflict is reported as exactly the four user constraints among `Node0, Node5, Node2, Node1`, and the group separations are geometrically honest (`Node0 top-of` both groups).

## Note

The spec is genuinely unsatisfiable, so the rendered counterfactual still drops one of those four constraints (the root stays off to one side). This PR fixes the **explanation**, not the inherent need to sacrifice a constraint. Biasing the drop choice toward a "middle" edge to keep the root centered is a possible follow-up.

## Testing

- All **1637 tests pass** (5 skipped), including the full **Z3-oracle equivalence** suite. The change only affects *which* counterfactual is built on UNSAT — never the SAT/UNSAT decision.
- `npm run build:all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)