### PR TITLE
feat(layout): hideAtom vs constraint is unsat; counterfactual shows the hidden atoms

### DIFF
--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -386,6 +386,8 @@ Hides atoms matching a selector from the visualization. (Can also be used as a d
     selector: InternalNode
 ```
 
+**Conflicts with layout constraints:** an atom cannot be both hidden and placed. If a layout constraint (`orientation`, `align`, `cyclic`) or a `group` contains a hidden atom as a member, the spec is unsatisfiable: the layout reports a hidden-node conflict error, and the diagram shown is a counterfactual in which the conflicting atoms are drawn anyway, outlined with a dashed border. Hiding a keyed group's *key* is fine — the key is not inside the group.
+
 ---
 
 ## Directives
@@ -851,6 +853,8 @@ Hides atoms matching a selector from the visualization.
 - hideAtom:
     selector: HelperNode
 ```
+
+Hiding an atom that a layout constraint references (or that a group contains) makes the spec unsatisfiable — see [Hide Atom Constraint](#hide-atom-constraint) for how the conflict is reported and drawn.
 
 ---
 

--- a/site/constraints.md
+++ b/site/constraints.md
@@ -313,6 +313,8 @@ Removes atoms from the visualization entirely. The atom and all its edges disapp
 
 > **Note:** `hideAtom` can appear in either the `constraints` or `directives` section.
 
+> **Conflicts:** an atom cannot be both hidden and placed. If an `orientation`, `align`, or `cyclic` constraint references a hidden atom, or a `group` contains one as a member, the spec is unsatisfiable — the layout reports a hidden-node conflict error, and the diagram shows a counterfactual in which the conflicting atoms are drawn anyway with a dashed outline. Hiding a keyed group's *key* is fine: the key is not inside the group.
+
 ```yaml
 - hideAtom:
     selector: <unary-selector>   # Required

--- a/site/directives.md
+++ b/site/directives.md
@@ -650,7 +650,7 @@ directives:
 
 ## Hiding Atoms (Directive)
 
-Hides atoms matching a selector. Identical to the [hideAtom constraint](constraints.md#hiding-atoms).
+Hides atoms matching a selector. Identical to the [hideAtom constraint](constraints.md#hiding-atoms) — including the conflict rule: hiding an atom that a layout constraint references (or that a group contains) makes the spec unsatisfiable, and the diagram draws the atom anyway with a dashed outline alongside the error.
 
 ```yaml
 - hideAtom:

--- a/src/components/ErrorMessageModal/ErrorMessageModal.tsx
+++ b/src/components/ErrorMessageModal/ErrorMessageModal.tsx
@@ -207,7 +207,7 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
   const descriptionText = useMemo(() => {
     if (isSelectorError) return 'One or more selectors in your layout specification could not be evaluated.';
     if (isOtherError) return 'An error occurred while processing your data.';
-    if (isHiddenNodeError) return 'Some constraints reference nodes that are hidden by a hideAtom directive. The conflicting constraints have been dropped from the layout.';
+    if (isHiddenNodeError) return 'Some layout constraints reference atoms hidden by a hideAtom directive. Those atoms have been re-introduced into the diagram (shown despite the hide) so the relationships can be drawn. Re-introduced atoms are outlined with a dashed border.';
     return 'Your data causes the following visualization constraints to conflict.';
   }, [isSelectorError, isOtherError, isHiddenNodeError]);
 
@@ -248,7 +248,7 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
       {/* (Positional) Constraint Error Cards */}
       { isPositionalError && (
         <>
-          <p id="hover-instructions">Hover over the conflicting constraints to see the corresponding diagram elements that cannot be visualized. </p>
+          <p id="hover-instructions">Hover over the {isHiddenNodeError ? 'constraints' : 'conflicting constraints'} to see the corresponding diagram elements{isHiddenNodeError ? ' that were affected' : ' that cannot be visualized'}. </p>
           <div className="constraint-relationship-table">
             <div className="constraint-columns">
               <div className="constraint-column">

--- a/src/components/ErrorMessageModal/ErrorMessageModal.tsx
+++ b/src/components/ErrorMessageModal/ErrorMessageModal.tsx
@@ -207,7 +207,7 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
   const descriptionText = useMemo(() => {
     if (isSelectorError) return 'One or more selectors in your layout specification could not be evaluated.';
     if (isOtherError) return 'An error occurred while processing your data.';
-    if (isHiddenNodeError) return 'Some layout constraints reference atoms hidden by a hideAtom directive. Those atoms have been re-introduced into the diagram (shown despite the hide) so the relationships can be drawn. Re-introduced atoms are outlined with a dashed border.';
+    if (isHiddenNodeError) return 'Some layout constraints reference atoms hidden by a hideAtom directive. An atom cannot be both hidden and placed, so this layout is unsatisfiable. The diagram shows what the layout would look like if those atoms were not hidden — they are outlined with a dashed border.';
     return 'Your data causes the following visualization constraints to conflict.';
   }, [isSelectorError, isOtherError, isHiddenNodeError]);
 

--- a/src/layout/constraint-types.ts
+++ b/src/layout/constraint-types.ts
@@ -55,10 +55,19 @@ export interface HiddenNodeConflictError extends ConstraintError {
     type: 'hidden-node-conflict';
     /** Map of hidden node ID → the hideAtom selector that hid it */
     hiddenNodes: Map<string, string>;
-    /** Map of source constraint → list of pairwise descriptions that were dropped */
+    /** Map of source constraint → list of pairwise descriptions that conflicted with the hide */
     droppedConstraints: Map<string, string[]>;
     /** Structured error messages for UI rendering (same format as positional errors) */
     errorMessages: ErrorMessages;
+    /**
+     * How the conflict was resolved:
+     * - 'reintroduced' (default): the hidden atoms were shown anyway because constraints
+     *   reference them; no constraints were dropped.
+     * - 'dropped': fallback — the conflicting constraints were dropped and the atoms stayed hidden.
+     */
+    resolution: 'reintroduced' | 'dropped';
+    /** Node IDs that were re-introduced into the diagram (only when resolution is 'reintroduced'). */
+    reintroducedNodeIds?: string[];
 }
 
 export function isHiddenNodeConflictError(error: unknown): error is HiddenNodeConflictError {

--- a/src/layout/constraint-types.ts
+++ b/src/layout/constraint-types.ts
@@ -48,8 +48,11 @@ export interface GroupOverlapError extends ConstraintError {
 }
 
 /**
- * Error for when a hideAtom directive hides a node that is also referenced by layout constraints.
- * Reported in a table format similar to IIS conflicts.
+ * Error for when a hideAtom directive hides a node that a layout constraint references.
+ * The two are mutually unsatisfiable — the atom cannot be both hidden and placed — so the
+ * layout is unsat. Reported in a table format similar to IIS conflicts. The accompanying
+ * counterfactual layout shows the conflicting atoms despite the hide (dashed outline);
+ * see `reintroducedNodeIds` and `InstanceLayout.reintroducedNodes`.
  */
 export interface HiddenNodeConflictError extends ConstraintError {
     type: 'hidden-node-conflict';
@@ -59,14 +62,7 @@ export interface HiddenNodeConflictError extends ConstraintError {
     droppedConstraints: Map<string, string[]>;
     /** Structured error messages for UI rendering (same format as positional errors) */
     errorMessages: ErrorMessages;
-    /**
-     * How the conflict was resolved:
-     * - 'reintroduced' (default): the hidden atoms were shown anyway because constraints
-     *   reference them; no constraints were dropped.
-     * - 'dropped': fallback — the conflicting constraints were dropped and the atoms stayed hidden.
-     */
-    resolution: 'reintroduced' | 'dropped';
-    /** Node IDs that were re-introduced into the diagram (only when resolution is 'reintroduced'). */
+    /** Node IDs the counterfactual layout draws despite the hide (dashed outline). */
     reintroducedNodeIds?: string[];
 }
 

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -277,17 +277,10 @@ export interface InstanceLayout {
      */
     warnings?: LayoutWarning[];
     /**
-     * Still-visible nodes that were the other end of a relationship dropped because the
-     * relationship's other end was hidden by a hideAtom directive. Surfaced so the
-     * counterfactual diagram can highlight the atoms a hidden-node conflict actually affects.
-     * Only populated by the drop-the-constraint fallback (see `reintroducedNodes` for the
-     * default re-introduction behavior).
-     */
-    hiddenConflictNodes?: LayoutNode[];
-    /**
-     * Atoms hidden by a hideAtom directive that were re-introduced into the diagram because
-     * a layout constraint references them. Surfaced so the renderer can mark them distinctly
-     * ("shown because a constraint needs it") rather than dropping the relationship.
+     * Atoms hidden by a hideAtom directive that a layout constraint references. The hide
+     * and the constraint cannot both be satisfied (the layout is reported unsat via
+     * HiddenNodeConflictError); this counterfactual diagram shows the atoms anyway, and
+     * the renderer marks them distinctly (dashed outline) as hidden-but-shown.
      */
     reintroducedNodes?: LayoutNode[];
     /**

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -277,6 +277,20 @@ export interface InstanceLayout {
      */
     warnings?: LayoutWarning[];
     /**
+     * Still-visible nodes that were the other end of a relationship dropped because the
+     * relationship's other end was hidden by a hideAtom directive. Surfaced so the
+     * counterfactual diagram can highlight the atoms a hidden-node conflict actually affects.
+     * Only populated by the drop-the-constraint fallback (see `reintroducedNodes` for the
+     * default re-introduction behavior).
+     */
+    hiddenConflictNodes?: LayoutNode[];
+    /**
+     * Atoms hidden by a hideAtom directive that were re-introduced into the diagram because
+     * a layout constraint references them. Surfaced so the renderer can mark them distinctly
+     * ("shown because a constraint needs it") rather than dropping the relationship.
+     */
+    reintroducedNodes?: LayoutNode[];
+    /**
      * Disjunctive constraints, where at least one alternative in each disjunction must be satisfiable.
      * These are separate from conjunctive constraints for clearer solver integration.
      */

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -367,6 +367,29 @@ export class LayoutInstance {
     private inferredEdgeGroupStamps: Map<string, { sourceGroupId?: string; targetGroupId?: string }> = new Map();
 
     /**
+     * Set of still-visible node IDs that were the other end of a relationship dropped
+     * because its partner was hidden. Used to highlight the visible atoms a hidden-node
+     * conflict affects in the counterfactual diagram.
+     * Reset at the start of each generateLayout() call.
+     */
+    private conflictedVisibleNodes: Set<string> = new Set();
+
+    /**
+     * Atom IDs that a hideAtom directive would hide but which must NOT be hidden because a
+     * layout constraint references them. Honored by ensureNoExtraNodes to re-introduce them.
+     * Carried across the internal re-generation pass, so it is reset only by the public
+     * generateLayout() entry point, never by an individual pass.
+     */
+    private exemptFromHiding: Set<string> = new Set();
+
+    /**
+     * Atom IDs that were re-introduced (kept visible) this pass despite matching a hideAtom
+     * directive, because a constraint references them. Repopulated by ensureNoExtraNodes on
+     * each pass.
+     */
+    private reintroducedNodes: Set<string> = new Set();
+
+    /**
      * Records a selector evaluation error for later reporting.
      * @param selector - The selector expression that failed
      * @param context - Description of where/why the selector was being evaluated
@@ -570,17 +593,38 @@ export class LayoutInstance {
      * The constraint is dropped from the layout, and the conflict is tracked for error reporting.
      * @param sourceConstraint - The source constraint that references the hidden node
      * @param pairwiseDescription - A human-readable description of the dropped pairwise constraint
-     * @param hiddenNodeId - The ID of the hidden node
+     * @param sourceNodeId - The source node of the dropped relationship
+     * @param targetNodeId - The target node of the dropped relationship
+     * @param sourceHidden - Whether the source node is hidden by a directive
+     * @param targetHidden - Whether the target node is hidden by a directive
      */
-    private recordHiddenNodeConflict(sourceConstraint: ConstraintSource, pairwiseDescription: string, hiddenNodeId: string): void {
+    private recordHiddenNodeConflict(
+        sourceConstraint: ConstraintSource,
+        pairwiseDescription: string,
+        sourceNodeId: string,
+        targetNodeId: string,
+        sourceHidden: boolean,
+        targetHidden: boolean
+    ): void {
         const sourceHTML = sourceConstraint.toHTML();
         if (!this.hiddenNodeConflicts.has(sourceHTML)) {
             this.hiddenNodeConflicts.set(sourceHTML, []);
         }
         this.hiddenNodeConflicts.get(sourceHTML)!.push(pairwiseDescription);
 
-        // Track which hidden nodes are involved in conflicts (for building hideAtom table entries)
-        this.conflictedHiddenNodes.add(hiddenNodeId);
+        // Track which hidden nodes are involved in conflicts (for building hideAtom table
+        // entries), and which still-visible nodes were the other end of the dropped
+        // relationship (so the counterfactual diagram can highlight them).
+        if (sourceHidden) {
+            this.conflictedHiddenNodes.add(sourceNodeId);
+        } else {
+            this.conflictedVisibleNodes.add(sourceNodeId);
+        }
+        if (targetHidden) {
+            this.conflictedHiddenNodes.add(targetNodeId);
+        } else {
+            this.conflictedVisibleNodes.add(targetNodeId);
+        }
     }
 
 
@@ -1352,6 +1396,14 @@ export class LayoutInstance {
 
                 const hideNode = hideLegacy || hideBySelector;
 
+                // A hideAtom-selected node that a layout constraint references is re-introduced
+                // (kept visible) rather than removed. The exemption set is populated on a prior
+                // pass when the hide conflicted with a constraint (see generateLayout).
+                if (hideBySelector && this.exemptFromHiding.has(node)) {
+                    this.reintroducedNodes.add(node);
+                    return; // keep the node; do not record it as hidden
+                }
+
                 if (hideNode) {
                     g.removeNode(node);
                     // Track selector-hidden nodes so constraint generation can report conflicts
@@ -1403,11 +1455,56 @@ export class LayoutInstance {
      * Generates the layout for the given data instance.
      * Projections should be applied to the data instance before calling this method
      * using `applyProjectionTransform()` from the data-instance module.
+     *
+     * When a hideAtom directive hides an atom that a layout constraint references, the
+     * conflict is resolved by re-introducing those atoms (showing them despite the hide)
+     * and keeping the constraints, rather than silently dropping the relationship. This is
+     * implemented as a second generation pass with the conflicting atoms exempted from
+     * hiding; the re-introduced atoms are marked on the layout and explained via the
+     * returned (informational) HiddenNodeConflictError.
+     *
      * @param a - The data instance to generate the layout for.
      * @returns An object containing the layout, constraint error (if any), and any selector errors encountered.
      * @throws {ConstraintError} If the layout cannot be generated due to unsatisfiable constraints and error isn't caught to be surfaced to the user.
      */
     public generateLayout(
+        a: IDataInstance
+    ): CounterfactualLayoutResult {
+        // Fresh exemption set per public call; it is the only state that must survive the
+        // internal re-generation pass below.
+        this.exemptFromHiding = new Set();
+
+        let result = this.generateLayoutPass(a);
+
+        // If any hidden atoms conflicted with constraints, re-introduce them and re-run.
+        const toReintroduce = [...this.conflictedHiddenNodes].filter(id => !this.exemptFromHiding.has(id));
+        if (toReintroduce.length > 0) {
+            // Capture the conflict explanation before the next pass resets the tracking maps.
+            const conflictInfo = this.buildHiddenNodeConflictInfo('reintroduced');
+            toReintroduce.forEach(id => this.exemptFromHiding.add(id));
+
+            result = this.generateLayoutPass(a);
+
+            // Mark the re-introduced atoms on the layout and attach the explanation, unless
+            // the re-run surfaced a genuine (e.g. positional) conflict that takes precedence.
+            const reintroduced = result.layout.nodes.filter(n => this.reintroducedNodes.has(n.id));
+            if (reintroduced.length > 0) {
+                result.layout.reintroducedNodes = reintroduced;
+            }
+            if (result.error === null) {
+                conflictInfo.reintroducedNodeIds = reintroduced.map(n => n.id);
+                result = { ...result, error: conflictInfo };
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Runs a single layout-generation pass. Honors `this.exemptFromHiding` so callers can
+     * re-introduce previously-hidden atoms. Not for direct use — call generateLayout().
+     */
+    private generateLayoutPass(
         a: IDataInstance
     ): CounterfactualLayoutResult {
         // Reset selector errors at the start of each layout generation
@@ -1418,9 +1515,12 @@ export class LayoutInstance {
         // per-item selector warnings this render is about to collect.
         this.recordSpecParseWarnings();
         // Reset hidden-node tracking at the start of each layout generation
+        // (exemptFromHiding is intentionally preserved across passes)
         this.hiddenNodeSelectors = new Map();
         this.hiddenNodeConflicts = new Map();
         this.conflictedHiddenNodes = new Set();
+        this.conflictedVisibleNodes = new Set();
+        this.reintroducedNodes = new Set();
         this.inferredEdgeGroupStamps = new Map();
 
         let ai = a;
@@ -1676,15 +1776,17 @@ export class LayoutInstance {
     }
 
     /**
-     * Handles conflicts where hideAtom directives hide nodes referenced by layout
-     * constraints. Reports the conflict in IIS-like table format and returns a
-     * counterfactual layout with the conflicting constraints already dropped.
+     * Builds the structured explanation for a hideAtom-vs-constraint conflict (IIS-like
+     * table + summary message), worded for how the conflict was resolved. Reads the
+     * hidden-node tracking maps populated during the conflicting pass, so it must be called
+     * before those maps are reset by a subsequent pass.
+     *
+     * @param resolution - 'reintroduced' when the atoms were shown anyway (default behavior),
+     *   'dropped' when the conflicting constraints were dropped (fallback).
      */
-    private handleHiddenNodeConflictError(
-        layout: InstanceLayout
-    ): CounterfactualLayoutResult {
+    private buildHiddenNodeConflictInfo(resolution: 'reintroduced' | 'dropped'): HiddenNodeConflictError {
         // Build the IIS-like error messages map:
-        //   Source Constraint HTML → list of dropped pairwise constraint descriptions
+        //   Source Constraint HTML → list of conflicting pairwise constraint descriptions
         // Also add a synthetic entry for each hideAtom directive involved
         const sourceConstraintHTMLToLayoutConstraintsHTML = new Map<string, string[]>();
 
@@ -1703,14 +1805,17 @@ export class LayoutInstance {
             }
         }
 
-        // Add hideAtom directives as source constraints in the table
+        // Add hideAtom directives as source constraints in the table. Only the atoms
+        // actually involved in a conflict are listed (they are tracked in
+        // conflictedHiddenNodes and were recorded in hiddenNodeSelectors when hidden).
+        const conflictedIds = [...this.conflictedHiddenNodes];
+        const hiddenState = resolution === 'reintroduced' ? 'hidden, but re-introduced' : 'hidden';
         for (const hideSelector of involvedHideSelectors) {
             const hideHTML = `hideAtom with selector <code>${hideSelector}</code>`;
-            // Collect which nodes this selector hid that are involved in conflicts
             const hiddenNodeDescriptions: string[] = [];
-            for (const [nodeId, selector] of this.hiddenNodeSelectors.entries()) {
-                if (selector === hideSelector) {
-                    hiddenNodeDescriptions.push(`${nodeId} is hidden`);
+            for (const nodeId of conflictedIds) {
+                if (this.hiddenNodeSelectors.get(nodeId) === hideSelector) {
+                    hiddenNodeDescriptions.push(`${nodeId} is ${hiddenState}`);
                 }
             }
             if (hiddenNodeDescriptions.length > 0) {
@@ -1719,7 +1824,6 @@ export class LayoutInstance {
         }
 
         // Build a summary message
-        const hiddenNodeIds = [...this.hiddenNodeSelectors.keys()];
         const firstConflictSourceHTML = [...this.hiddenNodeConflicts.keys()][0];
         const firstConflictDescription = this.hiddenNodeConflicts.get(firstConflictSourceHTML)?.[0] || '';
 
@@ -1729,22 +1833,43 @@ export class LayoutInstance {
             minimalConflictingConstraints: sourceConstraintHTMLToLayoutConstraintsHTML
         };
 
-        const error: HiddenNodeConflictError = {
+        const message = resolution === 'reintroduced'
+            ? `Atoms [${conflictedIds.join(', ')}] are hidden by a hideAtom directive but referenced by layout constraints, so they have been re-introduced into the diagram.`
+            : `Constraints reference hidden nodes [${conflictedIds.join(', ')}]. These constraints have been dropped from the layout.`;
+
+        return {
             name: 'HiddenNodeConflictError',
             type: 'hidden-node-conflict',
-            message: `Constraints reference hidden nodes [${hiddenNodeIds.join(', ')}]. These constraints have been dropped from the layout.`,
+            message,
             hiddenNodes: this.hiddenNodeSelectors,
             droppedConstraints: this.hiddenNodeConflicts,
-            errorMessages
+            errorMessages,
+            resolution
         };
+    }
+
+    /**
+     * Handles conflicts where hideAtom directives hide nodes referenced by layout
+     * constraints. Fallback path used only when re-introduction did not resolve the
+     * conflict; drops the conflicting constraints and highlights the still-visible partners.
+     */
+    private handleHiddenNodeConflictError(
+        layout: InstanceLayout
+    ): CounterfactualLayoutResult {
+        const error = this.buildHiddenNodeConflictInfo('dropped');
 
         // The layout already has the conflicting constraints dropped (they were skipped
         // during generation), so it serves as the counterfactual diagram.
         // Apply the same edge-visibility post-processing that the normal path performs.
+        // Surface the still-visible atoms that were the other end of a dropped relationship
+        // so the renderer can highlight them — the hidden atom itself is gone from the
+        // diagram, but its visible partners are the ones whose constraints were lost.
+        const hiddenConflictNodes = layout.nodes.filter(n => this.conflictedVisibleNodes.has(n.id));
         const counterfactualLayout: InstanceLayout = {
             ...layout,
             edges: this.filterHiddenEdges(layout.edges),
-            warnings: this.warnings
+            warnings: this.warnings,
+            hiddenConflictNodes: hiddenConflictNodes.length > 0 ? hiddenConflictNodes : undefined
         };
 
         return {
@@ -2113,11 +2238,10 @@ export class LayoutInstance {
                 const sourceHidden = this.isNodeHiddenByDirective(sourceNodeId);
                 const targetHidden = this.isNodeHiddenByDirective(targetNodeId);
                 if (sourceHidden || targetHidden) {
-                    const hiddenId = sourceHidden ? sourceNodeId : targetNodeId;
                     // Record one description per direction in natural language
                     for (const dir of directions) {
                         const description = describeDroppedOrientationConstraint(sourceNodeId, targetNodeId, dir);
-                        this.recordHiddenNodeConflict(c, description, hiddenId);
+                        this.recordHiddenNodeConflict(c, description, sourceNodeId, targetNodeId, sourceHidden, targetHidden);
                     }
                     return; // Skip this tuple
                 }
@@ -2450,10 +2574,9 @@ export class LayoutInstance {
                 const sourceHidden = this.isNodeHiddenByDirective(sourceNodeId);
                 const targetHidden = this.isNodeHiddenByDirective(targetNodeId);
                 if (sourceHidden || targetHidden) {
-                    const hiddenId = sourceHidden ? sourceNodeId : targetNodeId;
                     const alignDir = direction === 'horizontal' ? 'horizontally' : 'vertically';
                     const description = `${sourceNodeId} is ${alignDir} aligned with ${targetNodeId}`;
-                    this.recordHiddenNodeConflict(c, description, hiddenId);
+                    this.recordHiddenNodeConflict(c, description, sourceNodeId, targetNodeId, sourceHidden, targetHidden);
                     return; // Skip this tuple
                 }
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -1960,10 +1960,21 @@ export class LayoutInstance {
                 let sourceNodeId = tuple[0];
                 let targetNodeId = tuple[1];
 
+                // Skip tuples referencing hidden nodes; record the conflict for error reporting
+                // (the atom cannot be both hidden and placed on the cycle)
+                const sourceHidden = this.isNodeHiddenByDirective(sourceNodeId);
+                const targetHidden = this.isNodeHiddenByDirective(targetNodeId);
+                if (sourceHidden || targetHidden) {
+                    const description = `${sourceNodeId} is followed by ${targetNodeId} in a ${c.direction} cycle`;
+                    this.recordHiddenNodeConflict(c, description, sourceNodeId, targetNodeId, sourceHidden, targetHidden);
+                    return; // Skip this tuple
+                }
+
                 let srcN = layoutNodes.find((node) => node.id === sourceNodeId);
                 let tgtN = layoutNodes.find((node) => node.id === targetNodeId);
 
-                // Skip if either node is not found
+                // Skip if either node is not found (hidden for a non-directive reason,
+                // e.g. legacy disconnected-node hiding)
                 if (!srcN || !tgtN) {
                     return;
                 }

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -616,6 +616,25 @@ export class LayoutInstance {
         }
     }
 
+    /**
+     * Records a conflict where a group contains a hideAtom-hidden atom — unsatisfiable
+     * for the same reason as the pairwise case: the atom cannot be both hidden and drawn
+     * inside the group. generateLayout() shows the atom in the counterfactual and reports
+     * the conflict as a layout error. (Group keys are exempt: a binary group's key is not
+     * inside the hull, and hiding keys while keeping the group is a sanctioned pattern.)
+     * @param group - The group that contains the hidden atom
+     * @param hiddenNodeId - The hidden member atom
+     */
+    private recordHiddenGroupMemberConflict(group: LayoutGroup, hiddenNodeId: string): void {
+        const sourceHTML = group.sourceConstraint?.toHTML() ?? `group <code>${group.name}</code>`;
+        const description = `${hiddenNodeId} is in group ${group.name}`;
+        if (!this.hiddenNodeConflicts.has(sourceHTML)) {
+            this.hiddenNodeConflicts.set(sourceHTML, []);
+        }
+        this.hiddenNodeConflicts.get(sourceHTML)!.push(description);
+        this.conflictedHiddenNodes.add(hiddenNodeId);
+    }
+
 
     /**
      * Constructs a new `LayoutInstance` object.
@@ -1330,10 +1349,13 @@ export class LayoutInstance {
 
     /**
     * Modifies the graph to remove extraneous nodes (ex. those to be hidden)
-    * Also populates this.hiddenNodeSelectors so constraint generation can detect conflicts.
+    * Also populates this.hiddenNodeSelectors so constraint generation can detect conflicts,
+    * and records hide-vs-group conflicts against the already-generated groups (groups are
+    * built before hiding, so membership is checked here at hide time).
     * @param g - The graph, which will be modified to remove extraneous nodes.
+    * @param groups - The groups generated for this pass, checked for hidden members/keys.
     */
-    private ensureNoExtraNodes(g: Graph, a: IDataInstance) {
+    private ensureNoExtraNodes(g: Graph, a: IDataInstance, groups: LayoutGroup[]) {
 
         let nodes = [...g.nodes()];
 
@@ -1398,6 +1420,18 @@ export class LayoutInstance {
                     // Track selector-hidden nodes so constraint generation can report conflicts
                     if (hideBySelector && hidingSelector) {
                         this.hiddenNodeSelectors.set(node, hidingSelector);
+                        // A group that contains this atom cannot be drawn without it —
+                        // the hide and the group cannot both be satisfied. Only members
+                        // count: a binary group's key is not inside the hull (hiding keys
+                        // while keeping the group is a sanctioned pattern; see the
+                        // inferred-edge draw tests), and negated groups assert
+                        // non-containment, so a hidden member does not contradict them.
+                        for (const group of groups) {
+                            if (group.negated) continue;
+                            if (group.nodeIds.includes(node)) {
+                                this.recordHiddenGroupMemberConflict(group, node);
+                            }
+                        }
                     }
                 }
 
@@ -1538,7 +1572,7 @@ export class LayoutInstance {
         // like plain inferred edges — so they can reconnect built-in atoms).
         this.addDrawInferredEdges(g, groups);
 
-        this.ensureNoExtraNodes(g, a);
+        this.ensureNoExtraNodes(g, a, groups);
 
         // Recompute visual maps after graph mutations (inferred edges / node removal)
         let nodeIconMap = this.getNodeIconMap(g);

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -367,25 +367,17 @@ export class LayoutInstance {
     private inferredEdgeGroupStamps: Map<string, { sourceGroupId?: string; targetGroupId?: string }> = new Map();
 
     /**
-     * Set of still-visible node IDs that were the other end of a relationship dropped
-     * because its partner was hidden. Used to highlight the visible atoms a hidden-node
-     * conflict affects in the counterfactual diagram.
-     * Reset at the start of each generateLayout() call.
-     */
-    private conflictedVisibleNodes: Set<string> = new Set();
-
-    /**
-     * Atom IDs that a hideAtom directive would hide but which must NOT be hidden because a
-     * layout constraint references them. Honored by ensureNoExtraNodes to re-introduce them.
-     * Carried across the internal re-generation pass, so it is reset only by the public
+     * Atom IDs that a hideAtom directive would hide but which the counterfactual pass must
+     * show, because a layout constraint references them. Honored by ensureNoExtraNodes.
+     * Carried across the internal counterfactual pass, so it is reset only by the public
      * generateLayout() entry point, never by an individual pass.
      */
     private exemptFromHiding: Set<string> = new Set();
 
     /**
-     * Atom IDs that were re-introduced (kept visible) this pass despite matching a hideAtom
-     * directive, because a constraint references them. Repopulated by ensureNoExtraNodes on
-     * each pass.
+     * Atom IDs kept visible this pass despite matching a hideAtom directive, because a
+     * constraint references them. These are the atoms the counterfactual diagram draws
+     * with a dashed outline. Repopulated by ensureNoExtraNodes on each pass.
      */
     private reintroducedNodes: Set<string> = new Set();
 
@@ -589,12 +581,14 @@ export class LayoutInstance {
     }
 
     /**
-     * Records a conflict where a constraint references a hidden node.
-     * The constraint is dropped from the layout, and the conflict is tracked for error reporting.
+     * Records a conflict where a constraint references a hidden node — an unsatisfiable
+     * combination: the atom cannot be both hidden and placed. The tuple is skipped for
+     * this pass; generateLayout() then builds the counterfactual diagram by re-running
+     * with the hidden atoms shown, and reports the conflict as a layout error.
      * @param sourceConstraint - The source constraint that references the hidden node
-     * @param pairwiseDescription - A human-readable description of the dropped pairwise constraint
-     * @param sourceNodeId - The source node of the dropped relationship
-     * @param targetNodeId - The target node of the dropped relationship
+     * @param pairwiseDescription - A human-readable description of the conflicting pairwise constraint
+     * @param sourceNodeId - The source node of the conflicting relationship
+     * @param targetNodeId - The target node of the conflicting relationship
      * @param sourceHidden - Whether the source node is hidden by a directive
      * @param targetHidden - Whether the target node is hidden by a directive
      */
@@ -612,18 +606,13 @@ export class LayoutInstance {
         }
         this.hiddenNodeConflicts.get(sourceHTML)!.push(pairwiseDescription);
 
-        // Track which hidden nodes are involved in conflicts (for building hideAtom table
-        // entries), and which still-visible nodes were the other end of the dropped
-        // relationship (so the counterfactual diagram can highlight them).
+        // Track which hidden nodes are involved in conflicts, for the hideAtom table
+        // entries and for the counterfactual pass that shows them.
         if (sourceHidden) {
             this.conflictedHiddenNodes.add(sourceNodeId);
-        } else {
-            this.conflictedVisibleNodes.add(sourceNodeId);
         }
         if (targetHidden) {
             this.conflictedHiddenNodes.add(targetNodeId);
-        } else {
-            this.conflictedVisibleNodes.add(targetNodeId);
         }
     }
 
@@ -1396,9 +1385,9 @@ export class LayoutInstance {
 
                 const hideNode = hideLegacy || hideBySelector;
 
-                // A hideAtom-selected node that a layout constraint references is re-introduced
-                // (kept visible) rather than removed. The exemption set is populated on a prior
-                // pass when the hide conflicted with a constraint (see generateLayout).
+                // A hideAtom-selected node that a layout constraint references is kept for
+                // the counterfactual pass — the hide and the constraint cannot both hold, so
+                // generateLayout() reports an error and draws the atom anyway (see there).
                 if (hideBySelector && this.exemptFromHiding.has(node)) {
                     this.reintroducedNodes.add(node);
                     return; // keep the node; do not record it as hidden
@@ -1457,11 +1446,12 @@ export class LayoutInstance {
      * using `applyProjectionTransform()` from the data-instance module.
      *
      * When a hideAtom directive hides an atom that a layout constraint references, the
-     * conflict is resolved by re-introducing those atoms (showing them despite the hide)
-     * and keeping the constraints, rather than silently dropping the relationship. This is
-     * implemented as a second generation pass with the conflicting atoms exempted from
-     * hiding; the re-introduced atoms are marked on the layout and explained via the
-     * returned (informational) HiddenNodeConflictError.
+     * spec is unsatisfiable: the atom cannot be both hidden and placed. The returned
+     * error is a HiddenNodeConflictError describing the conflict, and the returned layout
+     * is a counterfactual diagram in which the conflicting atoms are shown despite the
+     * hide (marked on `layout.reintroducedNodes`; the renderer draws them with a dashed
+     * outline) so the conflicting relationships are visible. This is implemented as a
+     * second generation pass with the conflicting atoms exempted from hiding.
      *
      * @param a - The data instance to generate the layout for.
      * @returns An object containing the layout, constraint error (if any), and any selector errors encountered.
@@ -1471,22 +1461,24 @@ export class LayoutInstance {
         a: IDataInstance
     ): CounterfactualLayoutResult {
         // Fresh exemption set per public call; it is the only state that must survive the
-        // internal re-generation pass below.
+        // internal counterfactual pass below.
         this.exemptFromHiding = new Set();
 
         let result = this.generateLayoutPass(a);
 
-        // If any hidden atoms conflicted with constraints, re-introduce them and re-run.
-        const toReintroduce = [...this.conflictedHiddenNodes].filter(id => !this.exemptFromHiding.has(id));
-        if (toReintroduce.length > 0) {
+        // If any constraints referenced hidden atoms, the spec is unsatisfiable. Build the
+        // counterfactual diagram by re-running with those atoms shown, and report the error.
+        const conflicted = [...this.conflictedHiddenNodes];
+        if (conflicted.length > 0) {
             // Capture the conflict explanation before the next pass resets the tracking maps.
-            const conflictInfo = this.buildHiddenNodeConflictInfo('reintroduced');
-            toReintroduce.forEach(id => this.exemptFromHiding.add(id));
+            const conflictInfo = this.buildHiddenNodeConflictInfo();
+            conflicted.forEach(id => this.exemptFromHiding.add(id));
 
             result = this.generateLayoutPass(a);
 
-            // Mark the re-introduced atoms on the layout and attach the explanation, unless
-            // the re-run surfaced a genuine (e.g. positional) conflict that takes precedence.
+            // Mark the shown-despite-hide atoms on the layout, and attach the conflict
+            // error — unless the counterfactual pass surfaced its own (also unsatisfiable)
+            // conflict, which takes precedence.
             const reintroduced = result.layout.nodes.filter(n => this.reintroducedNodes.has(n.id));
             if (reintroduced.length > 0) {
                 result.layout.reintroducedNodes = reintroduced;
@@ -1501,8 +1493,9 @@ export class LayoutInstance {
     }
 
     /**
-     * Runs a single layout-generation pass. Honors `this.exemptFromHiding` so callers can
-     * re-introduce previously-hidden atoms. Not for direct use — call generateLayout().
+     * Runs a single layout-generation pass. Honors `this.exemptFromHiding` so the
+     * counterfactual pass can show previously-hidden atoms. Not for direct use — call
+     * generateLayout().
      */
     private generateLayoutPass(
         a: IDataInstance
@@ -1519,7 +1512,6 @@ export class LayoutInstance {
         this.hiddenNodeSelectors = new Map();
         this.hiddenNodeConflicts = new Map();
         this.conflictedHiddenNodes = new Set();
-        this.conflictedVisibleNodes = new Set();
         this.reintroducedNodes = new Set();
         this.inferredEdgeGroupStamps = new Map();
 
@@ -1692,10 +1684,22 @@ export class LayoutInstance {
             disjunctiveConstraints: allDisjunctions.length > 0 ? allDisjunctions : undefined
         };
 
-        // Check for hidden-node conflicts: constraints that were dropped because they
-        // reference nodes hidden by hideAtom directives. Report these like IIS conflicts.
+        // Constraint tuples referencing hideAtom-hidden atoms were skipped during
+        // generation, so the spec is unsatisfiable. Return this pass's layout with the
+        // conflict as the error; generateLayout() builds the real counterfactual by
+        // re-running with those atoms shown.
         if (this.hiddenNodeConflicts.size > 0) {
-            return this.handleHiddenNodeConflictError(layout);
+            const counterfactualLayout: InstanceLayout = {
+                ...layout,
+                edges: this.filterHiddenEdges(layout.edges),
+                warnings: this.warnings
+            };
+            return {
+                layout: counterfactualLayout,
+                error: this.buildHiddenNodeConflictInfo(),
+                selectorErrors: this.selectorErrors,
+                warnings: this.warnings
+            };
         }
 
         // Validate all constraints (conjunctive + disjunctive) in one pass
@@ -1777,14 +1781,12 @@ export class LayoutInstance {
 
     /**
      * Builds the structured explanation for a hideAtom-vs-constraint conflict (IIS-like
-     * table + summary message), worded for how the conflict was resolved. Reads the
+     * table + summary message). The hide and the constraint are mutually unsatisfiable —
+     * the table lists both sides, exactly like other IIS conflict reports. Reads the
      * hidden-node tracking maps populated during the conflicting pass, so it must be called
      * before those maps are reset by a subsequent pass.
-     *
-     * @param resolution - 'reintroduced' when the atoms were shown anyway (default behavior),
-     *   'dropped' when the conflicting constraints were dropped (fallback).
      */
-    private buildHiddenNodeConflictInfo(resolution: 'reintroduced' | 'dropped'): HiddenNodeConflictError {
+    private buildHiddenNodeConflictInfo(): HiddenNodeConflictError {
         // Build the IIS-like error messages map:
         //   Source Constraint HTML → list of conflicting pairwise constraint descriptions
         // Also add a synthetic entry for each hideAtom directive involved
@@ -1809,13 +1811,12 @@ export class LayoutInstance {
         // actually involved in a conflict are listed (they are tracked in
         // conflictedHiddenNodes and were recorded in hiddenNodeSelectors when hidden).
         const conflictedIds = [...this.conflictedHiddenNodes];
-        const hiddenState = resolution === 'reintroduced' ? 'hidden, but re-introduced' : 'hidden';
         for (const hideSelector of involvedHideSelectors) {
             const hideHTML = `hideAtom with selector <code>${hideSelector}</code>`;
             const hiddenNodeDescriptions: string[] = [];
             for (const nodeId of conflictedIds) {
                 if (this.hiddenNodeSelectors.get(nodeId) === hideSelector) {
-                    hiddenNodeDescriptions.push(`${nodeId} is ${hiddenState}`);
+                    hiddenNodeDescriptions.push(`${nodeId} is hidden`);
                 }
             }
             if (hiddenNodeDescriptions.length > 0) {
@@ -1833,9 +1834,7 @@ export class LayoutInstance {
             minimalConflictingConstraints: sourceConstraintHTMLToLayoutConstraintsHTML
         };
 
-        const message = resolution === 'reintroduced'
-            ? `Atoms [${conflictedIds.join(', ')}] are hidden by a hideAtom directive but referenced by layout constraints, so they have been re-introduced into the diagram.`
-            : `Constraints reference hidden nodes [${conflictedIds.join(', ')}]. These constraints have been dropped from the layout.`;
+        const message = `Layout constraints reference atoms [${conflictedIds.join(', ')}] that a hideAtom directive hides. The hide and the constraints cannot both be satisfied. The diagram shows the layout as if those atoms were not hidden; they are drawn with a dashed outline.`;
 
         return {
             name: 'HiddenNodeConflictError',
@@ -1843,40 +1842,7 @@ export class LayoutInstance {
             message,
             hiddenNodes: this.hiddenNodeSelectors,
             droppedConstraints: this.hiddenNodeConflicts,
-            errorMessages,
-            resolution
-        };
-    }
-
-    /**
-     * Handles conflicts where hideAtom directives hide nodes referenced by layout
-     * constraints. Fallback path used only when re-introduction did not resolve the
-     * conflict; drops the conflicting constraints and highlights the still-visible partners.
-     */
-    private handleHiddenNodeConflictError(
-        layout: InstanceLayout
-    ): CounterfactualLayoutResult {
-        const error = this.buildHiddenNodeConflictInfo('dropped');
-
-        // The layout already has the conflicting constraints dropped (they were skipped
-        // during generation), so it serves as the counterfactual diagram.
-        // Apply the same edge-visibility post-processing that the normal path performs.
-        // Surface the still-visible atoms that were the other end of a dropped relationship
-        // so the renderer can highlight them — the hidden atom itself is gone from the
-        // diagram, but its visible partners are the ones whose constraints were lost.
-        const hiddenConflictNodes = layout.nodes.filter(n => this.conflictedVisibleNodes.has(n.id));
-        const counterfactualLayout: InstanceLayout = {
-            ...layout,
-            edges: this.filterHiddenEdges(layout.edges),
-            warnings: this.warnings,
-            hiddenConflictNodes: hiddenConflictNodes.length > 0 ? hiddenConflictNodes : undefined
-        };
-
-        return {
-            layout: counterfactualLayout,
-            error,
-            selectorErrors: this.selectorErrors,
-            warnings: this.warnings
+            errorMessages
         };
     }
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -214,29 +214,32 @@ function removeDuplicateConstraints(constraints: LayoutConstraint[]): LayoutCons
 }
 
 /**
- * Produces a natural-language description for a dropped orientation constraint
- * involving a hidden node, matching the style of `orientationConstraintToString`.
+ * Produces a natural-language description for an orientation constraint tuple that
+ * conflicts with a hidden node. Orientation `directions` place the TARGET relative
+ * to the SOURCE (`right` on tuple (src, tgt) puts tgt to the right of src), so the
+ * description leads with the target — this must agree with what the counterfactual
+ * diagram actually draws.
  */
 function describeDroppedOrientationConstraint(sourceNodeId: string, targetNodeId: string, direction: string): string {
     switch (direction) {
         case 'left':
-            return `${sourceNodeId} must be to the left of ${targetNodeId}`;
+            return `${targetNodeId} must be to the left of ${sourceNodeId}`;
         case 'right':
-            return `${sourceNodeId} must be to the right of ${targetNodeId}`;
+            return `${targetNodeId} must be to the right of ${sourceNodeId}`;
         case 'above':
-            return `${sourceNodeId} must be above ${targetNodeId}`;
+            return `${targetNodeId} must be above ${sourceNodeId}`;
         case 'below':
-            return `${sourceNodeId} must be below ${targetNodeId}`;
+            return `${targetNodeId} must be below ${sourceNodeId}`;
         case 'directlyLeft':
-            return `${sourceNodeId} must be directly to the left of ${targetNodeId}`;
+            return `${targetNodeId} must be directly to the left of ${sourceNodeId}`;
         case 'directlyRight':
-            return `${sourceNodeId} must be directly to the right of ${targetNodeId}`;
+            return `${targetNodeId} must be directly to the right of ${sourceNodeId}`;
         case 'directlyAbove':
-            return `${sourceNodeId} must be directly above ${targetNodeId}`;
+            return `${targetNodeId} must be directly above ${sourceNodeId}`;
         case 'directlyBelow':
-            return `${sourceNodeId} must be directly below ${targetNodeId}`;
+            return `${targetNodeId} must be directly below ${sourceNodeId}`;
         default:
-            return `${sourceNodeId} is constrained relative to ${targetNodeId} (${direction})`;
+            return `${targetNodeId} is constrained relative to ${sourceNodeId} (${direction})`;
     }
 }
 
@@ -1484,8 +1487,11 @@ export class LayoutInstance {
      * error is a HiddenNodeConflictError describing the conflict, and the returned layout
      * is a counterfactual diagram in which the conflicting atoms are shown despite the
      * hide (marked on `layout.reintroducedNodes`; the renderer draws them with a dashed
-     * outline) so the conflicting relationships are visible. This is implemented as a
-     * second generation pass with the conflicting atoms exempted from hiding.
+     * outline) so the conflicting relationships are visible. This is implemented by
+     * re-running generation with the conflicting atoms exempted from hiding, repeated
+     * until a pass reports no new conflicts — showing an atom can surface conflicts an
+     * earlier, aborted pass never reached (e.g. one that stopped at a missing-node error
+     * before processing later constraints). Typically one re-run.
      *
      * @param a - The data instance to generate the layout for.
      * @returns An object containing the layout, constraint error (if any), and any selector errors encountered.
@@ -1495,32 +1501,67 @@ export class LayoutInstance {
         a: IDataInstance
     ): CounterfactualLayoutResult {
         // Fresh exemption set per public call; it is the only state that must survive the
-        // internal counterfactual pass below.
+        // internal counterfactual passes below.
         this.exemptFromHiding = new Set();
 
         let result = this.generateLayoutPass(a);
+        if (this.conflictedHiddenNodes.size === 0) {
+            return result;
+        }
 
-        // If any constraints referenced hidden atoms, the spec is unsatisfiable. Build the
-        // counterfactual diagram by re-running with those atoms shown, and report the error.
-        const conflicted = [...this.conflictedHiddenNodes];
-        if (conflicted.length > 0) {
-            // Capture the conflict explanation before the next pass resets the tracking maps.
-            const conflictInfo = this.buildHiddenNodeConflictInfo();
-            conflicted.forEach(id => this.exemptFromHiding.add(id));
+        // The spec is unsatisfiable. Accumulate the conflict explanation across passes —
+        // each pass's tracking maps are reset by the next — and re-run with the
+        // conflicting atoms shown until a pass converges. Every round strictly grows
+        // exemptFromHiding (an exempted atom is never hidden, so never re-conflicted),
+        // which bounds the loop by the number of hidden atoms; the hard cap is a
+        // defensive backstop only.
+        const allConflicts = new Map<string, string[]>();
+        const allConflictedIds = new Set<string>();
+        const allHiddenSelectors = new Map<string, string>();
+        const absorbPassConflicts = () => {
+            for (const [source, descriptions] of this.hiddenNodeConflicts) {
+                const merged = allConflicts.get(source) ?? [];
+                for (const d of descriptions) {
+                    if (!merged.includes(d)) {
+                        merged.push(d);
+                    }
+                }
+                allConflicts.set(source, merged);
+            }
+            this.conflictedHiddenNodes.forEach(id => allConflictedIds.add(id));
+            for (const [node, selector] of this.hiddenNodeSelectors) {
+                if (!allHiddenSelectors.has(node)) {
+                    allHiddenSelectors.set(node, selector);
+                }
+            }
+        };
 
+        const MAX_PASSES = 10;
+        let passes = 1;
+        while (this.conflictedHiddenNodes.size > 0 && passes < MAX_PASSES) {
+            absorbPassConflicts();
+            this.conflictedHiddenNodes.forEach(id => this.exemptFromHiding.add(id));
             result = this.generateLayoutPass(a);
+            passes++;
+        }
+        if (this.conflictedHiddenNodes.size > 0) {
+            // Unreachable if the loop invariant holds; keep the explanation whole anyway.
+            absorbPassConflicts();
+            console.warn(`Hidden-node conflict resolution did not converge after ${passes} passes.`);
+        }
 
-            // Mark the shown-despite-hide atoms on the layout, and attach the conflict
-            // error — unless the counterfactual pass surfaced its own (also unsatisfiable)
-            // conflict, which takes precedence.
-            const reintroduced = result.layout.nodes.filter(n => this.reintroducedNodes.has(n.id));
-            if (reintroduced.length > 0) {
-                result.layout.reintroducedNodes = reintroduced;
-            }
-            if (result.error === null) {
-                conflictInfo.reintroducedNodeIds = reintroduced.map(n => n.id);
-                result = { ...result, error: conflictInfo };
-            }
+        // Mark the shown-despite-hide atoms on the layout, and attach the merged conflict
+        // error. A different conflict surfaced by the final pass (e.g. positional) takes
+        // precedence, but a per-pass hidden-node error is replaced by the merged one so
+        // the explanation covers every pass.
+        const reintroduced = result.layout.nodes.filter(n => this.reintroducedNodes.has(n.id));
+        if (reintroduced.length > 0) {
+            result.layout.reintroducedNodes = reintroduced;
+        }
+        if (result.error === null || isHiddenNodeConflictError(result.error)) {
+            const conflictInfo = this.buildHiddenNodeConflictInfo(allConflicts, allConflictedIds, allHiddenSelectors);
+            conflictInfo.reintroducedNodeIds = reintroduced.map(n => n.id);
+            result = { ...result, error: conflictInfo };
         }
 
         return result;
@@ -1721,11 +1762,13 @@ export class LayoutInstance {
         // Constraint tuples referencing hideAtom-hidden atoms were skipped during
         // generation, so the spec is unsatisfiable. Return this pass's layout with the
         // conflict as the error; generateLayout() builds the real counterfactual by
-        // re-running with those atoms shown.
+        // re-running with those atoms shown. Negated groups are filtered out like the
+        // normal path does — they never draw a rectangle.
         if (this.hiddenNodeConflicts.size > 0) {
             const counterfactualLayout: InstanceLayout = {
                 ...layout,
                 edges: this.filterHiddenEdges(layout.edges),
+                groups: layout.groups.filter(gr => !gr.negated),
                 warnings: this.warnings
             };
             return {
@@ -1816,11 +1859,17 @@ export class LayoutInstance {
     /**
      * Builds the structured explanation for a hideAtom-vs-constraint conflict (IIS-like
      * table + summary message). The hide and the constraint are mutually unsatisfiable —
-     * the table lists both sides, exactly like other IIS conflict reports. Reads the
-     * hidden-node tracking maps populated during the conflicting pass, so it must be called
-     * before those maps are reset by a subsequent pass.
+     * the table lists both sides, exactly like other IIS conflict reports.
+     *
+     * Defaults to the current pass's tracking maps (they are reset by the next pass, so
+     * call before re-running); the orchestrator passes maps accumulated across passes
+     * instead, so the explanation covers conflicts an aborted earlier pass never reached.
      */
-    private buildHiddenNodeConflictInfo(): HiddenNodeConflictError {
+    private buildHiddenNodeConflictInfo(
+        conflicts: Map<string, string[]> = this.hiddenNodeConflicts,
+        conflictedNodeIds: Set<string> = this.conflictedHiddenNodes,
+        hiddenSelectors: Map<string, string> = this.hiddenNodeSelectors
+    ): HiddenNodeConflictError {
         // Build the IIS-like error messages map:
         //   Source Constraint HTML → list of conflicting pairwise constraint descriptions
         // Also add a synthetic entry for each hideAtom directive involved
@@ -1829,13 +1878,13 @@ export class LayoutInstance {
         // Collect all unique hideAtom selectors involved
         const involvedHideSelectors = new Set<string>();
 
-        for (const [sourceHTML, descriptions] of this.hiddenNodeConflicts.entries()) {
+        for (const [sourceHTML, descriptions] of conflicts.entries()) {
             sourceConstraintHTMLToLayoutConstraintsHTML.set(sourceHTML, descriptions);
         }
 
-        // Derive involved hideAtom selectors from conflictedHiddenNodes
-        for (const nodeId of this.conflictedHiddenNodes) {
-            const selector = this.hiddenNodeSelectors.get(nodeId);
+        // Derive involved hideAtom selectors from the conflicted node ids
+        for (const nodeId of conflictedNodeIds) {
+            const selector = hiddenSelectors.get(nodeId);
             if (selector) {
                 involvedHideSelectors.add(selector);
             }
@@ -1843,13 +1892,13 @@ export class LayoutInstance {
 
         // Add hideAtom directives as source constraints in the table. Only the atoms
         // actually involved in a conflict are listed (they are tracked in
-        // conflictedHiddenNodes and were recorded in hiddenNodeSelectors when hidden).
-        const conflictedIds = [...this.conflictedHiddenNodes];
+        // conflictedNodeIds and were recorded in hiddenSelectors when hidden).
+        const conflictedIds = [...conflictedNodeIds];
         for (const hideSelector of involvedHideSelectors) {
             const hideHTML = `hideAtom with selector <code>${hideSelector}</code>`;
             const hiddenNodeDescriptions: string[] = [];
             for (const nodeId of conflictedIds) {
-                if (this.hiddenNodeSelectors.get(nodeId) === hideSelector) {
+                if (hiddenSelectors.get(nodeId) === hideSelector) {
                     hiddenNodeDescriptions.push(`${nodeId} is hidden`);
                 }
             }
@@ -1859,8 +1908,8 @@ export class LayoutInstance {
         }
 
         // Build a summary message
-        const firstConflictSourceHTML = [...this.hiddenNodeConflicts.keys()][0];
-        const firstConflictDescription = this.hiddenNodeConflicts.get(firstConflictSourceHTML)?.[0] || '';
+        const firstConflictSourceHTML = [...conflicts.keys()][0];
+        const firstConflictDescription = conflicts.get(firstConflictSourceHTML)?.[0] || '';
 
         const errorMessages: ErrorMessages = {
             conflictingConstraint: firstConflictDescription,
@@ -1874,8 +1923,8 @@ export class LayoutInstance {
             name: 'HiddenNodeConflictError',
             type: 'hidden-node-conflict',
             message,
-            hiddenNodes: this.hiddenNodeSelectors,
-            droppedConstraints: this.hiddenNodeConflicts,
+            hiddenNodes: hiddenSelectors,
+            droppedConstraints: conflicts,
             errorMessages
         };
     }

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -988,20 +988,15 @@ export class WebColaCnDGraph extends HTMLElementBase {
       throw new Error(`Layout cannot have both conflictingConstraints (${conflictingNodeIds}) and overlappingNodes ${overlappingNodeIds}`);
     }
 
-    // Visible atoms whose relationship was dropped because their partner was hidden.
-    // These are mutually exclusive with the constraint/overlap conflicts above (a
-    // hidden-node conflict short-circuits before those validators run).
-    const hiddenConflictNodes = this.currentLayout.hiddenConflictNodes;
-
-    const errorNodes = [...conflictingNodes, ...overlappingNodes, ...hiddenConflictNodes];
+    const errorNodes = [...conflictingNodes, ...overlappingNodes];
 
     return errorNodes.some((errorNode: LayoutNode) => errorNode.id === node.id); // NOTE: `id` should be unique
   }
 
   /**
-   * Determines if a node was re-introduced — i.e. hidden by a hideAtom directive but shown
-   * anyway because a layout constraint references it. These are marked distinctly so the
-   * user understands why an atom they asked to hide is visible.
+   * Determines if a node is hidden-but-shown — hidden by a hideAtom directive that a layout
+   * constraint conflicts with, so the counterfactual diagram draws it anyway. These are
+   * marked distinctly (dashed outline) so the user can see which atom caused the conflict.
    * @param node - Node object to check
    * @returns True if the node is in the layout's set of re-introduced nodes
    */

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -988,9 +988,27 @@ export class WebColaCnDGraph extends HTMLElementBase {
       throw new Error(`Layout cannot have both conflictingConstraints (${conflictingNodeIds}) and overlappingNodes ${overlappingNodeIds}`);
     }
 
-    const errorNodes = [...conflictingNodes, ...overlappingNodes];
+    // Visible atoms whose relationship was dropped because their partner was hidden.
+    // These are mutually exclusive with the constraint/overlap conflicts above (a
+    // hidden-node conflict short-circuits before those validators run).
+    const hiddenConflictNodes = this.currentLayout.hiddenConflictNodes;
+
+    const errorNodes = [...conflictingNodes, ...overlappingNodes, ...hiddenConflictNodes];
 
     return errorNodes.some((errorNode: LayoutNode) => errorNode.id === node.id); // NOTE: `id` should be unique
+  }
+
+  /**
+   * Determines if a node was re-introduced — i.e. hidden by a hideAtom directive but shown
+   * anyway because a layout constraint references it. These are marked distinctly so the
+   * user understands why an atom they asked to hide is visible.
+   * @param node - Node object to check
+   * @returns True if the node is in the layout's set of re-introduced nodes
+   */
+  private isReintroducedNode(node: { id: string }): boolean {
+    const reintroduced = this.currentLayout?.reintroducedNodes;
+    if (!reintroduced || reintroduced.length === 0) return false;
+    return reintroduced.some((n: LayoutNode) => n.id === node.id);
   }
 
   /**
@@ -4031,9 +4049,12 @@ export class WebColaCnDGraph extends HTMLElementBase {
       .enter()
       .append("g")
       .attr("class", (d: any) => {
-        const baseClass = this.isErrorNode(d) ? "error-node" : "node";
+        let baseClass = this.isErrorNode(d) ? "error-node" : "node";
         if (this.isErrorNode(d) && this.isSmallNode(d)) {
-          return baseClass + " small-error-node";
+          baseClass += " small-error-node";
+        }
+        if (this.isReintroducedNode(d)) {
+          baseClass += " reintroduced-node";
         }
         return baseClass;
       })
@@ -10134,6 +10155,16 @@ export class WebColaCnDGraph extends HTMLElementBase {
         stroke-width: 2px;
         stroke-dasharray: 5 5;
         animation: dash 1s linear infinite;
+      }
+
+      /* Atoms re-introduced because a constraint references them despite a hideAtom
+         directive. Distinct from error nodes: a calmer dashed purple outline + faded
+         fill that reads as "shown because needed, but you meant to hide it". */
+      .reintroduced-node rect {
+        stroke: var(--cnd-reintroduced-stroke, #8e44ad);
+        stroke-width: 2px;
+        stroke-dasharray: 3 3;
+        fill-opacity: 0.55;
       }
 
       /* Enhanced visibility for small error nodes */

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -296,6 +296,8 @@ export class WebColaLayout {
   readonly groupDefinitions: any;
   readonly conflictingConstraints: LayoutConstraint[];
   readonly overlappingNodesData: LayoutNode[];
+  readonly hiddenConflictNodesData: LayoutNode[];
+  readonly reintroducedNodesData: LayoutNode[];
 
   private readonly DEFAULT_X: number;
   private readonly DEFAULT_Y: number;
@@ -403,6 +405,8 @@ export class WebColaLayout {
 
     this.conflictingConstraints = instanceLayout.conflictingConstraints || [];
     this.overlappingNodesData = instanceLayout.overlappingNodes || [];
+    this.hiddenConflictNodesData = instanceLayout.hiddenConflictNodes || [];
+    this.reintroducedNodesData = instanceLayout.reintroducedNodes || [];
     this.colaConstraints = instanceLayout.constraints.map(constraint => this.toColaConstraint(constraint));
 
     // Decide which constraint endpoints stay locked (fixed=1) and which
@@ -1260,6 +1264,14 @@ export class WebColaLayout {
 
   get overlappingNodes(): LayoutNode[] {
     return this.overlappingNodesData;
+  }
+
+  get hiddenConflictNodes(): LayoutNode[] {
+    return this.hiddenConflictNodesData;
+  }
+
+  get reintroducedNodes(): LayoutNode[] {
+    return this.reintroducedNodesData;
   }
 
   get overlappingGroups(): LayoutGroup[] {

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -296,7 +296,6 @@ export class WebColaLayout {
   readonly groupDefinitions: any;
   readonly conflictingConstraints: LayoutConstraint[];
   readonly overlappingNodesData: LayoutNode[];
-  readonly hiddenConflictNodesData: LayoutNode[];
   readonly reintroducedNodesData: LayoutNode[];
 
   private readonly DEFAULT_X: number;
@@ -405,7 +404,6 @@ export class WebColaLayout {
 
     this.conflictingConstraints = instanceLayout.conflictingConstraints || [];
     this.overlappingNodesData = instanceLayout.overlappingNodes || [];
-    this.hiddenConflictNodesData = instanceLayout.hiddenConflictNodes || [];
     this.reintroducedNodesData = instanceLayout.reintroducedNodes || [];
     this.colaConstraints = instanceLayout.constraints.map(constraint => this.toColaConstraint(constraint));
 
@@ -1264,10 +1262,6 @@ export class WebColaLayout {
 
   get overlappingNodes(): LayoutNode[] {
     return this.overlappingNodesData;
-  }
-
-  get hiddenConflictNodes(): LayoutNode[] {
-    return this.hiddenConflictNodesData;
   }
 
   get reintroducedNodes(): LayoutNode[] {

--- a/tests/hidden-node-conflict.test.ts
+++ b/tests/hidden-node-conflict.test.ts
@@ -218,8 +218,8 @@ directives:
     });
   });
 
-  describe('Counterfactual layout (dropped constraints)', () => {
-    it('produces a valid layout with the hidden node removed', () => {
+  describe('Counterfactual layout (re-introduced atoms)', () => {
+    it('re-introduces the hidden node into the layout rather than removing it', () => {
       const result = createLayout(`
 constraints:
   - orientation:
@@ -230,11 +230,33 @@ directives:
       selector: B
 `);
 
+      // B is referenced by the orientation constraint, so it is re-introduced (shown).
       const nodeIds = result.layout.nodes.map(n => n.id);
-      expect(nodeIds).not.toContain('B');
+      expect(nodeIds).toContain('B');
       expect(nodeIds).toContain('A');
       expect(nodeIds).toContain('C');
       expect(nodeIds).toContain('D');
+    });
+
+    it('keeps constraints that reference the re-introduced node', () => {
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+directives:
+  - hideAtom:
+      selector: B
+`);
+
+      // Constraints involving B are no longer dropped — at least one should reference B.
+      const referencesB = result.layout.constraints.some(c => {
+        if ('left' in c && 'right' in c) return c.left.id === 'B' || c.right.id === 'B';
+        if ('top' in c && 'bottom' in c) return c.top.id === 'B' || c.bottom.id === 'B';
+        if ('node1' in c && 'node2' in c) return c.node1.id === 'B' || c.node2.id === 'B';
+        return false;
+      });
+      expect(referencesB).toBe(true);
     });
 
     it('retains constraints that do not reference hidden nodes', () => {
@@ -248,10 +270,7 @@ directives:
       selector: B
 `);
 
-      // A->B and B->C produce constraints involving B, so they are dropped.
-      // C->D does NOT involve B, so it should remain.
-      expect(result.layout.constraints.length).toBeGreaterThan(0);
-      // The C->D constraint should still be present
+      // The C->D constraint (which never involved a hidden node) should still be present
       const hasCD = result.layout.constraints.some(c => {
         if ('left' in c && 'right' in c) {
           return (c.left.id === 'C' && c.right.id === 'D') || (c.left.id === 'D' && c.right.id === 'C');
@@ -260,8 +279,10 @@ directives:
       });
       expect(hasCD).toBe(true);
     });
+  });
 
-    it('drops all constraints referencing hidden nodes', () => {
+  describe('Re-introduction of conflicting hidden atoms', () => {
+    it('marks the re-introduced atom in layout.reintroducedNodes', () => {
       const result = createLayout(`
 constraints:
   - orientation:
@@ -272,21 +293,80 @@ directives:
       selector: B
 `);
 
-      // No constraint should reference B
-      for (const c of result.layout.constraints) {
-        if ('left' in c && 'right' in c) {
-          expect(c.left.id).not.toBe('B');
-          expect(c.right.id).not.toBe('B');
-        }
-        if ('top' in c && 'bottom' in c) {
-          expect(c.top.id).not.toBe('B');
-          expect(c.bottom.id).not.toBe('B');
-        }
-        if ('node1' in c && 'node2' in c) {
-          expect(c.node1.id).not.toBe('B');
-          expect(c.node2.id).not.toBe('B');
-        }
-      }
+      const ids = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(ids).toContain('B');
+      // Atoms that were never hidden should not be marked as re-introduced.
+      expect(ids).not.toContain('A');
+      expect(ids).not.toContain('D');
+    });
+
+    it('reports the resolution as "reintroduced" on the error', () => {
+      const result = createLayout(`
+constraints:
+  - align:
+      selector: edge
+      direction: horizontal
+directives:
+  - hideAtom:
+      selector: B
+`);
+
+      const error = result.error as HiddenNodeConflictError;
+      expect(error.resolution).toBe('reintroduced');
+      expect(error.reintroducedNodeIds).toContain('B');
+      expect(error.message.toLowerCase()).toContain('re-introduced');
+    });
+
+    it('produces a satisfiable layout (no further conflicts) once atoms are re-introduced', () => {
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+directives:
+  - hideAtom:
+      selector: B
+`);
+
+      // The conflict is resolved by re-introduction, not by an unsatisfiable counterfactual.
+      const error = result.error as HiddenNodeConflictError;
+      expect(error.resolution).toBe('reintroduced');
+      // All edge tuples are kept as constraints (A->B, B->C, C->D = 3 orientation constraints).
+      expect(result.layout.constraints.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('re-introduces both ends when every atom of a relationship is hidden', () => {
+      const twoNodeData = {
+        atoms: [
+          { id: 'X', type: 'Node', label: 'X' },
+          { id: 'Y', type: 'Node', label: 'Y' },
+        ],
+        relations: [
+          {
+            id: 'rel',
+            name: 'rel',
+            types: ['Node', 'Node'],
+            tuples: [{ atoms: ['X', 'Y'], types: ['Node', 'Node'] }]
+          }
+        ]
+      };
+
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: rel
+      directions: [right]
+directives:
+  - hideAtom:
+      selector: Node
+`, twoNodeData);
+
+      const nodeIds = result.layout.nodes.map(n => n.id);
+      expect(nodeIds).toContain('X');
+      expect(nodeIds).toContain('Y');
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toContain('X');
+      expect(reintroduced).toContain('Y');
     });
   });
 
@@ -308,16 +388,19 @@ directives:
       expect(result.error!.type).toBe('hidden-node-conflict');
 
       const error = result.error as HiddenNodeConflictError;
-      // Both B and C should be reported as hidden
+      // Both B and C should be reported as re-introduced
       expect(error.message).toContain('B');
       expect(error.message).toContain('C');
 
-      // Layout should not contain B or C
+      // Layout should re-introduce both B and C
       const nodeIds = result.layout.nodes.map(n => n.id);
-      expect(nodeIds).not.toContain('B');
-      expect(nodeIds).not.toContain('C');
+      expect(nodeIds).toContain('B');
+      expect(nodeIds).toContain('C');
       expect(nodeIds).toContain('A');
       expect(nodeIds).toContain('D');
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toContain('B');
+      expect(reintroduced).toContain('C');
     });
 
     it('handles hidden node referenced by both orientation and alignment constraints', () => {
@@ -380,10 +463,9 @@ directives:
       expect(result.error).not.toBeNull();
       expect(result.error!.type).toBe('hidden-node-conflict');
 
-      // All constraints should be dropped
-      expect(result.layout.constraints.length).toBe(0);
-      // No nodes should remain
-      expect(result.layout.nodes.length).toBe(0);
+      // Both atoms are re-introduced and the constraint is kept (rather than everything dropped).
+      expect(result.layout.nodes.length).toBe(2);
+      expect(result.layout.constraints.length).toBeGreaterThan(0);
     });
 
     it('produces valid layout when constraint and hide have disjoint selectors', () => {

--- a/tests/hidden-node-conflict.test.ts
+++ b/tests/hidden-node-conflict.test.ts
@@ -437,6 +437,75 @@ directives:
     });
   });
 
+  describe('Group constraints', () => {
+    // group over `edge` (binary selector): key = tuple[0], member = tuple[1]
+    // → bucket[A] contains B, bucket[B] contains C, bucket[C] contains D.
+
+    it('reports a hidden-node conflict when a hidden atom is a group member', () => {
+      const result = createLayout(`
+constraints:
+  - group:
+      selector: edge
+      name: bucket
+directives:
+  - hideAtom:
+      selector: D
+`);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+
+      // The counterfactual shows D inside its group despite the hide.
+      const nodeIds = result.layout.nodes.map(n => n.id);
+      expect(nodeIds).toContain('D');
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toContain('D');
+      expect(result.layout.groups.some(gr => gr.nodeIds.includes('D'))).toBe(true);
+    });
+
+    it('does NOT report a conflict when the hidden atom is only a group key', () => {
+      // Hiding a binary group's key while keeping the group is a sanctioned
+      // pattern (the key is not inside the hull; see inferred-edge draw tests).
+      const result = createLayout(`
+constraints:
+  - group:
+      selector: edge
+      name: bucket
+directives:
+  - hideAtom:
+      selector: A
+`);
+
+      // A is only ever a key (bucket[A]), never a member: no conflict, A stays hidden.
+      expect(result.error).toBeNull();
+      const nodeIds = result.layout.nodes.map(n => n.id);
+      expect(nodeIds).not.toContain('A');
+      // The group A keyed still exists, containing its member B.
+      expect(result.layout.groups.some(gr => gr.nodeIds.includes('B'))).toBe(true);
+    });
+
+    it('produces no error when the hidden atom is in no group', () => {
+      const dataWithExtra = {
+        ...testData,
+        atoms: [...testData.atoms, { id: 'E', type: 'Other', label: 'E' }]
+      };
+
+      const result = createLayout(`
+constraints:
+  - group:
+      selector: edge
+      name: bucket
+directives:
+  - hideAtom:
+      selector: Other
+`, dataWithExtra);
+
+      expect(result.error).toBeNull();
+      const nodeIds = result.layout.nodes.map(n => n.id);
+      expect(nodeIds).not.toContain('E');
+    });
+  });
+
   describe('Multiple hidden nodes and constraints', () => {
     it('handles multiple hidden nodes referenced by the same constraint', () => {
       const result = createLayout(`

--- a/tests/hidden-node-conflict.test.ts
+++ b/tests/hidden-node-conflict.test.ts
@@ -81,7 +81,7 @@ directives:
       expect(isHiddenNodeConflictError(result.error)).toBe(true);
     });
 
-    it('returns no error when hidden nodes are not referenced by any constraint', () => {
+    it('reports a conflict when the hidden atom appears only as a tuple target', () => {
       const result = createLayout(`
 constraints:
   - orientation:
@@ -92,13 +92,32 @@ directives:
       selector: D
 `);
 
-      // D is only referenced by C->D, and D is hidden.
-      // C->D tuple will be skipped, A->B and B->C are valid.
-      // This produces a conflict because D is referenced in edge tuples.
-      // Wait — D is in the tuple (C, D), so the orientation constraint
-      // DOES reference D as targetNodeId. So there IS a conflict.
+      // D appears only as the target of the (C, D) tuple — target references
+      // conflict just like source references do.
       expect(result.error).not.toBeNull();
       expect(result.error!.type).toBe('hidden-node-conflict');
+    });
+
+    it('returns no error when the hidden atom is not referenced by any constraint', () => {
+      const dataWithExtra = {
+        ...testData,
+        atoms: [...testData.atoms, { id: 'E', type: 'Isolated', label: 'E' }]
+      };
+
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+directives:
+  - hideAtom:
+      selector: Isolated
+`, dataWithExtra);
+
+      // E is in no edge tuple, so the hide simply applies.
+      expect(result.error).toBeNull();
+      expect(result.layout.nodes.map(n => n.id)).not.toContain('E');
+      expect(result.layout.reintroducedNodes).toBeUndefined();
     });
 
     it('returns no error when no hideAtom directive is present', () => {
@@ -890,6 +909,138 @@ directives:
       const warnings = result.layout.warnings ?? [];
       expect(warnings.length).toBeGreaterThan(0);
       expect(result.warnings?.length).toBe(warnings.length);
+    });
+  });
+
+  describe('Overlapping hides and shared members', () => {
+    it('handles the same atom hidden by two hideAtom directives', () => {
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+directives:
+  - hideAtom:
+      selector: B
+  - hideAtom:
+      selector: A + B
+`);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+
+      // B is marked exactly once no matter how many selectors hid it.
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced.filter(id => id === 'B')).toEqual(['B']);
+
+      // The table attributes B to the first matching selector.
+      const error = result.error as HiddenNodeConflictError;
+      const entries = [...error.errorMessages.minimalConflictingConstraints.entries()];
+      const hideRows = entries.filter(([key]) => key.includes('hideAtom'));
+      expect(hideRows.some(([, descs]) => descs.includes('B is hidden'))).toBe(true);
+    });
+
+    it('reintroduces a member shared by two keyed groups into both groups', () => {
+      const sharedData = {
+        atoms: [
+          { id: 'A', type: 'Node', label: 'A' },
+          { id: 'B', type: 'Node', label: 'B' },
+          { id: 'C', type: 'Node', label: 'C' },
+        ],
+        relations: [
+          {
+            id: 'edge',
+            name: 'edge',
+            types: ['Node', 'Node'],
+            tuples: [
+              { atoms: ['A', 'C'], types: ['Node', 'Node'] },
+              { atoms: ['B', 'C'], types: ['Node', 'Node'] },
+            ]
+          }
+        ]
+      };
+
+      const result = createLayout(`
+constraints:
+  - group:
+      selector: edge
+      name: bucket
+directives:
+  - hideAtom:
+      selector: C
+`, sharedData);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toEqual(['C']);
+      // C is a member of both bucket[A] and bucket[B] in the counterfactual.
+      const groupsWithC = result.layout.groups.filter(gr => gr.nodeIds.includes('C'));
+      expect(groupsWithC.length).toBe(2);
+    });
+  });
+
+  describe('Multi-pass convergence (conflicts revealed by re-introduction)', () => {
+    it('accumulates conflicts across passes when an aborted first pass hid some of them', () => {
+      // Pass 1: hiding B disconnects M, which hideDisconnected then legacy-hides.
+      // The r1.r2 orientation references the missing M and aborts constraint
+      // generation before the r3 constraint is processed — so Y's conflict is
+      // invisible in pass 1. Re-introducing B reconnects M; the next pass reaches
+      // r3, finds Y hidden, and the orchestrator must fold that new conflict in.
+      const chainData = {
+        atoms: [
+          { id: 'A', type: 'Node', label: 'A' },
+          { id: 'B', type: 'Node', label: 'B' },
+          { id: 'M', type: 'Node', label: 'M' },
+          { id: 'P', type: 'Node', label: 'P' },
+          { id: 'Y', type: 'Node', label: 'Y' },
+        ],
+        relations: [
+          { id: 'r1', name: 'r1', types: ['Node', 'Node'], tuples: [{ atoms: ['A', 'B'], types: ['Node', 'Node'] }] },
+          { id: 'r2', name: 'r2', types: ['Node', 'Node'], tuples: [{ atoms: ['B', 'M'], types: ['Node', 'Node'] }] },
+          { id: 'r3', name: 'r3', types: ['Node', 'Node'], tuples: [{ atoms: ['P', 'Y'], types: ['Node', 'Node'] }] },
+        ]
+      };
+
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: r1
+      directions: [right]
+  - orientation:
+      selector: r1.r2
+      directions: [right]
+  - orientation:
+      selector: r3
+      directions: [right]
+directives:
+  - hideAtom:
+      selector: B
+  - hideAtom:
+      selector: Y
+  - flag: hideDisconnected
+`, chainData);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+
+      // The merged explanation names both conflicting atoms...
+      expect(result.error!.message).toContain('B');
+      expect(result.error!.message).toContain('Y');
+
+      // ...and the counterfactual shows everything the error talks about.
+      const nodeIds = result.layout.nodes.map(n => n.id);
+      expect(nodeIds).toEqual(expect.arrayContaining(['A', 'B', 'M', 'P', 'Y']));
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id).sort();
+      expect(reintroduced).toEqual(['B', 'Y']);
+      const error = result.error as HiddenNodeConflictError;
+      expect((error.reintroducedNodeIds ?? []).slice().sort()).toEqual(['B', 'Y']);
+
+      // The IIS table covers conflicts from both passes.
+      const sourceKeys = [...error.errorMessages.minimalConflictingConstraints.keys()];
+      expect(sourceKeys.some(k => k.includes('r1') && !k.includes('r1.r2'))).toBe(true);
+      expect(sourceKeys.some(k => k.includes('r3'))).toBe(true);
     });
   });
 

--- a/tests/hidden-node-conflict.test.ts
+++ b/tests/hidden-node-conflict.test.ts
@@ -1,11 +1,14 @@
 /**
  * Tests for hidden-node conflict detection and reporting.
- * 
+ *
  * When a hideAtom directive hides a node that is also referenced by a layout constraint
- * (orientation or alignment), the system should:
- * 1. Report the conflict in an IIS-like table format (Source Constraints | Diagram Elements)
- * 2. Drop the conflicting pairwise constraints from the layout (counterfactual)
- * 3. Still produce a valid layout with the remaining constraints
+ * (orientation or alignment), the spec is unsatisfiable — the atom cannot be both hidden
+ * and placed. The system should:
+ * 1. Report the conflict as an error, in an IIS-like table format
+ *    (Source Constraints | Diagram Elements)
+ * 2. Return a counterfactual layout in which the conflicting hidden atoms are shown
+ *    despite the hide (marked on layout.reintroducedNodes; drawn with a dashed outline)
+ *    so the conflicting relationships are visible
  */
 
 import { describe, it, expect } from 'vitest';
@@ -218,8 +221,8 @@ directives:
     });
   });
 
-  describe('Counterfactual layout (re-introduced atoms)', () => {
-    it('re-introduces the hidden node into the layout rather than removing it', () => {
+  describe('Counterfactual layout (hidden atoms shown)', () => {
+    it('shows the hidden node in the counterfactual rather than removing it', () => {
       const result = createLayout(`
 constraints:
   - orientation:
@@ -281,8 +284,8 @@ directives:
     });
   });
 
-  describe('Re-introduction of conflicting hidden atoms', () => {
-    it('marks the re-introduced atom in layout.reintroducedNodes', () => {
+  describe('Marking of conflicting hidden atoms', () => {
+    it('marks the shown-despite-hide atom in layout.reintroducedNodes', () => {
       const result = createLayout(`
 constraints:
   - orientation:
@@ -300,7 +303,7 @@ directives:
       expect(ids).not.toContain('D');
     });
 
-    it('reports the resolution as "reintroduced" on the error', () => {
+    it('reports the shown atoms and the unsatisfiability on the error', () => {
       const result = createLayout(`
 constraints:
   - align:
@@ -312,12 +315,11 @@ directives:
 `);
 
       const error = result.error as HiddenNodeConflictError;
-      expect(error.resolution).toBe('reintroduced');
       expect(error.reintroducedNodeIds).toContain('B');
-      expect(error.message.toLowerCase()).toContain('re-introduced');
+      expect(error.message).toContain('cannot both be satisfied');
     });
 
-    it('produces a satisfiable layout (no further conflicts) once atoms are re-introduced', () => {
+    it('keeps all constraints in the counterfactual (nothing is silently dropped)', () => {
       const result = createLayout(`
 constraints:
   - orientation:
@@ -328,14 +330,13 @@ directives:
       selector: B
 `);
 
-      // The conflict is resolved by re-introduction, not by an unsatisfiable counterfactual.
-      const error = result.error as HiddenNodeConflictError;
-      expect(error.resolution).toBe('reintroduced');
+      // The error stands, but the counterfactual keeps every constraint.
+      expect(result.error).not.toBeNull();
       // All edge tuples are kept as constraints (A->B, B->C, C->D = 3 orientation constraints).
       expect(result.layout.constraints.length).toBeGreaterThanOrEqual(3);
     });
 
-    it('re-introduces both ends when every atom of a relationship is hidden', () => {
+    it('shows both ends when every atom of a relationship is hidden', () => {
       const twoNodeData = {
         atoms: [
           { id: 'X', type: 'Node', label: 'X' },

--- a/tests/hidden-node-conflict.test.ts
+++ b/tests/hidden-node-conflict.test.ts
@@ -676,6 +676,223 @@ directives:
     });
   });
 
+  describe('Counterfactual shows the conflicting relationships', () => {
+    it('draws the edges of the shown-despite-hide atom', () => {
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+directives:
+  - hideAtom:
+      selector: B
+`);
+
+      // The whole point of the counterfactual: the relationships that made the
+      // hide unsatisfiable are visible. B touches A->B and B->C.
+      const touchingB = result.layout.edges.filter(
+        e => e.source.id === 'B' || e.target.id === 'B'
+      );
+      expect(touchingB.length).toBeGreaterThanOrEqual(2);
+      expect(touchingB.some(e => e.source.id === 'A' && e.target.id === 'B')).toBe(true);
+      expect(touchingB.some(e => e.source.id === 'B' && e.target.id === 'C')).toBe(true);
+    });
+
+    it('leaves reintroducedNodes unset when there is no conflict', () => {
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+directives: []
+`);
+
+      expect(result.error).toBeNull();
+      expect(result.layout.reintroducedNodes).toBeUndefined();
+    });
+  });
+
+  describe('Error-slot precedence', () => {
+    it('a genuine positional conflict in the counterfactual takes precedence, but the atoms stay marked', () => {
+      // right AND left on every edge tuple is contradictory regardless of the hide;
+      // the counterfactual pass surfaces that as the (also unsat) primary error.
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+  - orientation:
+      selector: edge
+      directions: [left]
+directives:
+  - hideAtom:
+      selector: B
+`);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('positional-conflict');
+
+      // The hide conflict is still visible on the layout itself.
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toContain('B');
+    });
+  });
+
+  describe('Negated constraints', () => {
+    it('a negated orientation referencing a hidden atom is still a conflict', () => {
+      // The tuple-level check runs before negation handling: NOT(A right of B)
+      // still places B, so it cannot hold with B hidden.
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+      hold: never
+directives:
+  - hideAtom:
+      selector: B
+`);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toContain('B');
+    });
+
+    it('a negated cyclic constraint referencing a hidden atom is still a conflict', () => {
+      const ringData = {
+        atoms: [
+          { id: 'X', type: 'Node', label: 'X' },
+          { id: 'Y', type: 'Node', label: 'Y' },
+          { id: 'Z', type: 'Node', label: 'Z' },
+        ],
+        relations: [
+          {
+            id: 'next',
+            name: 'next',
+            types: ['Node', 'Node'],
+            tuples: [
+              { atoms: ['X', 'Y'], types: ['Node', 'Node'] },
+              { atoms: ['Y', 'Z'], types: ['Node', 'Node'] },
+              { atoms: ['Z', 'X'], types: ['Node', 'Node'] },
+            ]
+          }
+        ]
+      };
+
+      const result = createLayout(`
+constraints:
+  - cyclic:
+      selector: next
+      direction: clockwise
+      hold: never
+directives:
+  - hideAtom:
+      selector: Y
+`, ringData);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toContain('Y');
+    });
+
+    it('a hidden member of a negated group is NOT a conflict', () => {
+      // A negated group asserts non-containment; hiding a member does not
+      // contradict it, so the hide simply applies.
+      const result = createLayout(`
+constraints:
+  - group:
+      selector: edge
+      name: bucket
+      hold: never
+directives:
+  - hideAtom:
+      selector: D
+`);
+
+      expect(result.error?.type).not.toBe('hidden-node-conflict');
+      const nodeIds = result.layout.nodes.map(n => n.id);
+      expect(nodeIds).not.toContain('D');
+      expect(result.layout.reintroducedNodes).toBeUndefined();
+    });
+  });
+
+  describe('Unary group selectors', () => {
+    it('reports a conflict when a hidden atom is a member of a unary group', () => {
+      // Unary selector: every Node atom is a member (there is no separate key).
+      const result = createLayout(`
+constraints:
+  - group:
+      selector: Node
+      name: blob
+directives:
+  - hideAtom:
+      selector: B
+`);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toContain('B');
+      expect(result.layout.groups.some(gr => gr.nodeIds.includes('B'))).toBe(true);
+    });
+  });
+
+  describe('Interactions across constraint families', () => {
+    it('lists every conflicting source when one hidden atom is referenced by a constraint and a group', () => {
+      const result = createLayout(`
+constraints:
+  - orientation:
+      selector: edge
+      directions: [right]
+  - group:
+      selector: edge
+      name: bucket
+directives:
+  - hideAtom:
+      selector: D
+`);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+
+      const error = result.error as HiddenNodeConflictError;
+      const sourceKeys = [...error.errorMessages.minimalConflictingConstraints.keys()];
+      expect(sourceKeys.some(k => k.includes('OrientationConstraint'))).toBe(true);
+      expect(sourceKeys.some(k => k.includes('GroupBySelector'))).toBe(true);
+      expect(sourceKeys.some(k => k.includes('hideAtom'))).toBe(true);
+
+      // D is marked exactly once despite conflicting with two sources.
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toEqual(['D']);
+      expect(error.reintroducedNodeIds).toEqual(['D']);
+    });
+
+    it('carries spec warnings on the counterfactual result (the second pass does not lose them)', () => {
+      // The deprecated group-by-field form raises a parse warning AND builds a
+      // group whose hidden member conflicts — both must survive the re-run.
+      const result = createLayout(`
+constraints:
+  - group:
+      field: edge
+      groupOn: 0
+      addToGroup: 1
+directives:
+  - hideAtom:
+      selector: D
+`);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+
+      const warnings = result.layout.warnings ?? [];
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(result.warnings?.length).toBe(warnings.length);
+    });
+  });
+
   describe('isHiddenNodeConflictError type guard', () => {
     it('returns true for hidden-node-conflict errors', () => {
       const result = createLayout(`

--- a/tests/hidden-node-conflict.test.ts
+++ b/tests/hidden-node-conflict.test.ts
@@ -371,6 +371,72 @@ directives:
     });
   });
 
+  describe('Cyclic constraints', () => {
+    const ringData = {
+      atoms: [
+        { id: 'X', type: 'Node', label: 'X' },
+        { id: 'Y', type: 'Node', label: 'Y' },
+        { id: 'Z', type: 'Node', label: 'Z' },
+      ],
+      relations: [
+        {
+          id: 'next',
+          name: 'next',
+          types: ['Node', 'Node'],
+          tuples: [
+            { atoms: ['X', 'Y'], types: ['Node', 'Node'] },
+            { atoms: ['Y', 'Z'], types: ['Node', 'Node'] },
+            { atoms: ['Z', 'X'], types: ['Node', 'Node'] },
+          ]
+        }
+      ]
+    };
+
+    it('reports a hidden-node conflict when a cyclic constraint references a hidden atom', () => {
+      const result = createLayout(`
+constraints:
+  - cyclic:
+      selector: next
+      direction: clockwise
+directives:
+  - hideAtom:
+      selector: Y
+`, ringData);
+
+      expect(result.error).not.toBeNull();
+      expect(result.error!.type).toBe('hidden-node-conflict');
+
+      // The counterfactual shows Y on the cycle despite the hide.
+      const nodeIds = result.layout.nodes.map(n => n.id);
+      expect(nodeIds).toContain('Y');
+      const reintroduced = (result.layout.reintroducedNodes ?? []).map(n => n.id);
+      expect(reintroduced).toContain('Y');
+      expect(reintroduced).not.toContain('X');
+      expect(reintroduced).not.toContain('Z');
+    });
+
+    it('produces no error when the hidden atom is not on the cycle', () => {
+      const dataWithExtra = {
+        ...ringData,
+        atoms: [...ringData.atoms, { id: 'W', type: 'Other', label: 'W' }]
+      };
+
+      const result = createLayout(`
+constraints:
+  - cyclic:
+      selector: next
+      direction: clockwise
+directives:
+  - hideAtom:
+      selector: Other
+`, dataWithExtra);
+
+      expect(result.error).toBeNull();
+      const nodeIds = result.layout.nodes.map(n => n.id);
+      expect(nodeIds).not.toContain('W');
+    });
+  });
+
   describe('Multiple hidden nodes and constraints', () => {
     it('handles multiple hidden nodes referenced by the same constraint', () => {
       const result = createLayout(`

--- a/tests/hide-atom-directive.test.ts
+++ b/tests/hide-atom-directive.test.ts
@@ -149,7 +149,7 @@ directives:
     }).not.toThrow();
   });
 
-  it('surfaces constraints that reference hidden atoms as hidden-node-conflict errors', () => {
+  it('re-introduces hidden atoms that a constraint references (hidden-node-conflict)', () => {
     const layoutSpecYaml = `
 constraints:
   - orientation:
@@ -172,7 +172,10 @@ directives:
     expect(error?.type).toBe('hidden-node-conflict');
     expect(error?.message).toContain('B');
 
+    // B is referenced by the orientation constraint, so it is re-introduced rather than hidden.
     const nodeIds = layout.nodes.map(node => node.id);
-    expect(nodeIds).not.toContain('B');
+    expect(nodeIds).toContain('B');
+    const reintroduced = (layout.reintroducedNodes ?? []).map(n => n.id);
+    expect(reintroduced).toContain('B');
   });
 });


### PR DESCRIPTION
## What & why

When a `hideAtom` directive hides an atom that a layout constraint references, the spec is **genuinely unsatisfiable**: the atom cannot be both hidden and placed. Previously the counterfactual dropped the constraint and left the atom gone — the diagram gave no cue about the affected relationship.

This PR treats the conflict as a **true unsat error**, and makes the counterfactual diagram useful: it shows what the layout would look like **if the hide were ignored**. The conflicting atoms are drawn despite the hide — outlined with a dashed border — so the user can see exactly which atom and which relationship caused the conflict.

Detection covers every constraint family that references atoms: **orientation, align, cyclic, and group membership**.

## Screenshots

Each diagram below is the counterfactual returned alongside the `HiddenNodeConflictError` (rendered in `webcola-demo/json-demo.html`). The dashed purple atom is the one a `hideAtom` directive hides.

### Orientation — `hideAtom: B` vs `orientation: right` on `A→B→C→D`

The hide would silently break `A→B` and `B→C`; instead the layout errors and the counterfactual draws B dashed with both relationships visible.

<img src="https://raw.githubusercontent.com/sidprasad/spytial-core/pr-479-assets/orientation-conflict.png" width="620" alt="Chain A to D with B outlined in a dashed purple border">

### Group — `hideAtom: D` vs `group` over `edge`

D is a member of `bucket[C]`; a group cannot be drawn containing a hidden atom. The counterfactual shows D dashed **inside its group**.

<img src="https://raw.githubusercontent.com/sidprasad/spytial-core/pr-479-assets/group-conflict.png" width="300" alt="Groups bucket[A], bucket[B], bucket[C] with member D outlined in a dashed purple border inside bucket[C]">

### Cyclic — `hideAtom: Y` vs `cyclic: clockwise` on ring `X→Y→Z→X`

Cyclic constraints decompose into pairwise positional constraints internally, so they get the same tuple-level check. Y is drawn dashed, on the cycle.

<img src="https://raw.githubusercontent.com/sidprasad/spytial-core/pr-479-assets/cyclic-conflict.png" width="560" alt="Ring X, Y, Z with Y outlined in a dashed purple border">

The error panel reports the conflict in the same IIS-like table as other unsat layouts — for the cyclic example above:

| Source Constraints | Diagram Elements |
| --- | --- |
| Cyclic constraint with direction [clockwise] and selector `next` | X is followed by Y in a clockwise cycle<br>Y is followed by Z in a clockwise cycle |
| hideAtom with selector `Y` | Y is hidden |

*(Screenshots live on the orphan branch `pr-479-assets`; keep that branch — the image URLs above point at it and break if it is deleted.)*

## How it works

- `generateLayout()` is split into a thin public **orchestrator** + a private **`generateLayoutPass()`**. On a hidden-node conflict it re-runs the pass with the conflicting atoms *exempted from hiding* to build the counterfactual, reusing the entire pipeline (groups → constraints → validation). It re-runs **until a pass reports no new conflicts**, accumulating the explanation across passes — showing an atom can surface conflicts an aborted earlier pass never reached (e.g. one that stopped at a missing-node error before later constraints). Typically one re-run; the loop is bounded because the exemption set grows strictly each round. **Zero overhead on the common path** (no conflict → no second pass).
- The conflict error is attached to the result even though the counterfactual pass itself succeeds — the spec as written is unsat; the returned layout is the counterfactual. If the counterfactual pass surfaces its own conflict (e.g. positional), that error takes precedence — either way the result is an error, and the atoms stay marked on the layout.
- **Detection sites:** orientation/align/cyclic record conflicts at their tuple loops (`recordHiddenNodeConflict`); group membership is checked in `ensureNoExtraNodes` at hide time against the already-generated groups (`recordHiddenGroupMemberConflict`), since groups are built before hiding.
- **Deliberate exemptions:** a binary group's **key** is not inside the hull — hiding keys while keeping the group is a sanctioned pattern (inferred-edge `draw` anchors group ends on members; see `inferred-edge-draw.test.ts`). **Negated groups** assert non-containment, so a hidden member does not contradict them.
- Shown-despite-hide atoms flow through `InstanceLayout.reintroducedNodes` → the WebCola translator → a `reintroduced-node` CSS class (dashed `#8e44ad` stroke, faded fill), mirroring the `conflictingNodes`/`overlappingNodes` pattern. `HiddenNodeConflictError` carries `reintroducedNodeIds`.

## Testing

- `tests/hidden-node-conflict.test.ts` (43 tests) covers: error semantics per constraint family (orientation, align, cyclic, group — binary and unary selectors), the IIS table structure, counterfactual contents (atom present, its edges drawn, all constraints kept, `reintroducedNodes` marking), error-slot precedence when the counterfactual pass hits a genuine positional conflict, negated-constraint boundaries (negated orientation/cyclic still conflict; negated group members do not; group keys do not), multi-source conflicts listing every source, spec warnings surviving the re-run, overlapping hideAtom selectors, a member shared by two keyed groups, and a **multi-pass convergence regression** (a conflict only reachable after the first re-introduction is folded into the same error).
- **Full suite green: 146 files / 2094 tests** (excluding Z3/oracle suites per project gates); typecheck at the 73-error pre-existing baseline; `build:all` clean (16/16).
- Verified end-to-end in the JSON demo (screenshots above): dashed rendering confirmed via shadow-DOM computed styles (stroke `#8e44ad`, `stroke-dasharray: 3 3`, `fill-opacity: 0.55`).
- An adversarial review pass ran over the branch; its findings (multi-pass conflict accumulation, orientation descriptions phrased opposite to what the diagram draws, a self-contradicting test title, undocumented semantics) are fixed in `8b794e4`, including doc updates to `docs/YAML_SPECIFICATION.md`, `site/constraints.md`, and `site/directives.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

