### PR TITLE
Rework symmetric-edge editing and endpoint handles in structured-input-graph

### DIFF
--- a/src/translators/webcola/structured-input-graph.ts
+++ b/src/translators/webcola/structured-input-graph.ts
@@ -19,7 +19,9 @@ import { ConstraintError } from '../../layout/constraint-validator';
  * - Full CnD pipeline integration (data instance, evaluator, layout instance)
  * - Constraint enforcement on data changes
  * - Data export using the data instance's reify() method (supports JSON, Pyret, Alloy, etc.)
- * - Enhanced edge endpoint markers (amber square for source, red triangle for target)
+ * - Draggable edge endpoint handles in input mode: hollow ring at the source,
+ *   filled diamond at the target (both diamonds for symmetric edges), tinted to
+ *   the edge color
  * 
  * Attributes:
  * - cnd-spec: CnD specification string (YAML/JSON)
@@ -1079,6 +1081,16 @@ export class StructuredInputGraph extends WebColaCnDGraph {
    */
   setDataInstance(instance: IInputDataInstance): void {
     this.dataInstance = instance;
+  }
+
+  /**
+   * De-collapse symmetric edges in the editable graph: a relation backed by
+   * both (a,b) and (b,a) renders as two independent arrows — each mapping 1:1
+   * to a tuple — so delete/reconnect act on exactly one direction instead of an
+   * ambiguous collapsed edge. The read-only base keeps the tidy double-header.
+   */
+  protected shouldCollapseSymmetricEdges(): boolean {
+    return false;
   }
 
 

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -1911,6 +1911,16 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   }
 
   /**
+   * Whether opposite-direction tuples with the same label collapse into one
+   * double-headed edge. True for the read-only base; the editable
+   * StructuredInputGraph overrides this to false so each direction stays an
+   * independent, individually-editable arrow.
+   */
+  protected shouldCollapseSymmetricEdges(): boolean {
+    return true;
+  }
+
+  /**
    * Re-render the graph with current layout data.
    *
    * Applies current node positions immediately without restarting the
@@ -2160,9 +2170,13 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     // Build the options the translator will see.
     // lockUnconstrainedNodes is gated on useReducedIterations so that only
     // stability-mode layouts lock nodes; morph transitions keep nodes free.
-    const translatorOptions: WebColaLayoutOptions | undefined = hasPriorPositions
-      ? { priorPositions: resolvedState, lockUnconstrainedNodes: useReducedIterations }
-      : undefined;
+    const translatorOptions: WebColaLayoutOptions = hasPriorPositions
+      ? {
+          priorPositions: resolvedState,
+          lockUnconstrainedNodes: useReducedIterations,
+          collapseSymmetricEdges: this.shouldCollapseSymmetricEdges()
+        }
+      : { collapseSymmetricEdges: this.shouldCollapseSymmetricEdges() };
 
     this.applyViewportRenderPolicy(hasPriorPositions, hasPriorTransform);
     
@@ -3299,43 +3313,82 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   private setupEdgeEndpointMarkers(
     linkGroups: d3.Selection<SVGGElement, any, any, unknown>
   ): void {
-    // Add target endpoint marker (at the arrow end)
-    linkGroups
-      .filter((d: any) => !this.isAlignmentEdge(d))
-      .append("circle")
-      .attr("class", "edge-endpoint-marker target-marker")
-      .attr("r", 8)
-      .attr("fill", "#007bff")
-      .attr("stroke", "white")
-      .attr("stroke-width", 2)
-      .attr("opacity", 0) // Hidden by default
-      .attr("cursor", "move")
-      .style("pointer-events", "none") // Will be enabled in input mode
-      .call(
-        d3.drag()
-          .on('start', (d: EdgeWithMetadata) => this.startEdgeEndpointDrag(d, 'target'))
-          .on('drag', (d: EdgeWithMetadata) => this.dragEdgeEndpoint(d, 'target'))
-          .on('end', (d: EdgeWithMetadata) => this.endEdgeEndpointDrag(d, 'target'))
-      );
+    const self = this;
 
-    // Add source endpoint marker (at the start, for bidirectional edges or moving the source)
-    linkGroups
-      .filter((d: any) => !this.isAlignmentEdge(d))
-      .append("circle")
-      .attr("class", "edge-endpoint-marker source-marker")
-      .attr("r", 8)
-      .attr("fill", "#28a745")
-      .attr("stroke", "white")
-      .attr("stroke-width", 2)
-      .attr("opacity", 0) // Hidden by default
-      .attr("cursor", "move")
-      .style("pointer-events", "none") // Will be enabled in input mode
-      .call(
+    // Build one draggable endpoint handle. The handle's SHAPE — not just its
+    // color — encodes the endpoint's role, so it reads under color-vision
+    // deficiency and never collides with the app's primary-action blue:
+    //   • directed edge  → hollow ring at the source (origin), filled diamond
+    //                       at the target (matches the arrowhead it sits on);
+    //   • symmetric edge → both ends are filled diamonds, because a
+    //                       bidirectional edge has no privileged direction.
+    // Each handle is tinted with its own edge's rendered color so it's obvious
+    // which edge a knob belongs to in a dense graph.
+    const addHandle = (role: 'source' | 'target'): void => {
+      const handles = linkGroups
+        .filter((d: any) => !this.isAlignmentEdge(d))
+        .append('g')
+        .attr('class', `edge-endpoint-marker ${role}-marker`)
+        .attr('opacity', 0)              // hidden until input mode
+        .style('pointer-events', 'none');
+
+      handles.each(function (d: any) {
+        const g = d3.select(this);
+
+        // Source of truth for the tint: the already-rendered edge path. Falls
+        // back to the computed color, then a neutral slate.
+        let color = self.edgeStrokeColor(d) || '#475569';
+        const path = (this.parentNode as Element | null)
+          ?.querySelector('path[data-link-id]') as SVGPathElement | null;
+        if (path) {
+          const stroke = path.getAttribute('stroke');
+          if (stroke && stroke !== 'none') color = stroke;
+        }
+
+        // A bidirectional edge's two ends are interchangeable → both are heads.
+        const isHead = !!d.bidirectional || role === 'target';
+        if (isHead) {
+          // Filled diamond (rotated square) centered on the origin; the parent
+          // <g>'s translate does the positioning.
+          g.append('rect')
+            .attr('class', 'endpoint-shape')
+            .attr('x', -6).attr('y', -6)
+            .attr('width', 12).attr('height', 12)
+            .attr('rx', 2)
+            .attr('transform', 'rotate(45)')
+            .attr('fill', color)
+            .attr('stroke', 'white')
+            .attr('stroke-width', 2);
+        } else {
+          // Hollow ring = the source/origin end of a directed edge.
+          g.append('circle')
+            .attr('class', 'endpoint-shape')
+            .attr('r', 6)
+            .attr('fill', 'white')
+            .attr('stroke', color)
+            .attr('stroke-width', 2.5);
+        }
+
+        // Native hover tooltip — the cheapest path to making the gesture
+        // discoverable instead of tribal knowledge.
+        const tip = d.bidirectional
+          ? 'Symmetric edge — drag either end to move it · drop on empty space to delete'
+          : role === 'source'
+            ? 'Source end — drag to reconnect · drop on empty space to delete'
+            : 'Target end — drag to reconnect · drop on empty space to delete';
+        g.append('title').text(tip);
+      });
+
+      handles.call(
         d3.drag()
-          .on('start', (d: EdgeWithMetadata) => this.startEdgeEndpointDrag(d, 'source'))
-          .on('drag', (d: EdgeWithMetadata) => this.dragEdgeEndpoint(d, 'source'))
-          .on('end', (d: EdgeWithMetadata) => this.endEdgeEndpointDrag(d, 'source'))
+          .on('start', (d: EdgeWithMetadata) => this.startEdgeEndpointDrag(d, role))
+          .on('drag', (d: EdgeWithMetadata) => this.dragEdgeEndpoint(d, role))
+          .on('end', (d: EdgeWithMetadata) => this.endEdgeEndpointDrag(d, role))
       );
+    };
+
+    addHandle('target');
+    addHandle('source');
   }
 
   /**
@@ -3358,15 +3411,14 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     if (!this.edgeDragState.isDragging) return;
 
     const [mouseX, mouseY] = d3.mouse(this.container.node());
-    
-    // Update the marker position
+
+    // Move the dragged handle group to follow the cursor.
     const markerClass = endpoint === 'target' ? '.target-marker' : '.source-marker';
     this.container
       .selectAll('.link-group')
       .filter((d: any) => d.id === edgeData.id)
       .select(markerClass)
-      .attr('cx', mouseX)
-      .attr('cy', mouseY);
+      .attr('transform', `translate(${mouseX}, ${mouseY})`);
   }
 
   /**
@@ -4429,33 +4481,27 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     // visible to update anyway.
     if (!this.svgLinkGroups || !this.isConnected) return;
 
-    // Update target markers (at the arrow end)
-    this.svgLinkGroups.select('.target-marker')
-      .attr('cx', (d: EdgeWithMetadata) => {
-        const point = this.getEdgePathPoint(d.id, 'end');
-        return point ? point.x : (d.target.x || 0);
-      })
-      .attr('cy', (d: EdgeWithMetadata) => {
-        const point = this.getEdgePathPoint(d.id, 'end');
-        return point ? point.y : (d.target.y || 0);
-      })
-      .attr('opacity', this.isInputModeActive ? 0.8 : 0)
-      .style('pointer-events', this.isInputModeActive ? 'all' : 'none')
-      .raise(); // Always on top
+    const place = (
+      sel: d3.Selection<any, any, any, unknown>,
+      position: 'start' | 'end'
+    ): void => {
+      sel
+        .attr('transform', (d: EdgeWithMetadata) => {
+          const point = this.getEdgePathPoint(d.id, position);
+          const fallback = (position === 'end' ? d.target : d.source) as any;
+          const x = point ? point.x : (fallback?.x || 0);
+          const y = point ? point.y : (fallback?.y || 0);
+          return `translate(${x}, ${y})`;
+        })
+        .attr('opacity', this.isInputModeActive ? 0.95 : 0)
+        .style('pointer-events', this.isInputModeActive ? 'all' : 'none')
+        .style('cursor', 'move')
+        .raise(); // keep handles above the edge paths
+    };
 
-    // Update source markers (at the start)
-    this.svgLinkGroups.select('.source-marker')
-      .attr('cx', (d: EdgeWithMetadata) => {
-        const point = this.getEdgePathPoint(d.id, 'start');
-        return point ? point.x : (d.source.x || 0);
-      })
-      .attr('cy', (d: EdgeWithMetadata) => {
-        const point = this.getEdgePathPoint(d.id, 'start');
-        return point ? point.y : (d.source.y || 0);
-      })
-      .attr('opacity', this.isInputModeActive ? 0.8 : 0)
-      .style('pointer-events', this.isInputModeActive ? 'all' : 'none')
-      .raise(); // Always on top
+    // Target markers sit at the arrow end; source markers at the path start.
+    place(this.svgLinkGroups.select('.target-marker'), 'end');
+    place(this.svgLinkGroups.select('.source-marker'), 'start');
   }
 
   /**
@@ -9882,6 +9928,16 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
 
       svg.input-mode:active {
         cursor: crosshair !important;
+      }
+
+      /* Draggable edge endpoint handles (shown only in input mode) */
+      .edge-endpoint-marker { transition: opacity 0.12s ease; }
+      .edge-endpoint-marker .endpoint-shape {
+        transition: stroke-width 0.1s ease, filter 0.1s ease;
+      }
+      .edge-endpoint-marker:hover .endpoint-shape {
+        stroke-width: 3.5;
+        filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.35));
       }
 
       .temporary-edge {

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -201,6 +201,15 @@ export interface WebColaLayoutOptions {
   transitionMode?: WebColaRenderTransitionMode;
 
   /**
+   * When false, opposite-direction tuples with the same label (A→B and B→A)
+   * are NOT merged into a single double-headed edge. The editable
+   * StructuredInputGraph turns collapse OFF so each tuple stays an independent,
+   * individually-editable arrow; the read-only base leaves it ON for a tidy
+   * double-header. Defaults to true.
+   */
+  collapseSymmetricEdges?: boolean;
+
+  /**
    * When true (stability mode), nodes with prior positions are locked
    * at those positions (fixed=1) wherever it does not violate a
    * constraint:
@@ -290,6 +299,7 @@ export class WebColaLayout {
 
   /** When true, lock unconstrained nodes with prior positions via fixed=1. */
   private lockUnconstrainedNodes: boolean;
+  private collapseSymmetric: boolean;
 
   constructor(instanceLayout: InstanceLayout, fig_height: number = 800, fig_width: number = 800, options?: WebColaLayoutOptions) {
 
@@ -313,6 +323,7 @@ export class WebColaLayout {
     }
 
     this.lockUnconstrainedNodes = options?.lockUnconstrainedNodes ?? false;
+    this.collapseSymmetric = options?.collapseSymmetricEdges ?? true;
 
     // Can I create a DAGRE graph here.
     try {
@@ -347,8 +358,12 @@ export class WebColaLayout {
     }
     this.colaEdges = instanceLayout.edges.map(edge => this.toColaEdge(edge));
 
-    // Collapse symmetric edges with the same label
-    this.colaEdges = this.collapseSymmetricEdges(this.colaEdges);
+    // Collapse symmetric edges with the same label into one double-headed edge.
+    // Editable graphs disable this so each direction stays an independent,
+    // individually-editable arrow (see collapseSymmetricEdges option).
+    if (this.collapseSymmetric) {
+      this.colaEdges = this.collapseSymmetricEdges(this.colaEdges);
+    }
 
     // Collapse identical nested groups to reduce jitter and constraint conflicts
     const deduplicatedGroups = this.collapseIdenticalGroups(instanceLayout.groups);
@@ -732,15 +747,25 @@ export class WebColaLayout {
         continue;
       }
 
+      // A self-loop (source === target) is NOT symmetric: it has a single
+      // direction and would otherwise match itself as its own reverse below,
+      // spuriously rendering a second arrowhead. Keep it as-is.
+      if (edge.source === edge.target) {
+        edgeMap.set(edge.id, edge);
+        processed.add(edge.id);
+        continue;
+      }
+
       // Create a key for the edge pair (always use lower source/target index first for consistency)
       const minIndex = Math.min(edge.source, edge.target);
       const maxIndex = Math.max(edge.source, edge.target);
       const pairKey = `${minIndex}-${maxIndex}-${edge.label}`;
 
-      // Look for the reverse edge with the same label
-      const reverseEdge = edges.find(e => 
-        e.source === edge.target && 
-        e.target === edge.source && 
+      // Look for the reverse edge with the same label (never the edge itself)
+      const reverseEdge = edges.find(e =>
+        e.id !== edge.id &&
+        e.source === edge.target &&
+        e.target === edge.source &&
         e.label === edge.label &&
         !processed.has(e.id)
       );

--- a/tests/webcola-teardown.test.ts
+++ b/tests/webcola-teardown.test.ts
@@ -62,10 +62,10 @@ describe('WebColaCnDGraph teardown (#474)', () => {
       };
 
       expect(() => proto.updateEdgeEndpointMarkers.call(fakeThis)).not.toThrow();
-      expect(target.applied.cx).toBe(30);
-      expect(target.applied.cy).toBe(40);
-      expect(source.applied.cx).toBe(1);
-      expect(source.applied.cy).toBe(2);
+      // Handles are positioned via a translate transform on the group, falling
+      // back to the edge's layout coordinates when the path geometry is unreadable.
+      expect(target.applied.transform).toBe('translate(30, 40)');
+      expect(source.applied.transform).toBe('translate(1, 2)');
     });
   });
 
@@ -241,6 +241,7 @@ describe('WebColaCnDGraph overlapping renders', () => {
           resolveTransitionMode: vi.fn(() => { order.push('resolveTransitionMode'); return 'replace'; }),
           hasValidTransform: () => false,
           applyViewportRenderPolicy: vi.fn(),
+          shouldCollapseSymmetricEdges: () => true,
           svg: null,
           zoomBehavior: null,
           showError: vi.fn(),


### PR DESCRIPTION
## What & why

While auditing how the editable `structured-input-graph` lets people add/remove nodes and edges, two problems with the edge-drag modality surfaced:

1. **Symmetric edges were a lie under editing.** A symmetric relation is backed by *two* tuples — `(a,b)` and `(b,a)` — which the renderer collapses into one double-headed edge. But the editing gestures only ever touched the **canonical** tuple, so dragging or deleting "the edge" left the reverse tuple orphaned, and it popped back as a stray one-way arrow. One visual object mapping to two data facts made every gesture ambiguous.
2. **The endpoint handles were two indistinguishable circles.** Source = green, target = blue, differing by color alone (a problem under color-vision deficiency), with the target blue colliding with the app's primary-action blue. And for a symmetric edge — which has no privileged direction — a source/target color split is meaningless.

## Changes

- **De-collapse symmetric edges in the editable graph only.** Each direction now renders as its own arrow, 1:1 with a tuple, so delete/reconnect act on exactly one direction (no orphaned reverse, no coupling). This is scoped via a new `collapseSymmetricEdges` translator option (defaults `true`); the read-only base keeps the tidy double-header by leaving the new `shouldCollapseSymmetricEdges()` hook returning `true`, while `StructuredInputGraph` overrides it to `false`.
- **Redesigned draggable endpoint handles.** Hollow ring at the source, filled diamond at the target (both diamonds when an edge is still collapsed in the base), tinted to the edge's own color, with `<title>` hover tooltips. Shape — not just color — carries the role.
- **Self-loop fix** in `collapseSymmetricEdges`: a self-loop no longer matches itself as its own reverse and is no longer spuriously marked bidirectional.
- Corrected stale JSDoc that described the old (amber square / red triangle) markers.

## Scope / reviewer notes

- Touches three files: `webcolatranslator.ts` (collapse option + self-loop fix), `webcola-cnd-graph.ts` (handle redesign + `shouldCollapseSymmetricEdges` hook + `translatorOptions`), `structured-input-graph.ts` (override + JSDoc).
- The de-collapse relies on the existing parallel-edge router (undirected pair-key + offset/curvature), so two opposite tuples fan into two distinct, individually grabbable arcs — no new routing code.
- New-node placement remains exactly as before (no behavior change to the "+ Node" button).
- `src/index.ts` and the untracked `mermaid/` data-instance + `playground.html` are an unrelated, pre-existing feature and are deliberately **not** included here.
- `build:browser` is green; `structured-input-edge-reconnection`, `deletion-constraint-validation`, and `structured-input-constraint-validation` suites pass (21 tests) on Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)