### PR TITLE
feat(error-reporting): collapsible modal, remove unsat triangle, highlight referenced nodes (#490)

### DIFF
--- a/src/components/ErrorMessageModal/ErrorMessageContainer.tsx
+++ b/src/components/ErrorMessageModal/ErrorMessageContainer.tsx
@@ -10,6 +10,11 @@ export interface ErrorMessageContainerProps {
   errorManager: ErrorStateManager;
   /** Additional CSS classes */
   className?: string;
+  /**
+   * Optional id of a `webcola-cnd-graph` element. When set, hovering a
+   * conflicting constraint highlights the referenced nodes in that diagram.
+   */
+  graphElementId?: string;
 }
 
 /**
@@ -18,7 +23,8 @@ export interface ErrorMessageContainerProps {
  */
 export const ErrorMessageContainer: React.FC<ErrorMessageContainerProps> = ({
   errorManager,
-  className = ''
+  className = '',
+  graphElementId
 }) => {
   const [currentError, setCurrentError] = useState<SystemError | null>(
     errorManager.getCurrentError()
@@ -45,8 +51,9 @@ export const ErrorMessageContainer: React.FC<ErrorMessageContainerProps> = ({
   
   return (
     <div className={containerClassName}>
-      <ErrorMessageModal 
+      <ErrorMessageModal
         systemError={currentError}
+        graphElementId={graphElementId}
       />
     </div>
   );

--- a/src/components/ErrorMessageModal/ErrorMessageModal.css
+++ b/src/components/ErrorMessageModal/ErrorMessageModal.css
@@ -39,3 +39,23 @@ code > code, code > pre {
     padding: 0.2em 0.4em;
     border-radius: 4px;
 }
+
+/* Collapse/expand header bar */
+.error-modal-header {
+    gap: 0.5rem;
+}
+
+.error-modal-toggle {
+    background: transparent;
+    border: none;
+    color: var(--bs-danger);
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0 0.25rem;
+    cursor: pointer;
+}
+
+.error-modal-toggle:hover,
+.error-modal-toggle:focus {
+    opacity: 0.75;
+}

--- a/src/components/ErrorMessageModal/ErrorMessageModal.tsx
+++ b/src/components/ErrorMessageModal/ErrorMessageModal.tsx
@@ -9,6 +9,12 @@ import { ErrorMessages, SystemError, SelectorErrorDetail } from './index';
 export interface ErrorMessageModalProps {
   /** Error object containing  */
   systemError?: SystemError;
+  /**
+   * Optional id of a `webcola-cnd-graph` element. When provided, hovering a
+   * conflicting constraint highlights the referenced nodes in that diagram
+   * (via the graph's public `highlightNodes` / `clearNodeHighlights` API).
+   */
+  graphElementId?: string;
 }
 
 /** Constraint node with bidirectional relationships */
@@ -29,19 +35,51 @@ type HighlightState = {
  * Supports both constraint conflicts and parse errors
  * @public
  */
-export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemError }: ErrorMessageModalProps) => {
+export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemError, graphElementId }: ErrorMessageModalProps) => {
   const [highlightState, setHighlightState] = useState<HighlightState>({ ids: [], source: null });
   const [collapsed, setCollapsed] = useState(false);
 
-  /** Handle mouse enter for constraint highlighting */
-  const handleMouseEnter = (node: ConstraintNode, source: 'source' | 'diagram') => {
-    setHighlightState({ ids: [node.id, ...node.relatedIds], source });
+  /** Minimal shape of the graph element's node-highlighting API */
+  type GraphHighlightElement = HTMLElement & {
+    highlightNodes?: (nodeIds: string[]) => boolean;
+    clearNodeHighlights?: () => boolean;
   };
 
-  /** 
-   * Clear highlighting on mouse leave 
+  /**
+   * Highlight the diagram nodes referenced inside a hovered constraint item.
+   * Node references carry a `data-node-id` attribute (see formatNodeLabel), so
+   * we read them straight from the rendered DOM rather than parsing text.
+   */
+  const highlightGraphNodesFrom = (el: HTMLElement) => {
+    if (!graphElementId) return;
+    const graph = document.getElementById(graphElementId) as GraphHighlightElement | null;
+    if (!graph || typeof graph.highlightNodes !== 'function') return;
+    const ids = Array.from(el.querySelectorAll('[data-node-id]'))
+      .map(n => n.getAttribute('data-node-id'))
+      .filter((id): id is string => !!id);
+    if (ids.length > 0) graph.highlightNodes(Array.from(new Set(ids)));
+  };
+
+  /** Clear any diagram node highlights this modal applied */
+  const clearGraphNodeHighlights = () => {
+    if (!graphElementId) return;
+    const graph = document.getElementById(graphElementId) as GraphHighlightElement | null;
+    if (graph && typeof graph.clearNodeHighlights === 'function') graph.clearNodeHighlights();
+  };
+
+  /** Handle mouse enter for constraint highlighting */
+  const handleMouseEnter = (e: React.MouseEvent<HTMLElement>, node: ConstraintNode, source: 'source' | 'diagram') => {
+    setHighlightState({ ids: [node.id, ...node.relatedIds], source });
+    highlightGraphNodesFrom(e.currentTarget);
+  };
+
+  /**
+   * Clear highlighting on mouse leave
   */
-  const handleMouseLeave = () => setHighlightState({ ids: [], source: null });
+  const handleMouseLeave = () => {
+    setHighlightState({ ids: [], source: null });
+    clearGraphNodeHighlights();
+  };
 
   /** 
    * Get CSS class for constraint highlighting 
@@ -210,7 +248,7 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
                         key={node.id}
                         data-constraint-id={node.id}
                         className={`constraint-item ${getHighlightClass(node.id)}`}
-                        onMouseEnter={() => handleMouseEnter(node, 'source')}
+                        onMouseEnter={(e) => handleMouseEnter(e, node, 'source')}
                         onMouseLeave={handleMouseLeave}
                       >
                         <code dangerouslySetInnerHTML={{ __html: node.content }}></code>
@@ -224,7 +262,7 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
                           key={node.id}
                           data-constraint-id={node.id}
                           className={`constraint-item ${getHighlightClass(node.id)}`}
-                          onMouseEnter={() => handleMouseEnter(node, 'diagram')}
+                          onMouseEnter={(e) => handleMouseEnter(e, node, 'diagram')}
                           onMouseLeave={handleMouseLeave}
                         >
                           <code dangerouslySetInnerHTML={{ __html: node.content }}></code>

--- a/src/components/ErrorMessageModal/ErrorMessageModal.tsx
+++ b/src/components/ErrorMessageModal/ErrorMessageModal.tsx
@@ -31,6 +31,7 @@ type HighlightState = {
  */
 export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemError }: ErrorMessageModalProps) => {
   const [highlightState, setHighlightState] = useState<HighlightState>({ ids: [], source: null });
+  const [collapsed, setCollapsed] = useState(false);
 
   /** Handle mouse enter for constraint highlighting */
   const handleMouseEnter = (node: ConstraintNode, source: 'source' | 'diagram') => {
@@ -157,7 +158,21 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
 
   return (
     <div id="error-message-modal" className="mt-3 d-flex flex-column overflow-x-auto p-3 rounded border border-danger border-2">
-      <h4 style={{color: 'var(--bs-danger)'}}>{headerText}</h4>
+      <div className="error-modal-header d-flex justify-content-between align-items-center">
+        <h4 className="mb-0" style={{color: 'var(--bs-danger)'}}>{headerText}</h4>
+        <button
+          type="button"
+          className="error-modal-toggle"
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? 'Expand error details' : 'Collapse error details'}
+          title={collapsed ? 'Expand error details' : 'Collapse error details'}
+          onClick={() => setCollapsed(c => !c)}
+        >
+          {collapsed ? '▸' : '▾'}
+        </button>
+      </div>
+      {!collapsed && (
+        <>
       <p>{descriptionText}</p>
       {/* Parse/Generic/Group Error Card */}
       {isOtherError && (
@@ -244,6 +259,8 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
               </ul>
             </div>
           </div>
+        </>
+      )}
         </>
       )}
   </div>

--- a/src/layout/constraint-types.ts
+++ b/src/layout/constraint-types.ts
@@ -125,21 +125,24 @@ export function formatNodeLabel(node: LayoutNode): string {
         }
 
         if (attributeParts.length > 0) {
-            // Escape label to prevent XSS
-            return `${escapeHtml(node.label)} (${attributeParts.join(', ')})`;
+            // Escape label to prevent XSS. The id is carried as a non-visible
+            // data-node-id attribute so hovering can highlight the diagram node,
+            // without showing the bare id as display text.
+            return `<span data-node-id="${escapeHtml(node.id)}">${escapeHtml(node.label)} (${attributeParts.join(', ')})</span>`;
         }
     }
 
     // No attributes present - show label with ID explanation
     // Use HTML title attribute for hover tooltip explaining what the ID is
+    // data-node-id lets consumers (e.g. the error modal) highlight the node.
     // Escape all user-provided values to prevent XSS
     if (node.label && node.label !== node.id) {
         // Format: label (id = X) where hovering explains the ID
-        return `<span title="${ID_TOOLTIP_TEXT}">${escapeHtml(node.label)} (id = ${escapeHtml(node.id)})</span>`;
+        return `<span data-node-id="${escapeHtml(node.id)}" title="${ID_TOOLTIP_TEXT}">${escapeHtml(node.label)} (id = ${escapeHtml(node.id)})</span>`;
     }
 
     // Only ID available (label same as ID or no label)
-    return `<span title="${ID_TOOLTIP_TEXT}">${escapeHtml(node.id)}</span>`;
+    return `<span data-node-id="${escapeHtml(node.id)}" title="${ID_TOOLTIP_TEXT}">${escapeHtml(node.id)}</span>`;
 }
 
 // TODO:

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -9817,22 +9817,33 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         stroke-width: 3px; /* Change this to your desired highlight width */
       }
 
-      /* Node highlighting styles */
-      .node.highlighted rect {
+      /* Node highlighting styles. Also applies to .error-node so hovering a
+         conflicting constraint in the error modal highlights the unsat nodes;
+         the solid orange stroke + glow overrides the dashed red error style. */
+      .node.highlighted rect,
+      .error-node.highlighted rect {
         stroke: #ff9500;
         stroke-width: 3px;
+        stroke-dasharray: none;
+        animation: none;
         filter: drop-shadow(0 0 6px rgba(255, 149, 0, 0.6));
       }
 
-      .node.highlighted-first rect {
+      .node.highlighted-first rect,
+      .error-node.highlighted-first rect {
         stroke: #007aff;
         stroke-width: 3px;
+        stroke-dasharray: none;
+        animation: none;
         filter: drop-shadow(0 0 6px rgba(0, 122, 255, 0.6));
       }
 
-      .node.highlighted-second rect {
+      .node.highlighted-second rect,
+      .error-node.highlighted-second rect {
         stroke: #ff3b30;
         stroke-width: 3px;
+        stroke-dasharray: none;
+        animation: none;
         filter: drop-shadow(0 0 6px rgba(255, 59, 48, 0.6));
       }
 

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -842,13 +842,6 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   }
 
   /**
-   * Access whether this graph is a graph visualizing an unsat core.
-   */
-  private get isUnsatCore(): boolean {
-    return this.hasAttribute('unsat');
-  }
-
-  /**
    * Access transition mode for layout swaps.
    * Supported values:
    * - "morph": exiting elements fade out, entering fade in, continuing slide
@@ -1367,7 +1360,6 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         </div>
       </div>
       <div id="svg-container">
-      <span id="error-icon" title="This graph is depicting an error state">⚠️</span>
       <div id="loading" role="status" aria-live="polite" aria-atomic="true">
         <span class="loading-dot" aria-hidden="true"></span>
         <span id="loading-progress">Computing layout...</span>
@@ -2451,11 +2443,6 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
               this.updatePositions();
               this.routeEdges();
             }
-          }
-
-          // Check if it's an unsat core layout
-          if (this.isUnsatCore) {
-            this.showErrorIcon();
           }
 
           // Dispatch relations-available event after layout is complete
@@ -9953,37 +9940,6 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         opacity: 0.8;
       }
 
-      /* Error icon positioning - bottom area to avoid header overlap */
-      #error-icon {
-        margin: 5px;
-        padding: 8px 12px;
-        font-size: 16px;
-        position: absolute;
-        bottom: 10px; /* Position at bottom instead of top */
-        left: 10px;
-        z-index: 1000;
-        cursor: help;
-        background-color: rgba(220, 53, 69, 0.95);
-        color: white;
-        border-radius: 6px;
-        border: none;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-        font-weight: 500;
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        visibility: hidden; /* Use visibility instead of display */
-      }
-      
-      #error-icon.visible {
-        visibility: visible;
-      }
-
-      #error-icon::before {
-        content: "⚠️";
-        font-size: 18px;
-      }
-
       /* Graph toolbar styling */
       #graph-toolbar {
         display: flex;
@@ -10338,22 +10294,6 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     this.hideLoading();
     error.style.display = 'block';
     error.textContent = message;
-  }
-
-  /**
-   * Show error icon
-   */
-  private showErrorIcon(): void {
-    const errorIcon = this.root.querySelector('#error-icon') as HTMLElement;
-    errorIcon.classList.add('visible');
-  }
-
-  /**
-   * Hide error icon
-   */
-  private hideErrorIcon(): void {
-    const errorIcon = this.root.querySelector('#error-icon') as HTMLElement;
-    errorIcon.classList.remove('visible');
   }
 
   // =========================================

--- a/tests/components/ErrorMessageModal.test.tsx
+++ b/tests/components/ErrorMessageModal.test.tsx
@@ -285,4 +285,63 @@ describe('ErrorMessageModal Component', () => {
       expect(screen.getByText('An error occurred while processing your data.')).toBeInTheDocument()
     })
   })
+
+  describe('Diagram node highlighting', () => {
+    // Conflict text whose node references carry data-node-id (as formatNodeLabel emits)
+    const nodeRefHtml = '<span data-node-id="p2">Bob</span> is above <span data-node-id="p1">Alice</span>'
+    const positionalErrorWithNodeIds: SystemError = {
+      type: 'positional-error',
+      messages: {
+        conflictingConstraint: nodeRefHtml,
+        conflictingSourceConstraint: 'OrientationConstraint with directions [below]',
+        minimalConflictingConstraints: new Map([
+          ['OrientationConstraint with directions [below]', [nodeRefHtml]]
+        ])
+      }
+    }
+
+    function mountMockGraph(id: string) {
+      const el = document.createElement('div') as HTMLElement & {
+        highlightNodes: ReturnType<typeof vi.fn>
+        clearNodeHighlights: ReturnType<typeof vi.fn>
+      }
+      el.id = id
+      el.highlightNodes = vi.fn(() => true)
+      el.clearNodeHighlights = vi.fn(() => true)
+      document.body.appendChild(el)
+      return el
+    }
+
+    const diagramItem = () =>
+      document.querySelector('.constraint-item[data-constraint-id^="diagram-"]') as HTMLElement
+
+    it('highlights referenced diagram nodes on hover and clears them on leave', async () => {
+      const user = userEvent.setup()
+      const graph = mountMockGraph('mock-graph-highlight')
+      try {
+        render(<ErrorMessageModal systemError={positionalErrorWithNodeIds} graphElementId="mock-graph-highlight" />)
+
+        await user.hover(diagramItem())
+        expect(graph.highlightNodes).toHaveBeenCalledTimes(1)
+        expect(graph.highlightNodes).toHaveBeenCalledWith(expect.arrayContaining(['p1', 'p2']))
+
+        await user.unhover(diagramItem())
+        expect(graph.clearNodeHighlights).toHaveBeenCalled()
+      } finally {
+        graph.remove()
+      }
+    })
+
+    it('does not touch the graph when graphElementId is omitted', async () => {
+      const user = userEvent.setup()
+      const graph = mountMockGraph('mock-graph-unused')
+      try {
+        render(<ErrorMessageModal systemError={positionalErrorWithNodeIds} />)
+        await user.hover(diagramItem())
+        expect(graph.highlightNodes).not.toHaveBeenCalled()
+      } finally {
+        graph.remove()
+      }
+    })
+  })
 })

--- a/tests/components/ErrorMessageModal.test.tsx
+++ b/tests/components/ErrorMessageModal.test.tsx
@@ -242,4 +242,47 @@ describe('ErrorMessageModal Component', () => {
       expect(diagramConstraint).not.toHaveClass('highlight-diagram')
     })
   })
+
+  describe('Collapse/minimize', () => {
+    const parseError: SystemError = {
+      type: 'parse-error',
+      message: 'Orientation constraint must have selector field',
+      source: 'spec.yaml'
+    }
+
+    it('should render expanded by default with body content visible', () => {
+      render(<ErrorMessageModal systemError={parseError} />)
+
+      const toggle = screen.getByRole('button', { name: /collapse error details/i })
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByText('An error occurred while processing your data.')).toBeInTheDocument()
+      expect(screen.getByText('Orientation constraint must have selector field')).toBeInTheDocument()
+    })
+
+    it('should hide body content when the toggle is clicked', async () => {
+      const user = userEvent.setup()
+      render(<ErrorMessageModal systemError={parseError} />)
+
+      await user.click(screen.getByRole('button', { name: /collapse error details/i }))
+
+      // Modal container and header remain; body content is gone
+      expect(document.getElementById('error-message-modal')).toBeInTheDocument()
+      expect(screen.queryByText('An error occurred while processing your data.')).not.toBeInTheDocument()
+      expect(screen.queryByText('Orientation constraint must have selector field')).not.toBeInTheDocument()
+
+      // Toggle now advertises expand and reports collapsed state
+      expect(screen.getByRole('button', { name: /expand error details/i })).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('should restore body content when toggled again', async () => {
+      const user = userEvent.setup()
+      render(<ErrorMessageModal systemError={parseError} />)
+
+      await user.click(screen.getByRole('button', { name: /collapse error details/i }))
+      expect(screen.queryByText('An error occurred while processing your data.')).not.toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: /expand error details/i }))
+      expect(screen.getByText('An error occurred while processing your data.')).toBeInTheDocument()
+    })
+  })
 })

--- a/tests/iis-reporting-format.test.ts
+++ b/tests/iis-reporting-format.test.ts
@@ -53,9 +53,12 @@ describe('IIS Reporting Format', () => {
         // Should include attributes in the display
         expect(errorMessage).toContain('Person');
         expect(errorMessage).toContain('name: Alice');
-        // Should not show bare IDs when attributes are present
-        expect(errorMessage).not.toContain('atom1');
-        expect(errorMessage).not.toContain('atom2');
+        // Should not show bare IDs when attributes are present.
+        // The id is still carried as a non-visible data-node-id attribute (used to
+        // highlight the diagram node on hover), so strip those before asserting.
+        const visibleText = errorMessage.replace(/\sdata-node-id="[^"]*"/g, '');
+        expect(visibleText).not.toContain('atom1');
+        expect(visibleText).not.toContain('atom2');
     });
 
     it('should truncate long attribute values', () => {

--- a/webcola-demo/react-component-integration.tsx
+++ b/webcola-demo/react-component-integration.tsx
@@ -1061,9 +1061,12 @@ export function mountReplWithVisualization(
  * 
  * @public
  */
-export function mountErrorMessageModal(containerId: string = 'error-messages'): boolean {
+export function mountErrorMessageModal(
+  containerId: string = 'error-messages',
+  graphElementId: string = 'graph-container'
+): boolean {
   const container = document.getElementById(containerId);
-  
+
   if (!container) {
     console.error(`Error Modal: Container '${containerId}' not found`);
     return false;
@@ -1071,7 +1074,7 @@ export function mountErrorMessageModal(containerId: string = 'error-messages'): 
 
   try {
     const root = createRoot(container);
-    root.render(<ErrorMessageContainer errorManager={globalErrorManager} />);
+    root.render(<ErrorMessageContainer errorManager={globalErrorManager} graphElementId={graphElementId} />);
     console.log(`Error Modal mounted to #${containerId}`);
     return true;
   } catch (error) {


### PR DESCRIPTION
## Summary

Error-reporting improvements for #490. Three changes to the error modal + one related follow-up requested in the same thread:

**1. Collapse / minimize the error modal** — the inline error card grows with the number of conflicting constraints and could cover the screen. Added a chevron toggle in the header; collapsing hides the body and shrinks the card to a single header line. Accessible (`aria-expanded`, label/glyph flip between Collapse `▾` / Expand `▸`), defaults to expanded.

**2. Remove the red "unsat" triangle** — deleted the `#error-icon` ⚠️ badge shown on the graph for unsatisfiable layouts (template span, trigger, `show`/`hideErrorIcon`, CSS, dead `isUnsatCore` getter). The modal remains the user-facing error channel; the `unsat` attribute contract is unchanged.

**3. Highlight referenced diagram nodes on hover** (follow-up) — hovering a conflicting constraint now highlights the node(s) it names in the diagram:
- `formatNodeLabel` emits a non-visible `data-node-id` attribute on every node reference, so node identity is recoverable from the rendered HTML without parsing display text (works even in the attributes branch where the bare id is hidden).
- `ErrorMessageModal` / `ErrorMessageContainer` gain an optional `graphElementId` prop. On hover the modal reads `[data-node-id]` from the hovered item and calls the graph's public `highlightNodes()`; on leave, `clearNodeHighlights()`. Mirrors the existing `RelationHighlighter` pattern; no-op when the prop is omitted.
- The node-highlight CSS is broadened to `.error-node.highlighted` so the highlight is visible on the "error node" style shown while the modal is open (solid orange stroke + glow over the dashed red outline).

**Deferred — constraint-table restacking:** every stacking option risks pushing a hover-highlighted correspondence off-screen, defeating the purpose. Left for a follow-up. This PR intentionally does not close the issue.

## Testing
- **vitest:** 56+ passed across the error/constraint suites, including new collapse/expand tests and node-highlight tests (hover → `highlightNodes(ids)`, leave → `clearNodeHighlights`, no-op without `graphElementId`). Updated one `iis-reporting-format` assertion to strip the new `data-node-id` attribute before checking the id isn't shown as visible text.
- **tsc --noEmit:** no new errors (pre-existing baseline unchanged).
- **Manual (json-demo, unsat layout):** `#error-icon` no longer in the DOM; modal toggle collapses/re-expands correctly; the hovered constraint "Alice (id = p1) must be above Bob (id = p2)" exposes `data-node-id` `[p1, p2]`, and `highlightNodes(['p1','p2'])` renders both error-nodes with computed `stroke: rgb(255,149,0)` (orange), cleared on leave.

## Files
- `src/components/ErrorMessageModal/ErrorMessageModal.tsx` / `.css`, `ErrorMessageContainer.tsx` — collapse toggle + node-highlight-on-hover
- `src/layout/constraint-types.ts` — `data-node-id` on node references
- `src/translators/webcola/webcola-cnd-graph.ts` — remove unsat triangle; broaden highlight CSS to error nodes
- `webcola-demo/react-component-integration.tsx` — wire `graphElementId`
- `tests/components/ErrorMessageModal.test.tsx`, `tests/iis-reporting-format.test.ts`

Addresses #490 (concerns 1 & 2 + node-highlight follow-up; table restacking deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)