### PR TITLE
feat(error-reporting): resizable constraint table + auto-scroll correspondence into view

### DIFF
--- a/src/components/ErrorMessageModal/ErrorMessageModal.css
+++ b/src/components/ErrorMessageModal/ErrorMessageModal.css
@@ -25,6 +25,54 @@
     margin-bottom: 1rem;
 }
 
+/*
+ * Two independently-scrolling columns inside one resizable region.
+ * - resize: vertical gives a drag handle to tune height (larger/smaller/taller)
+ * - max-height caps the default so a long conflict list can't cover the screen
+ *   (and is the drag ceiling); min-height is the drag floor
+ * - overflow: hidden is required for `resize`; each column body scrolls itself,
+ *   which is what lets a hovered item stay put while its correspondence in the
+ *   OTHER column scrolls into view
+ */
+.constraint-columns {
+    display: flex;
+    gap: 0;
+    max-height: 45vh;
+    min-height: 5rem;
+    overflow: hidden;
+    resize: vertical;
+}
+
+.constraint-column {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #dee2e6;
+}
+
+/* Collapse the seam between the two adjacent columns */
+.constraint-column + .constraint-column {
+    border-left: none;
+}
+
+.constraint-column-header {
+    flex: 0 0 auto;
+    font-weight: 600;
+    padding: 0.5rem;
+    background: #f8f9fa;
+    border-bottom: 1px solid #dee2e6;
+}
+
+/* The independent per-column scroll container (both axes: wide constraint
+ * text scrolls within the column instead of widening the whole modal). */
+.constraint-column-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+}
+
 .constraint-relationship-table .constraint-item {
     padding: 0.5rem;
     border-bottom: 1px solid #eee;

--- a/src/components/ErrorMessageModal/ErrorMessageModal.tsx
+++ b/src/components/ErrorMessageModal/ErrorMessageModal.tsx
@@ -67,10 +67,27 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
     if (graph && typeof graph.clearNodeHighlights === 'function') graph.clearNodeHighlights();
   };
 
+  /**
+   * Scroll a hovered item's correspondence into view in the *other* column.
+   * The two columns scroll independently, so this reveals the related item
+   * without disturbing the column the cursor is over — hover a source
+   * constraint and the diagram column scrolls to its correspondence.
+   */
+  const scrollRelatedIntoView = (el: HTMLElement, relatedIds: string[]) => {
+    if (relatedIds.length === 0) return;
+    const container = el.closest('.constraint-columns');
+    const target = container?.querySelector(`[data-constraint-id="${relatedIds[0]}"]`) as HTMLElement | null;
+    // Feature-detect: scrollIntoView is absent in jsdom (tests) and some hosts
+    if (target && typeof target.scrollIntoView === 'function') {
+      target.scrollIntoView({ block: 'nearest' });
+    }
+  };
+
   /** Handle mouse enter for constraint highlighting */
   const handleMouseEnter = (e: React.MouseEvent<HTMLElement>, node: ConstraintNode, source: 'source' | 'diagram') => {
     setHighlightState({ ids: [node.id, ...node.relatedIds], source });
     highlightGraphNodesFrom(e.currentTarget);
+    scrollRelatedIntoView(e.currentTarget, node.relatedIds);
   };
 
   /**
@@ -233,46 +250,40 @@ export const ErrorMessageModal: React.FC<ErrorMessageModalProps> = ({ systemErro
         <>
           <p id="hover-instructions">Hover over the conflicting constraints to see the corresponding diagram elements that cannot be visualized. </p>
           <div className="constraint-relationship-table">
-            <table className="table table-bordered">
-              <thead>
-                <tr>
-                  <th>Source Constraints</th>
-                  <th>Diagram Elements</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td className="source-constraints-cell p-0">
-                    {sourceConstraints.map(node => (
-                      <div 
-                        key={node.id}
-                        data-constraint-id={node.id}
-                        className={`constraint-item ${getHighlightClass(node.id)}`}
-                        onMouseEnter={(e) => handleMouseEnter(e, node, 'source')}
-                        onMouseLeave={handleMouseLeave}
-                      >
-                        <code dangerouslySetInnerHTML={{ __html: node.content }}></code>
-                      </div>
-                    ))}
-                  </td>
-                  <td className="diagram-constraints-cell p-0">
-                    <div className="d-flex flex-column h-100">
-                      {diagramConstraints.map(node => (
-                        <div 
-                          key={node.id}
-                          data-constraint-id={node.id}
-                          className={`constraint-item ${getHighlightClass(node.id)}`}
-                          onMouseEnter={(e) => handleMouseEnter(e, node, 'diagram')}
-                          onMouseLeave={handleMouseLeave}
-                        >
-                          <code dangerouslySetInnerHTML={{ __html: node.content }}></code>
-                        </div>
-                      ))}
+            <div className="constraint-columns">
+              <div className="constraint-column">
+                <div className="constraint-column-header">Source Constraints</div>
+                <div className="constraint-column-body source-constraints-cell">
+                  {sourceConstraints.map(node => (
+                    <div
+                      key={node.id}
+                      data-constraint-id={node.id}
+                      className={`constraint-item ${getHighlightClass(node.id)}`}
+                      onMouseEnter={(e) => handleMouseEnter(e, node, 'source')}
+                      onMouseLeave={handleMouseLeave}
+                    >
+                      <code dangerouslySetInnerHTML={{ __html: node.content }}></code>
                     </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                  ))}
+                </div>
+              </div>
+              <div className="constraint-column">
+                <div className="constraint-column-header">Diagram Elements</div>
+                <div className="constraint-column-body diagram-constraints-cell">
+                  {diagramConstraints.map(node => (
+                    <div
+                      key={node.id}
+                      data-constraint-id={node.id}
+                      className={`constraint-item ${getHighlightClass(node.id)}`}
+                      onMouseEnter={(e) => handleMouseEnter(e, node, 'diagram')}
+                      onMouseLeave={handleMouseLeave}
+                    >
+                      <code dangerouslySetInnerHTML={{ __html: node.content }}></code>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
         </>
       )}

--- a/tests/components/ErrorMessageModal.test.tsx
+++ b/tests/components/ErrorMessageModal.test.tsx
@@ -344,4 +344,44 @@ describe('ErrorMessageModal Component', () => {
       }
     })
   })
+
+  describe('Scroll correspondence into view', () => {
+    const errorMessages: ErrorMessages = {
+      conflictingConstraint: 'Node2 is above Node1',
+      conflictingSourceConstraint: 'OrientationConstraint with directions [below] and selector Node2-&gt;Node1',
+      minimalConflictingConstraints: new Map([
+        ['OrientationConstraint with directions [below] and selector Node2-&gt;Node1', ['Node2 is above Node1']],
+        ['OrientationConstraint with directions [directlyRight] and selector ~v', ['Node1 is horizontally aligned with Variable3', 'Node2 is horizontally aligned with Variable3']]
+      ])
+    }
+    const positionalError: SystemError = {
+      type: 'positional-error',
+      messages: errorMessages
+    }
+
+    it('scrolls the related diagram element into view when hovering a source constraint', async () => {
+      const user = userEvent.setup()
+      // jsdom does not implement scrollIntoView; record the element it is called on
+      const scrolledInto: Element[] = []
+      const original = Element.prototype.scrollIntoView
+      Element.prototype.scrollIntoView = function (this: Element) {
+        scrolledInto.push(this)
+      } as typeof Element.prototype.scrollIntoView
+      try {
+        render(<ErrorMessageModal systemError={positionalError} />)
+
+        // source-0 corresponds to diagram-0-0 ("Node2 is above Node1")
+        const sourceConstraint = screen
+          .getByText('OrientationConstraint with directions [below] and selector Node2->Node1')
+          .parentElement!
+        await user.hover(sourceConstraint)
+
+        const relatedDiagram = document.querySelector('[data-constraint-id="diagram-0-0"]')
+        expect(relatedDiagram).not.toBeNull()
+        expect(scrolledInto).toContain(relatedDiagram)
+      } finally {
+        Element.prototype.scrollIntoView = original
+      }
+    })
+  })
 })


### PR DESCRIPTION
Follow-up to #490 / #492. Two usability gaps remained in the positional-conflict error modal (`ErrorMessageModal`), which renders inline above the graph with no scroll container of its own.

## What & why

**1. Resizable, height-capped constraint table.** The shipped collapse toggle is all-or-nothing. The table now:
- caps at `45vh` by default (a long conflict list no longer covers the screen),
- is **resizable** (`resize: vertical`) — drag the handle to tune height, `min-height` floor / `45vh` ceiling,
- scrolls overflow within each column.

The collapse toggle is **kept** (complementary: collapse fully dismisses; resize tunes).

**2. Auto-scroll the correspondence into view.** Hovering a Source Constraint whose Diagram Element sat far down the list left the two un-viewable together. The two lists are now **independently-scrolling columns**, and on hover the *other* column auto-scrolls (`scrollIntoView`, feature-detected) to bring the correspondence into view while the hovered item stays put. Works both directions.

## Implementation
- Split the two-column `<table>` into flex columns (`.constraint-columns` › `.constraint-column` › header + scrollable `.constraint-column-body`). Independent per-column scroll is what makes "see both" possible — a single shared scroll region can't show a top item and a bottom item at once.
- `scrollRelatedIntoView` helper called from `handleMouseEnter`.
- Preserves the existing DOM contract (header labels, `.constraint-item`, `data-constraint-id`, highlight classes), so existing tests are unaffected.

Files: `ErrorMessageModal.tsx`, `ErrorMessageModal.css`, `ErrorMessageModal.test.tsx` (3 files, +138/-39).

## Verification
- **Unit tests:** 15/15 pass (Node 22), incl. a new test asserting the related item is scrolled into view on hover.
- **Typecheck:** holds at the ~80-error baseline, none in changed files.
- **Build:** `build:all` rebuilds the components bundle with the new CSS.
- **Browser (json-demo, long conflict list):**
  - F1 — columns render side-by-side, bounded height, each with its own scrollbar; `resize: vertical` + `overflow: hidden` confirmed via computed style.
  - F2 — hovering the far source constraint scrolled the diagram column `scrollTop 0 → 669`, correspondence fully visible and highlighted, source column unmoved.

## Out of scope
Deferred concern #3 (restacking the table) stays deferred — though this independent-scroll + scroll-into-view mechanism is what would later make a stacked layout safe. No changes to `ErrorStateManager`, the collapse behavior, or the `unsat` attribute contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)