### PR TITLE
fix(spec-editor): selector text invisible in builder view (opaque textarea hid highlight mirror)

### DIFF
--- a/src/spec-editor/ui/spec-editor.css
+++ b/src/spec-editor/ui/spec-editor.css
@@ -317,6 +317,12 @@
 .spytial-ed-selector-input-wrap {
   position: relative;
   width: 100%;
+  /* The field's surface fill lives HERE (behind the highlight mirror), not on
+     the textarea: the textarea sits on top with a transparent background so the
+     mirror's syntax-highlighted text shows through. An opaque textarea would
+     paint over the mirror and the field would look empty (all-surface). */
+  background: var(--spytial-ed-surface, #faf8f2);
+  border-radius: var(--spytial-ed-radius-sm, 2px);
 }
 
 /*
@@ -389,7 +395,9 @@
   min-height: 2.2em;
   resize: none;
   overflow: hidden; /* height is driven by JS auto-grow */
-  background: var(--spytial-ed-surface, #faf8f2);
+  /* transparent so the highlight mirror behind shows through; the field fill is
+     on `.spytial-ed-selector-input-wrap` (matches the code-view overlay). */
+  background: transparent;
   border-color: var(--spytial-ed-border, #d9d2c0);
   color: transparent;
   caret-color: var(--spytial-ed-accent, #b5431a);
@@ -419,8 +427,13 @@
 }
 
 .spytial-ed-selector-textarea:disabled {
-  background: var(--spytial-ed-surface-raised, #f1ecdf);
   cursor: not-allowed;
+}
+
+/* Disabled fill goes on the wrapper (the textarea is transparent), so the
+   highlight mirror stays visible. Mirrors the code view's :has pattern. */
+.spytial-ed-selector-input-wrap:has(.spytial-ed-selector-textarea:disabled) {
+  background: var(--spytial-ed-surface-raised, #f1ecdf);
 }
 
 /* highlighting disabled (escape hatch): the textarea shows its own text */


### PR DESCRIPTION
## What

In the structured editor's **BUILDER** view, the **selector field** rendered as an empty/blank box — text typed into it was invisible ("all white" in the light preset, blank-dark in the dark preset).

This fixes that: selector text now renders with syntax highlighting on the field's surface fill.

| Before | After |
| --- | --- |
| Field looks empty; typed selector is hidden | Selector text (e.g. `Near0.animals`) visible & highlighted |

## Why

The selector field uses a mirror-overlay: a transparent-text `<textarea>` (`z-index: 1`) sits over a `<div>` mirror (`z-index: 0`) that paints the syntax-highlighted text. The textarea was given an **opaque** `background: var(--spytial-ed-surface)`, so its own fill painted directly over the mirror and hid everything typed. Because the cover color is the surface, it read as "all white" in the light preset.

The sibling **CODE/YAML** view was unaffected because its textarea is correctly `background: transparent` — the selector field simply didn't get the same treatment. Introduced in the ground-up rebuild (#478).

## The fix

In `src/spec-editor/ui/spec-editor.css`, bringing the selector field in line with the code-view overlay pattern:

- selector textarea → `background: transparent` (so the mirror shows through)
- field surface fill → moved to the wrapper `.spytial-ed-selector-input-wrap`
- disabled fill → routed to the wrapper via `:has()` (same pattern the code view already uses)

## Testing

Verified live against a freshly rebuilt bundle in the spec-editor demo: selector text now renders correctly in **both** the light and dark presets, and the field still looks like a filled input box. CODE view and the disabled state are unaffected.

> Surfaced from the copeanddrag app (consuming `spytial-core@2.9.0`); the integration there is correct — the bug is in spytial-core. Consumers pick this up on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)