### PR TITLE
evaluator: re-export static analyzer + FOIL synthesizers on ./evaluator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/evaluators/data/sgq-evaluator.ts
+++ b/src/evaluators/data/sgq-evaluator.ts
@@ -2,6 +2,19 @@ import IEvaluator, {EvaluatorResult} from "../interfaces";
 import {SimpleGraphQueryEvaluator, EvaluationResult, ErrorResult} from "simple-graph-query";
 export { JSONDataInstance } from "../../data-instance/json-data-instance";
 
+// Also surface SQG's static analyzer and by-example (FOIL-style) synthesizers on the
+// ./evaluator entry, so headless consumers — e.g. spytial.suggest's tier-2 bridge —
+// can reach the cheap static gate and the selector synthesizer through the same
+// windowless module they already require for evaluation, with no second import and no
+// browser globals. Runtime values only; the types ride along in the generated .d.ts.
+export {
+    analyzeForgeExpression,
+    synthesizeSelector,
+    synthesizeBinaryRelation,
+    synthesizeBinaryRelationWithWhy,
+    synthesizeSelectorWithWhy,
+} from "simple-graph-query";
+
 import {EvaluationContext, EvaluatorConfig, IEvaluatorResult } from "../interfaces";
 import { IDataInstance } from "../../data-instance/interfaces";
 import {SingleValue, Tuple} from "../interfaces";


### PR DESCRIPTION
## What

The windowless `./evaluator` entry (`sgq-evaluator.ts`) exported only the evaluator trio (`JSONDataInstance`, `SGraphQueryEvaluator`, `SGQEvaluatorResult`). This adds `analyzeForgeExpression`, `synthesizeSelector`, and `synthesizeBinaryRelation` (plus the `…WithWhy` variants) to that surface.

## Why

They already live in `simple-graph-query`, and `noExternal` already bundles that lib into the evaluator build — so the code was physically inside `dist/evaluator.js` but not on the module's exports. Surfacing them lets a headless consumer reach, through a single `require`, three capabilities instead of one:

- **evaluation** (unchanged),
- a cheap **static gate**: `analyzeForgeExpression(expr, schema?)` → `unsat | tautology | empty | ill-typed | unknown`, each with a `reason`, and
- by-example **selector synthesis**.

The immediate consumer is `spytial.suggest`'s tier-2 bridge, which uses the static gate to give the model repair feedback (a provably-empty selector, an arity mismatch) instead of silently dropping it.

## Verification

- `npm run build:evaluator` succeeds; `dist/evaluator.js` exports all three new functions and stays self-contained (only `require("util")`).
- `analyzeForgeExpression("univ - univ")` → `{status:"empty", reason:"expression is provably the empty set"}`; passing a `JSONDataInstance` as the schema unlocks type-lattice reasoning (`NoneType & LLNode` → provably empty). `synthesizeBinaryRelation` returns an expression from a datum + target pair-set.

Additive change; minor bump 2.10.1 → 2.11.0. Publish is tag-triggered, so merging does not release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
