### PR TITLE
Make ./evaluator a self-contained bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/tests/evaluator-subpath-contract.test.ts
+++ b/tests/evaluator-subpath-contract.test.ts
@@ -27,6 +27,24 @@ describe('evaluator subpath packaging contract', () => {
 
     expect(configText).toContain("entry: { evaluator: 'src/evaluators/data/sgq-evaluator.ts' }");
     expect(configText).toContain("platform: 'node'");
-    expect(configText).toContain("'simple-graph-query'");
+  });
+
+  it('inlines runtime deps so ./evaluator is a self-contained single file', () => {
+    // The evaluator entry must bundle its runtime deps (graphlib + lodash,
+    // simple-graph-query) rather than externalize them, so downstream consumers
+    // (e.g. spytial-py's headless suggest evaluator) can vendor one .js/.mjs with
+    // no sibling node_modules. Read the source config, not the gitignored dist.
+    const configText = readFileSync(join(process.cwd(), 'tsup.evaluator.config.ts'), 'utf8');
+
+    const noExternal = configText.match(/noExternal:\s*\[([^\]]*)\]/)?.[1] ?? '';
+    expect(noExternal).toContain("'graphlib'");
+    expect(noExternal).toContain("'simple-graph-query'");
+    expect(noExternal).toContain("'lodash'");
+
+    // ...and none of those may be re-externalized (which would undo the bundling).
+    const external = configText.match(/(?<!no)external:\s*\[([^\]]*)\]/)?.[1] ?? '';
+    expect(external).not.toContain("'simple-graph-query'");
+    expect(external).not.toContain("'graphlib'");
+    expect(external).not.toContain("'lodash'");
   });
 });

--- a/tsup.evaluator.config.ts
+++ b/tsup.evaluator.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
   minify: true,
   target: 'es2020',
   outDir: 'dist',
-  external: ['react', 'react-dom', 'simple-graph-query', 'forge-expr-evaluator'],
+  external: ['react', 'react-dom', 'forge-expr-evaluator'],
+  // Inline the evaluator's runtime deps so the ./evaluator entry is a single
+  // self-contained file. This lets downstream consumers (e.g. spytial-py's
+  // headless suggest evaluator) vendor one .js/.mjs with no sibling node_modules.
+  // simple-graph-query already ships a self-contained bundle; graphlib pulls
+  // lodash, so lodash must be bundled too (it's a direct dep, otherwise external).
+  noExternal: ['graphlib', 'simple-graph-query', 'lodash'],
   bundle: true,
   treeshake: true,
   platform: 'node',


### PR DESCRIPTION
## What

The `./evaluator` subpath entry externalized its runtime deps (`graphlib`, `simple-graph-query`, and transitively `lodash`), so consuming it required a sibling `node_modules` tree. This inlines them via tsup `noExternal`, making `dist/evaluator.js` a **single self-contained file** — its only remaining `require` is the `util` builtin.

## Why

Downstream consumers can now vendor one `.js`/`.mjs` (plus a stub `package.json` with the `./evaluator` export) with **no `npm install`**. The immediate motivation is spytial-py's headless `suggest` tier-2 evaluator ([`_eval.py`](https://github.com/sidprasad/spytial-py/blob/main/spytial/suggest/_eval.py)), which today requires `SPYTIAL_CORE_NODE_PATH` pointing at an npm-installed core. With a self-contained evaluator it can ship the file in its wheel and tier-2 works on `pip install` (given `node`).

## Changes

- `tsup.evaluator.config.ts`: move `simple-graph-query` out of `external`; add `noExternal: ['graphlib','simple-graph-query','lodash']` (lodash is graphlib's dep **and** a direct spytial-core dep, so it must be named or it stays external).
- `tests/evaluator-subpath-contract.test.ts`: source-level guard asserting the three deps stay in `noExternal` and never re-appear in `external`, so this can't silently regress. (Reads the config source, not the gitignored `dist`, so it's CI-safe.)
- `package.json`: bump 2.10.0 → 2.10.1 (publish-ready; `prepublishOnly` rebuilds the bundled `dist`).

## Verification

- `dist/evaluator.js`: 12 KB → 797 KB (deps inlined); only `require`s `util`; loads standalone from an empty dir.
- Verified end-to-end through the real spytial-py bridge against a minimal vendored package (no `node_modules`): `is_available: True`, selectors resolve at correct arity, hallucinated barewords rejected.
- **278/278** evaluator + data-instance tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)