### PR TITLE
feat(grouping): group-by-selector "add edge" becomes a direction (none/togroup/fromgroup)

### DIFF
--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -156,7 +156,7 @@ Groups elements based on a selector expression.
 - group:
     selector: <n-ary-selector>   # Required: Selector returning elements to group
     name: <group-name>           # Required: Display name for the group
-    addEdge: <boolean>           # Optional: Add visual edge to group members
+    addEdge: <direction>         # Optional: none | togroup | fromgroup (default none)
 ```
 
 **Fields:**
@@ -165,7 +165,9 @@ Groups elements based on a selector expression.
 |-------|----------|------|---------|-------------|
 | `selector` | ✅ Yes | string | - | Selector returning atoms to include in group |
 | `name` | ✅ Yes | string | - | Display name shown on the group box |
-| `addEdge` | ❌ No | boolean | `false` | Whether to add visual edges between group members |
+| `addEdge` | ❌ No | `none` \| `togroup` \| `fromgroup` | `none` | Draw an edge between the group key and the group. `togroup` points key → group; `fromgroup` points group → key; `none` draws nothing. (Legacy `true` is accepted and treated as `togroup`.) |
+
+For a binary selector with tuples `(a, b), (a, c), (a, d)`, the group is keyed by `a` and contains `{b, c, d}`. `addEdge: togroup` draws an edge from `a` into that group; `addEdge: fromgroup` draws it from the group back to `a`.
 
 **Examples:**
 
@@ -175,11 +177,11 @@ Groups elements based on a selector expression.
     selector: Team.members
     name: "Team Members"
 
-# Group with connecting edges
+# Group with an edge pointing from the key into the group
 - group:
     selector: Department.employees
     name: "Department"
-    addEdge: true
+    addEdge: togroup
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/site/constraints.md
+++ b/site/constraints.md
@@ -184,14 +184,14 @@ Draws a visual bounding box around nodes matched by a selector.
 - group:
     selector: <n-ary-selector>   # Required
     name: <group-name>           # Required
-    addEdge: <boolean>           # Optional (default: false)
+    addEdge: <direction>         # Optional: none | togroup | fromgroup (default: none)
 ```
 
 | Field | Required | Type | Default | Description |
 |-------|----------|------|---------|-------------|
 | `selector` | Yes | string | — | Selector returning atoms to include in the group. This could be a unary or binary selector. If a binary selector, the first element is a group key, while the second element is added to groups associated with that key. |
 | `name` | Yes | string | — | Display name shown on the group box |
-| `addEdge` | No | boolean | `false` | Whether to add visual edges between group members and the group key |
+| `addEdge` | No | `none` \| `togroup` \| `fromgroup` | `none` | Draw an edge between the group key and the group. For a binary selector with tuples `(a, b), (a, c), (a, d)` the group is keyed by `a` and contains `{b, c, d}`: `togroup` draws an edge from `a` into the group, `fromgroup` draws it from the group back to `a`, and `none` draws nothing. (Legacy `true` is accepted and treated as `togroup`.) |
 
 ### Examples
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -2353,11 +2353,24 @@ export class LayoutInstance {
             let source = layoutNodes.find((node) => node.id === edge.v);
             let target = layoutNodes.find((node) => node.id === edge.w);
             let relName = this.getRelationName(g, edge);
-            let color = this.getEdgeColor(relName, edge.v, edge.w, edgeId);
-            let style = this.getEdgeStyle(relName, edge.v, edge.w, edgeId);
-            let weight = this.getEdgeWeight(relName, edge.v, edge.w, edgeId);
-            let showLabel = this.getEdgeShowLabel(relName, edge.v, edge.w, edgeId);
-            let highlight = this.getEdgeHighlight(relName, edge.v, edge.w, edgeId);
+
+            // For a group edge, the key (anchor) node is looked up from the group rather
+            // than assumed to be edge.v: a 'fromgroup' edge is created member→key, so its
+            // graph source is the member. Edge directives are written against the original
+            // selector-tuple order (key, member), so canonicalise the (source, target) atoms
+            // back to that order for directive lookup — directives then apply regardless of
+            // which way the arrow is drawn. The drawn arrow still follows the graph edge
+            // (source/target below), and keyNodeId records the true anchor for the renderer.
+            const isGroupEdge = !!edgeId && edgeId.startsWith('_g_');
+            const groupKey = isGroupEdge ? (keyNodeByGroupName.get(edgeLabel) ?? edge.v) : undefined;
+            const dirSource = groupKey !== undefined ? groupKey : edge.v;
+            const dirTarget = groupKey !== undefined ? (groupKey === edge.v ? edge.w : edge.v) : edge.w;
+
+            let color = this.getEdgeColor(relName, dirSource, dirTarget, edgeId);
+            let style = this.getEdgeStyle(relName, dirSource, dirTarget, edgeId);
+            let weight = this.getEdgeWeight(relName, dirSource, dirTarget, edgeId);
+            let showLabel = this.getEdgeShowLabel(relName, dirSource, dirTarget, edgeId);
+            let highlight = this.getEdgeHighlight(relName, dirSource, dirTarget, edgeId);
 
             // Skip edges with missing source or target nodes
             if (!source || !target || !edgeId) {
@@ -2378,14 +2391,11 @@ export class LayoutInstance {
                 // For group edges the graphlib edge label IS the group name (see constructGroupEdgeID).
                 // Carry it forward so the renderer can look up the group directly by ID
                 // without re-parsing the edge ID string or matching fragile leaf indices.
-                groupId: edgeId.startsWith('_g_') ? edgeLabel : undefined,
-                // Stamp the group's key (anchor) node so the renderer knows definitively
-                // which end is the anchor vs. the group member. We look it up by group name
-                // rather than assuming edge.v, because 'fromgroup' edges are created with the
-                // member as the source. Falls back to edge.v if the group isn't found.
-                keyNodeId: edgeId.startsWith('_g_')
-                    ? (keyNodeByGroupName.get(edgeLabel) ?? edge.v)
-                    : undefined,
+                groupId: isGroupEdge ? edgeLabel : undefined,
+                // The group's key (anchor) node (computed above), so the renderer knows
+                // definitively which end is the anchor vs. the group member regardless of
+                // the drawn direction. Undefined for non-group edges.
+                keyNodeId: groupKey,
             };
             return e;
         }).filter((edge): edge is LayoutEdge => edge !== null);

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -667,11 +667,18 @@ export class LayoutInstance {
                         };
                         groups.push(newGroup);
 
-                        // NOW if we have the GroupBySelector addEdge flag set, we should add an edge between the keyNode and the new node.
-                        if(gc.addEdge) {
-
-                            const edgeId = constructGroupEdgeID(groupName, groupOn, addToGroup);
-                            g.setEdge(groupOn, addToGroup, groupName, edgeId);
+                        // NOW if the GroupBySelector requests an edge, draw it between the key
+                        // node (groupOn) and the group, in the requested direction:
+                        //   'togroup'   → key → group   (edge source = key)
+                        //   'fromgroup' → group → key   (edge source = member)
+                        // The member end is later snapped to the group hull by the renderer,
+                        // which identifies the key end via the edge's stamped keyNodeId.
+                        if (gc.addEdge !== 'none') {
+                            const [edgeSrc, edgeTgt] = gc.addEdge === 'fromgroup'
+                                ? [addToGroup, groupOn]
+                                : [groupOn, addToGroup];
+                            const edgeId = constructGroupEdgeID(groupName, edgeSrc, edgeTgt);
+                            g.setEdge(edgeSrc, edgeTgt, groupName, edgeId);
                         }
 
                     }
@@ -1226,7 +1233,7 @@ export class LayoutInstance {
             cyclicDisjunctions = this.buildCyclicDisjunctions(layoutNodes, g);
             allDisjunctions.push(...cyclicDisjunctions);
 
-            layoutEdges = this.buildLayoutEdges(g, layoutNodes);
+            layoutEdges = this.buildLayoutEdges(g, layoutNodes, groups);
         } catch (error) {
             if (isMissingNodeConstraintError(error)) {
                 return this.handleMissingNodeConstraintError(
@@ -1313,7 +1320,7 @@ export class LayoutInstance {
         }
     ): CounterfactualLayoutResult {
         const layoutEdges = this.filterHiddenEdges(
-            this.buildLayoutEdges(context.graph, context.layoutNodes)
+            this.buildLayoutEdges(context.graph, context.layoutNodes, context.groups)
         );
         const layoutGroups = context.groups;
 
@@ -2329,7 +2336,16 @@ export class LayoutInstance {
         return disconnectedNodes;
     }
 
-    private buildLayoutEdges(g: Graph, layoutNodes: LayoutNode[]): LayoutEdge[] {
+    private buildLayoutEdges(g: Graph, layoutNodes: LayoutNode[], groups: LayoutGroup[] = []): LayoutEdge[] {
+        // Map each group's name → its key node. Group edges are labelled with the
+        // group name, so this lets us stamp the true key (anchor) end regardless
+        // of which way round the underlying graphlib edge was created (the key is
+        // the source for 'togroup', the target for 'fromgroup').
+        const keyNodeByGroupName = new Map<string, string>();
+        for (const grp of groups) {
+            if (grp.keyNodeId != null) keyNodeByGroupName.set(grp.name, grp.keyNodeId);
+        }
+
         return g.edges().map((edge) => {
 
             const edgeId = edge.name;
@@ -2363,9 +2379,13 @@ export class LayoutInstance {
                 // Carry it forward so the renderer can look up the group directly by ID
                 // without re-parsing the edge ID string or matching fragile leaf indices.
                 groupId: edgeId.startsWith('_g_') ? edgeLabel : undefined,
-                // edge.v is always the groupOn (key/anchor) node — stamp it so the renderer
-                // knows definitively which end is the anchor vs. the group member.
-                keyNodeId: edgeId.startsWith('_g_') ? edge.v : undefined,
+                // Stamp the group's key (anchor) node so the renderer knows definitively
+                // which end is the anchor vs. the group member. We look it up by group name
+                // rather than assuming edge.v, because 'fromgroup' edges are created with the
+                // member as the source. Falls back to edge.v if the group isn't found.
+                keyNodeId: edgeId.startsWith('_g_')
+                    ? (keyNodeByGroupName.get(edgeLabel) ?? edge.v)
+                    : undefined,
             };
             return e;
         }).filter((edge): edge is LayoutEdge => edge !== null);

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -133,22 +133,52 @@ export class AlignConstraint extends ConstraintOperation {
 
 
 
+/**
+ * Direction of the optional edge a {@link GroupBySelector} draws between the
+ * group key and the group. For binary selector tuples (a, b), (a, c), … the
+ * group is keyed by `a` and contains {b, c, …}; the edge connects `a` to that
+ * group.
+ *   - `'none'`      → draw no edge (default)
+ *   - `'togroup'`   → draw an edge a → group
+ *   - `'fromgroup'` → draw an edge group → a
+ */
+export type GroupEdgeDirection = 'none' | 'togroup' | 'fromgroup';
+
+/** The closed set of values accepted in the `addEdge` field. */
+export const GROUP_EDGE_DIRECTIONS: readonly GroupEdgeDirection[] = ['none', 'togroup', 'fromgroup'];
+
+/**
+ * Normalise a raw `addEdge` value into a {@link GroupEdgeDirection}. Accepts the
+ * three string values, and — for backwards compatibility with specs written
+ * against the old boolean flag — maps `true` to `'togroup'` (the historical
+ * behaviour: an edge from the key node into the group). Anything else is `'none'`.
+ */
+export function normalizeGroupEdgeDirection(value: unknown): GroupEdgeDirection {
+    if (value === true || value === 'togroup') return 'togroup';
+    if (value === 'fromgroup') return 'fromgroup';
+    return 'none';
+}
+
 export class GroupBySelector extends ConstraintOperation{
     name: string;
-    addEdge: boolean;
+    addEdge: GroupEdgeDirection;
 
-    constructor(selector : string, name: string, addEdge: boolean = false, negated: boolean = false) {
+    constructor(selector : string, name: string, addEdge: GroupEdgeDirection | boolean = 'none', negated: boolean = false) {
         super(selector, negated);
         this.name = name;
-        this.addEdge = addEdge;
+        this.addEdge = normalizeGroupEdgeDirection(addEdge);
     }
 
     override toHTML(): string {
         if (this.negated) {
             return `Members selected by <code>${this.selector}</code> cannot form a group`;
         }
+        const edgeNote =
+            this.addEdge === 'togroup' ? ` An edge is drawn from the key to the group.`
+            : this.addEdge === 'fromgroup' ? ` An edge is drawn from the group to the key.`
+            : '';
         return `GroupBySelector with selector <code>${this.selector}</code>
-        and name <code>${this.name}</code>.`;
+        and name <code>${this.name}</code>.${edgeNote}`;
     }
 }
 

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -15,7 +15,7 @@
  *     - orientation: { selector, directions: [...], hold? }
  *     - cyclic:      { selector, direction, hold? }
  *     - align:       { selector, direction, hold? }
- *     - group:       { selector, name, addEdge?, hold? }      (groupselector)
+ *     - group:       { selector, name, addEdge?: none|togroup|fromgroup, hold? }  (groupselector)
  *     - group:       { field, groupOn, addToGroup, selector?, hold? }  (groupfield, deprecated)
  *     - size:        { selector, width, height }
  *     - hideAtom:    { selector }
@@ -93,6 +93,23 @@ export const ORIENTATION_DIRECTIONS = [
 export const CYCLIC_DIRECTIONS = ['clockwise', 'counterclockwise'] as const;
 export const ALIGN_DIRECTIONS = ['horizontal', 'vertical'] as const;
 export const EDGE_STYLES = ['solid', 'dashed', 'dotted'] as const;
+
+/**
+ * Direction of the optional edge a group-by-selector draws between the group
+ * key and the group. `none` draws nothing; `togroup` points key → group;
+ * `fromgroup` points group → key. (Mirrors GroupEdgeDirection in layoutspec.ts.)
+ */
+export const GROUP_EDGE_DIRECTIONS = ['none', 'togroup', 'fromgroup'] as const;
+
+/**
+ * Normalise an `addEdge` value into a GROUP_EDGE_DIRECTIONS member. Tolerates
+ * the legacy boolean flag (`true` → 'togroup') so older specs keep working.
+ */
+function normGroupEdge(value: unknown): (typeof GROUP_EDGE_DIRECTIONS)[number] {
+  if (value === true || value === 'togroup') return 'togroup';
+  if (value === 'fromgroup') return 'fromgroup';
+  return 'none';
+}
 
 /**
  * The complete set of flags the engine recognizes (`layoutspec.ts` checks for
@@ -240,10 +257,11 @@ const groupselector: ItemDefinition = {
     },
     {
       key: 'addEdge',
-      kind: 'boolean',
+      kind: 'enum',
       label: 'Add edge',
-      default: false,
-      help: 'Draw an edge between grouped members.',
+      options: GROUP_EDGE_DIRECTIONS,
+      default: 'none',
+      help: 'Draw an edge between the group key and the group: "togroup" points key → group, "fromgroup" points group → key, "none" draws nothing.',
     },
   ],
   summary(params) {
@@ -257,8 +275,9 @@ const groupselector: ItemDefinition = {
     if (!missing(params.name)) {
       node.name = asString(params.name);
     }
-    if (params.addEdge === true) {
-      node.addEdge = true;
+    const edge = normGroupEdge(params.addEdge);
+    if (edge !== 'none') {
+      node.addEdge = edge;
     }
     if (params.hold !== undefined) {
       node.hold = params.hold;
@@ -275,7 +294,7 @@ const groupselector: ItemDefinition = {
     }
     const params: Record<string, unknown> = {
       selector: asString(group.selector),
-      addEdge: group.addEdge === true,
+      addEdge: normGroupEdge(group.addEdge),
     };
     if (group.name !== undefined) {
       params.name = asString(group.name);

--- a/tests/denotation-diff.test.ts
+++ b/tests/denotation-diff.test.ts
@@ -84,11 +84,11 @@ describe('flipConstraint', () => {
     });
 
     it('flips GroupBySelector', () => {
-        const c = new GroupBySelector('r', 'grp', true, false);
+        const c = new GroupBySelector('r', 'grp', 'fromgroup', false);
         const f = flipConstraint(c) as GroupBySelector;
         expect(f.negated).toBe(true);
         expect(f.name).toBe('grp');
-        expect(f.addEdge).toBe(true);
+        expect(f.addEdge).toBe('fromgroup');
     });
 
     it('flips GroupByField', () => {

--- a/tests/layout-instance.test.ts
+++ b/tests/layout-instance.test.ts
@@ -140,6 +140,70 @@ constraints:
     expect(selectorGroup?.name).toBe('nodes[node-x1:x1]');
   });
 
+  describe('group-by-selector addEdge direction', () => {
+    // Binary selector (A, B): group keyed by A, containing {B}.
+    const groupEdgeData: IJsonDataInstance = {
+      atoms: [
+        { id: 'A', type: 'Node', label: 'A' },
+        { id: 'B', type: 'Node', label: 'B' }
+      ],
+      relations: [
+        {
+          id: 'nodes',
+          name: 'nodes',
+          types: ['Node', 'Node'],
+          tuples: [{ atoms: ['A', 'B'], types: ['Node', 'Node'] }]
+        }
+      ]
+    };
+
+    function groupEdgeFor(addEdge: string) {
+      const spec = parseLayoutSpec(`
+constraints:
+  - group:
+      selector: nodes
+      name: nodes
+      addEdge: ${addEdge}
+`);
+      const instance = new JSONDataInstance(groupEdgeData);
+      const evaluator = createEvaluator(instance);
+      const li = new LayoutInstance(spec, evaluator, 0, true);
+      const { layout } = li.generateLayout(instance);
+      const groupEdge = layout.edges.find(e => e.groupId?.startsWith('nodes['));
+      return { layout, groupEdge };
+    }
+
+    it('draws no group edge by default (addEdge: none)', () => {
+      const { groupEdge } = groupEdgeFor('none');
+      expect(groupEdge).toBeUndefined();
+    });
+
+    it('togroup draws key → group (source = key A, target = member B)', () => {
+      const { groupEdge } = groupEdgeFor('togroup');
+      expect(groupEdge).toBeDefined();
+      expect(groupEdge!.source.id).toBe('A');
+      expect(groupEdge!.target.id).toBe('B');
+      expect(groupEdge!.keyNodeId).toBe('A');
+    });
+
+    it('fromgroup draws group → key (source = member B, target = key A); keyNodeId still A', () => {
+      const { groupEdge } = groupEdgeFor('fromgroup');
+      expect(groupEdge).toBeDefined();
+      expect(groupEdge!.source.id).toBe('B');
+      expect(groupEdge!.target.id).toBe('A');
+      // keyNodeId must remain the real key even though it's the graph edge's target.
+      expect(groupEdge!.keyNodeId).toBe('A');
+    });
+
+    it('legacy addEdge: true behaves as togroup', () => {
+      const { groupEdge } = groupEdgeFor('true');
+      expect(groupEdge).toBeDefined();
+      expect(groupEdge!.source.id).toBe('A');
+      expect(groupEdge!.target.id).toBe('B');
+      expect(groupEdge!.keyNodeId).toBe('A');
+    });
+  });
+
   it('adds alignment edges for disconnected nodes with orientation constraints', () => {
     const instance = new JSONDataInstance(jsonDataDisconnected);
     const evaluator = createEvaluator(instance);

--- a/tests/layout-instance.test.ts
+++ b/tests/layout-instance.test.ts
@@ -202,6 +202,34 @@ constraints:
       expect(groupEdge!.target.id).toBe('B');
       expect(groupEdge!.keyNodeId).toBe('A');
     });
+
+    it('edge directives still match a fromgroup group edge by canonical (key, member) order', () => {
+      // The group edge is drawn member→key (B→A) for fromgroup, but the directive
+      // is written against the original selector-tuple order (key→member, A→B). The
+      // directive must still apply — directive lookup is canonicalised to (key, member).
+      const spec = parseLayoutSpec(`
+constraints:
+  - group:
+      selector: nodes
+      name: nodes
+      addEdge: fromgroup
+directives:
+  - edgeColor:
+      field: nodes
+      value: '#FF0000'
+      filter: 'A -> B'
+`);
+      const instance = new JSONDataInstance(groupEdgeData);
+      const evaluator = createEvaluator(instance);
+      const li = new LayoutInstance(spec, evaluator, 0, true);
+      const { layout } = li.generateLayout(instance);
+
+      const groupEdge = layout.edges.find(e => e.groupId?.startsWith('nodes['));
+      expect(groupEdge).toBeDefined();
+      expect(groupEdge!.source.id).toBe('B'); // arrow drawn group → key
+      expect(groupEdge!.target.id).toBe('A');
+      expect(groupEdge!.color).toBe('#FF0000'); // directive for A->B still applies
+    });
   });
 
   it('adds alignment edges for disconnected nodes with orientation constraints', () => {

--- a/tests/spec-editor-codec.test.ts
+++ b/tests/spec-editor-codec.test.ts
@@ -126,12 +126,25 @@ describe('yaml-codec — real-world round trips', () => {
     expect(spec.directives.tags[0].value).toBe('Person.status');
   });
 
-  it('round-trips group-by-selector (selector/name/addEdge)', () => {
+  it('round-trips group-by-selector (selector/name/addEdge); legacy addEdge:true → togroup', () => {
     const out = assertRoundTrips(GROUP_SELECTOR_SPEC);
     const spec = parseLayoutSpec(out);
     expect(spec.constraints.grouping.byselector).toHaveLength(1);
     expect(spec.constraints.grouping.byselector[0].name).toBe('team');
-    expect(spec.constraints.grouping.byselector[0].addEdge).toBe(true);
+    // The legacy boolean `addEdge: true` normalises to the 'togroup' direction.
+    expect(spec.constraints.grouping.byselector[0].addEdge).toBe('togroup');
+  });
+
+  it('round-trips group-by-selector with addEdge: fromgroup', () => {
+    const yaml = `constraints:
+  - group:
+      selector: sameTeam
+      name: team
+      addEdge: fromgroup
+`;
+    const out = assertRoundTrips(yaml);
+    const spec = parseLayoutSpec(out);
+    expect(spec.constraints.grouping.byselector[0].addEdge).toBe('fromgroup');
   });
 });
 

--- a/tests/spec-editor-registry-diagnostics.test.ts
+++ b/tests/spec-editor-registry-diagnostics.test.ts
@@ -52,7 +52,7 @@ describe('registry — definitions and defaults', () => {
   it('seeds defaults from FieldSpec defaults only', () => {
     expect(defaultParamsFor('cyclic')).toEqual({ direction: 'clockwise' });
     expect(defaultParamsFor('size')).toEqual({ width: 100, height: 60 });
-    expect(defaultParamsFor('groupselector')).toEqual({ addEdge: false });
+    expect(defaultParamsFor('groupselector')).toEqual({ addEdge: 'none' });
     // orientation has no defaultable fields
     expect(defaultParamsFor('orientation')).toEqual({});
   });


### PR DESCRIPTION
## What

The **Add edge** option on group-by-selector was a boolean (yes/no). It's now a three-way **direction**, so the edge between a group's key and the group can point either way — or not be drawn at all.

For binary selector tuples `(a,b), (a,c), (a,d)` the group is keyed by `a` and contains `{b,c,d}`:

| Value | Effect |
|-------|--------|
| `none` (default) | no edge |
| `togroup` | edge `a → group` |
| `fromgroup` | edge `group → a` |

```yaml
- group:
    selector: sameTeam
    name: team
    addEdge: fromgroup   # group → key
```

## Why

Previously the edge could only go *key → group*. Drawing it *group → key* is a common need (e.g. "members point back at their owner"), which a boolean can't express.

## Backwards compatibility

Fully compatible — **no migration needed**:

- Legacy `addEdge: true` parses to `togroup` (the exact old behavior: an edge from the key into the group).
- `addEdge: false` / absent → `none`.
- The `GroupBySelector` constructor accepts and normalizes booleans, so programmatic `new GroupBySelector(sel, name, true)` callers keep working.
- The only breaking change is the TypeScript **type** of the `GroupBySelector.addEdge` field (`boolean` → `'none' | 'togroup' | 'fromgroup'`); a downstream consumer reading that field as a boolean would need a one-line adjustment. All in-repo consumers are updated.

A round-trip test covers the legacy `true → togroup` mapping.

## How it works

- **Model** (`layoutspec.ts`): new `GroupEdgeDirection` type + `normalizeGroupEdgeDirection()`; the constructor normalizes its input (boolean or string), so both the YAML parser and `denotation-diff` get a clean enum.
- **Edge creation** (`layoutinstance.ts`): swaps the graphlib edge source/target for `fromgroup`. Since the endpoint that lands inside the group hull flips too, `buildLayoutEdges` now stamps `keyNodeId` by looking the key up from the group (by name) instead of assuming it's the graphlib edge source. This also fixes a latent mis-stamp for deprecated `byfield` groups with `groupOn: 1`.
- **Renderer**: no change — the group-edge routing was already direction-agnostic (it checks `keyNodeId` against *both* ends and snaps the member end to the hull).
- **No-code spec editor** (`registry.ts`): the `addEdge` field is now an `enum` (segmented pills) instead of a boolean switch; codec normalizes and omits `none`.
- **Docs**: `docs/YAML_SPECIFICATION.md` and `site/constraints.md` updated.

## Testing

- Added 4 end-to-end tests in `tests/layout-instance.test.ts` asserting edge source/target/`keyNodeId` for `none` / `togroup` / `fromgroup` / legacy-`true`.
- Updated + passing: codec round-trip (incl. new `fromgroup` case), registry diagnostics, denotation-diff, code-nocode-sync, spec-editor UI suites.
- Typecheck unchanged at the 80-error baseline (no regressions); `build:lib` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)