### PR TITLE
feat(style): unified style-system foundation — resolver, edgeStyle, edgeColor/inferredEdge desugar

### DIFF
--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -363,7 +363,64 @@ Hides atoms matching a selector from the visualization. (Can also be used as a d
 
 Directives control visual styling and presentation without affecting layout structure.
 
-### Atom Color Directive
+### Atom Style Directive (atomStyle)
+
+Styles the atoms (nodes) matching a selector. An atom is a composite of an interior **fill**, an outline **border**, and its **label**, so styling uses the shared `fillStyle`, `borderStyle`, and `textStyle` blocks (the same block vocabulary as `edgeStyle`'s `lineStyle`/`textStyle`).
+
+```yaml
+- atomStyle:
+    selector: <unary-selector>   # Optional: which atoms to style (absent = all atoms)
+    fillStyle:                   # Optional: the interior fill (opt-in)
+      color: <color>
+    borderStyle:                 # Optional: the outline
+      color: <color>
+      width: <number>
+    textStyle:                   # Optional: the atom's own (name) label
+      size: <small|normal|large>
+      color: <color>
+```
+
+**Fields:**
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `selector` | ❌ No | string | Unary selector for target atoms; absent styles every atom |
+| `fillStyle.color` | ❌ No | string | CSS color of the node's interior fill (opt-in; the default is an unfilled Tufte look where only stroke + label mark the node) |
+| `borderStyle.color` | ❌ No | string | CSS color of the node's outline |
+| `borderStyle.width` | ❌ No | number | Outline thickness in pixels (must be > 0) |
+| `textStyle.size` | ❌ No | enum | `small`, `normal`, or `large` — *reserved; not yet applied to the node's own label* |
+| `textStyle.color` | ❌ No | string | CSS color of the atom's label |
+
+**Inheritance & conflicts:** rules match atoms through their selector, and a supertype selector already returns subtype atoms — so a `Node` rule and a `RedNode` rule both apply to a `RedNode` atom, their set properties **composing** (gap-fill inheritance up the type hierarchy). Two rules that set the *same* property to *different* values is an error: styles never silently override.
+
+**Examples:**
+
+```yaml
+# Filled, thick-bordered Person nodes with dark-red labels
+- atomStyle:
+    selector: Person
+    fillStyle: { color: '#e0f2ff' }
+    borderStyle: { color: '#0369a1', width: 4 }
+    textStyle: { color: '#b91c1c' }
+
+# Just recolor the outline of error atoms (border-preserving, like atomColor)
+- atomStyle:
+    selector: Error
+    borderStyle: { color: red }
+```
+
+**Migrating from `atomColor`:** `atomColor` (below) is the legacy flat form and still works; its `value` maps onto `borderStyle.color` (so existing diagrams keep their outlines exactly), and you can add a `fillStyle` for a real interior fill:
+
+| `atomColor` | `atomStyle` |
+|---|---|
+| `value` | `borderStyle.color` |
+| `selector` | `selector` |
+
+---
+
+### Atom Color Directive (atomColor) — *legacy*
+
+> **Deprecated:** prefer [`atomStyle`](#atom-style-directive-atomstyle) above. `atomColor` still works and will desugar onto `atomStyle` (`value` → `borderStyle.color`) with a deprecation warning.
 
 Sets the color of atoms matching a selector.
 

--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -394,7 +394,81 @@ Sets the color of atoms matching a selector.
 
 ---
 
-### Edge Style Directive (edgeColor)
+### Edge Style Directive (edgeStyle)
+
+Styles the edges of a field/relation. An edge is a composite of a drawn **line**, a **label**, and behavior flags, so styling is expressed with the shared `lineStyle` and `textStyle` blocks — the same block vocabulary reused by `inferredEdge` and group connectors.
+
+```yaml
+- edgeStyle:
+    field: <field-name>          # Required: relation/field whose edges this styles
+    selector: <unary-selector>   # Optional: match only edges from these source atoms
+    filter: <n-ary-selector>     # Optional: match only these (source, target) tuples
+    lineStyle:                   # Optional: the drawn line
+      color: <color>
+      pattern: <solid|dashed|dotted>
+      weight: <number>
+      highlight: <color>
+    textStyle:                   # Optional: the edge label
+      size: <small|normal|large>
+      color: <color>
+    showLabel: <boolean>         # Optional: show the edge label
+    hidden: <boolean>            # Optional: hide the edge entirely
+```
+
+**Fields:**
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `field` | ✅ Yes | string | Name of the relation |
+| `selector` | ❌ No | string | Unary selector — match only edges whose source atom is selected |
+| `filter` | ❌ No | string | N-ary selector — match only specific (source, target) tuples |
+| `lineStyle.color` | ❌ No | string | CSS color of the line |
+| `lineStyle.pattern` | ❌ No | enum | `solid`, `dashed`, or `dotted` |
+| `lineStyle.weight` | ❌ No | number | Line thickness in pixels (must be > 0) |
+| `lineStyle.highlight` | ❌ No | string | CSS color drawn as a wider, translucent underlay beneath the line |
+| `textStyle.size` | ❌ No | enum | `small`, `normal`, or `large` (relative to the node label) |
+| `textStyle.color` | ❌ No | string | CSS color of the edge label |
+| `showLabel` | ❌ No | boolean | Whether to display the edge label (default `true`) |
+| `hidden` | ❌ No | boolean | Hide the edge entirely (default `false`) |
+
+**Composition & conflicts:** when several `edgeStyle` rules match the same edge, their set properties **compose** — a `lineStyle.color` from one rule and a `textStyle.size` from another combine. Two rules that set the *same* property to *different* values is an error: styles never silently override.
+
+**Examples:**
+
+```yaml
+# Dashed blue 'parent' edges
+- edgeStyle:
+    field: parent
+    lineStyle: { color: blue, pattern: dashed }
+
+# Thicker red edges from Document sources, with small grey labels
+- edgeStyle:
+    field: references
+    selector: Document
+    lineStyle: { color: red, weight: 2 }
+    textStyle: { size: small, color: '#666' }
+
+# Yellow highlight glow under black edges
+- edgeStyle:
+    field: critical_path
+    lineStyle: { color: black, highlight: "#ffeb3b" }
+```
+
+**Migrating from `edgeColor`:** `edgeColor` (below) is the legacy flat form and still works; it maps onto `edgeStyle` field-for-field:
+
+| `edgeColor` | `edgeStyle` |
+|---|---|
+| `value` | `lineStyle.color` |
+| `style` | `lineStyle.pattern` |
+| `weight` | `lineStyle.weight` |
+| `highlight` | `lineStyle.highlight` |
+| `showLabel` / `hidden` | `showLabel` / `hidden` |
+
+---
+
+### Edge Color Directive (edgeColor) — *legacy*
+
+> **Deprecated:** prefer [`edgeStyle`](#edge-style-directive-edgestyle) above. `edgeColor` still works and will desugar onto `edgeStyle` with a deprecation warning.
 
 Customizes the appearance of edges for a specific field/relation.
 
@@ -690,28 +764,36 @@ Hides atoms matching a selector from the visualization.
 
 ### Inferred Edge Directive
 
-Creates visual edges based on a selector expression (edges that don't exist in the data).
+Creates visual edges based on a selector expression (edges that don't exist in the data). The structural `name` + `selector` say *which* edge to draw; its appearance uses the shared `lineStyle` / `textStyle` blocks (the same vocabulary as `edgeStyle`).
 
 ```yaml
 - inferredEdge:
-    name: <edge-label>           # Required: Label for the inferred edge
-    selector: <binary-selector>  # Required: Selector returning pairs to connect
-    color: <color>               # Optional: Edge color
-    style: <line-style>          # Optional: Line style
-    weight: <number>             # Optional: Line thickness
-    highlight: <color>           # Optional: Highlight color (underlay)
+    name: <edge-label>           # Required: label for the inferred edge
+    selector: <binary-selector>  # Required: selector returning pairs to connect
+    lineStyle:                   # Optional: the drawn line
+      color: <color>
+      pattern: <solid|dashed|dotted>
+      weight: <number>
+      highlight: <color>
+    textStyle:                   # Optional: the edge label
+      size: <small|normal|large>
+      color: <color>
 ```
 
 **Fields:**
 
-| Field | Required | Type | Default | Description |
-|-------|----------|------|---------|-------------|
-| `name` | ✅ Yes | string | - | Label displayed on the edge |
-| `selector` | ✅ Yes | string | - | Binary selector returning (source, target) pairs |
-| `color` | ❌ No | string | `#000000` | CSS color value |
-| `style` | ❌ No | string | `solid` | `solid`, `dashed`, or `dotted` |
-| `weight` | ❌ No | number | - | Line thickness in pixels |
-| `highlight` | ❌ No | string | - | CSS color drawn as a wider, translucent underlay beneath the edge. Omit for no highlight. |
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | ✅ Yes | string | Label displayed on the edge |
+| `selector` | ✅ Yes | string | Binary selector returning (source, target) pairs |
+| `lineStyle.color` | ❌ No | string | Line color (default `#000000`) |
+| `lineStyle.pattern` | ❌ No | enum | `solid`, `dashed`, or `dotted` |
+| `lineStyle.weight` | ❌ No | number | Line thickness in pixels |
+| `lineStyle.highlight` | ❌ No | string | CSS color drawn as a wider, translucent underlay beneath the line |
+| `textStyle.size` | ❌ No | enum | `small`, `normal`, or `large` |
+| `textStyle.color` | ❌ No | string | Edge-label color |
+
+> **Legacy:** the flat inline `color` / `style` / `weight` / `highlight` keys still parse (`style`→`pattern`) but are deprecated — use the `lineStyle` block. Mixing forms emits a warning.
 
 **Examples:**
 

--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -157,6 +157,21 @@ Groups elements based on a selector expression.
     selector: <n-ary-selector>   # Required: Selector returning elements to group
     name: <group-name>           # Required: Display name for the group
     addEdge: <direction>         # Optional: none | togroup | fromgroup (default none)
+    textStyle:                   # Optional: style the group's own label
+      color: <color>
+```
+
+A group has two style surfaces: its **own label** (top-level `textStyle`) and — when `addEdge` draws a connector — that **connector**, which is an edge and so takes the shared `lineStyle` / `textStyle` blocks. To style the connector, give `addEdge` in block form:
+
+```yaml
+- group:
+    selector: <n-ary-selector>
+    name: <group-name>
+    addEdge:                     # Block form styles the connector edge
+      points: <none|togroup|fromgroup>
+      lineStyle: { color: <color>, pattern: <solid|dashed|dotted>, weight: <number>, highlight: <color> }
+      textStyle: { size: <small|normal|large>, color: <color> }   # the connector's label
+    textStyle: { color: <color> }                                 # the group's own label
 ```
 
 **Fields:**
@@ -165,7 +180,9 @@ Groups elements based on a selector expression.
 |-------|----------|------|---------|-------------|
 | `selector` | ✅ Yes | string | - | Selector returning atoms to include in group |
 | `name` | ✅ Yes | string | - | Display name shown on the group box |
-| `addEdge` | ❌ No | `none` \| `togroup` \| `fromgroup` | `none` | Draw an edge between the group key and the group. `togroup` points key → group; `fromgroup` points group → key; `none` draws nothing. (Legacy `true` is accepted and treated as `togroup`.) |
+| `addEdge` | ❌ No | direction *or* block | `none` | The connector between the group key and the group. As a bare string it is just the direction (`none` / `togroup` / `fromgroup`; legacy `true` = `togroup`). As a **block** it also styles the connector: `points` (the direction) plus `lineStyle` and `textStyle` (same blocks as `edgeStyle`). `togroup` points key → group; `fromgroup` points group → key. |
+| `textStyle.color` | ❌ No | string | - | Color of the group's own label |
+| `textStyle.size` | ❌ No | enum | - | `small` / `normal` / `large` — *reserved; group labels currently auto-fit their box* |
 
 For a binary selector with tuples `(a, b), (a, c), (a, d)`, the group is keyed by `a` and contains `{b, c, d}`. `addEdge: togroup` draws an edge from `a` into that group; `addEdge: fromgroup` draws it from the group back to `a`.
 
@@ -182,6 +199,16 @@ For a binary selector with tuples `(a, b), (a, c), (a, d)`, the group is keyed b
     selector: Department.employees
     name: "Department"
     addEdge: togroup
+
+# Styled: a dashed teal connector with a red label, and a purple group label
+- group:
+    selector: Department.employees
+    name: "Department"
+    addEdge:
+      points: togroup
+      lineStyle: { color: "#0aa", pattern: dashed, weight: 3 }
+      textStyle: { color: "#a00" }
+    textStyle: { color: "#7c3aed" }
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/site/constraints.md
+++ b/site/constraints.md
@@ -185,13 +185,28 @@ Draws a visual bounding box around nodes matched by a selector.
     selector: <n-ary-selector>   # Required
     name: <group-name>           # Required
     addEdge: <direction>         # Optional: none | togroup | fromgroup (default: none)
+    textStyle: { color: <color> }  # Optional: style the group's own label
+```
+
+A group has two style surfaces: its **own label** (top-level `textStyle`) and — when `addEdge` draws a connector — that **connector**, which is an edge and takes the shared `lineStyle` / `textStyle` blocks. Give `addEdge` in block form to style the connector:
+
+```yaml
+- group:
+    selector: <n-ary-selector>
+    name: <group-name>
+    addEdge:
+      points: togroup
+      lineStyle: { color: <color>, pattern: <solid|dashed|dotted>, weight: <number> }
+      textStyle: { color: <color> }   # the connector's label
+    textStyle: { color: <color> }      # the group's own label
 ```
 
 | Field | Required | Type | Default | Description |
 |-------|----------|------|---------|-------------|
 | `selector` | Yes | string | — | Selector returning atoms to include in the group. This could be a unary or binary selector. If a binary selector, the first element is a group key, while the second element is added to groups associated with that key. |
 | `name` | Yes | string | — | Display name shown on the group box |
-| `addEdge` | No | `none` \| `togroup` \| `fromgroup` | `none` | Draw an edge between the group key and the group. For a binary selector with tuples `(a, b), (a, c), (a, d)` the group is keyed by `a` and contains `{b, c, d}`: `togroup` draws an edge from `a` into the group, `fromgroup` draws it from the group back to `a`, and `none` draws nothing. (Legacy `true` is accepted and treated as `togroup`.) |
+| `addEdge` | No | direction *or* block | `none` | The connector between the group key and the group. As a bare string, just the direction (`none` / `togroup` / `fromgroup`; legacy `true` = `togroup`). As a block, also styles the connector (`points` + `lineStyle` + `textStyle`). For tuples `(a, b), (a, c), (a, d)` the group is keyed by `a`: `togroup` draws `a` → group, `fromgroup` draws group → `a`. |
+| `textStyle.color` | No | string | — | Color of the group's own label (`size` is reserved — group labels auto-fit) |
 
 ### Examples
 
@@ -200,6 +215,16 @@ Draws a visual bounding box around nodes matched by a selector.
 - group:
     selector: Team.members
     name: "Team Members"
+
+# Styled: dashed teal connector with a red label, purple group label
+- group:
+    selector: Team.members
+    name: "Team Members"
+    addEdge:
+      points: togroup
+      lineStyle: { color: "#0aa", pattern: dashed, weight: 3 }
+      textStyle: { color: "#a00" }
+    textStyle: { color: "#7c3aed" }
 ```
 
 <div class="spytial-diagram" data-height="360" data-caption="Live: Team.members draws a bounding box around the three members.">

--- a/site/directives.md
+++ b/site/directives.md
@@ -69,16 +69,21 @@ directives:
 
 ## Edge Styling
 
-Customizes the appearance of edges for a specific field (relation). Use `edgeColor` in the directives section.
+Customizes the appearance of edges for a specific field (relation). Use `edgeStyle` in the directives section. An edge has a **line** and a **label**, styled with the shared `lineStyle` and `textStyle` blocks — the same blocks `inferredEdge` and group connectors reuse.
 
 ```yaml
-- edgeColor:
+- edgeStyle:
     field: <field-name>          # Required
-    value: <color>               # Required
-    selector: <unary-selector>   # Optional
-    filter: <n-ary-selector>     # Optional
-    style: <line-style>          # Optional (default: solid)
-    weight: <number>             # Optional
+    selector: <unary-selector>   # Optional: match edges from these source atoms
+    filter: <n-ary-selector>     # Optional: match specific tuples
+    lineStyle:                   # Optional: the drawn line
+      color: <color>
+      pattern: <solid|dashed|dotted>
+      weight: <number>
+      highlight: <color>
+    textStyle:                   # Optional: the edge label
+      size: <small|normal|large>
+      color: <color>
     showLabel: <boolean>         # Optional (default: true)
     hidden: <boolean>            # Optional (default: false)
 ```
@@ -86,13 +91,20 @@ Customizes the appearance of edges for a specific field (relation). Use `edgeCol
 | Field | Required | Type | Default | Description |
 |-------|----------|------|---------|-------------|
 | `field` | Yes | string | — | Name of the relation |
-| `value` | Yes | string | — | CSS color value |
-| `selector` | No | string | — | Filter by source atom type |
-| `filter` | No | string | — | Filter specific tuples |
-| `style` | No | string | `solid` | `solid`, `dashed`, or `dotted` |
-| `weight` | No | number | — | Line thickness in pixels |
+| `selector` | No | string | — | Match by source atom |
+| `filter` | No | string | — | Match specific tuples |
+| `lineStyle.color` | No | string | — | Line color |
+| `lineStyle.pattern` | No | enum | `solid` | `solid`, `dashed`, or `dotted` |
+| `lineStyle.weight` | No | number | — | Line thickness in pixels (> 0) |
+| `lineStyle.highlight` | No | string | — | Translucent underlay color |
+| `textStyle.size` | No | enum | `normal` | `small`, `normal`, or `large` |
+| `textStyle.color` | No | string | — | Edge-label color |
 | `showLabel` | No | boolean | `true` | Whether to display the edge label |
 | `hidden` | No | boolean | `false` | Hide the edge entirely |
+
+When several `edgeStyle` rules match one edge their set properties **compose**; setting the *same* property two different ways is an error — no silent override.
+
+> **`edgeColor` is the legacy form** and still works: `value`→`lineStyle.color`, `style`→`lineStyle.pattern`, `weight`→`lineStyle.weight`, `highlight`→`lineStyle.highlight`. It will desugar to `edgeStyle` with a deprecation warning. The scoping and example snippets below use `edgeColor`; swap the flat keys for the blocks above to get the `edgeStyle` form.
 
 ### Scoping with `selector` and `filter`
 

--- a/site/directives.md
+++ b/site/directives.md
@@ -4,40 +4,50 @@ Directives control the **visual presentation** of your graph — colors, icons, 
 
 ---
 
-## Atom Color
+## Atom Styling
 
-Sets the background color of nodes matching a selector.
+Styles the atoms (nodes) matching a selector. An atom has an interior **fill**, an outline **border**, and a **label**, styled with the shared `fillStyle`, `borderStyle`, and `textStyle` blocks — the same block vocabulary `edgeStyle` uses for lines and labels. Use `atomStyle` in the directives section.
 
 ```yaml
-- atomColor:
-    selector: <unary-selector>   # Required
-    value: <color>               # Required
+- atomStyle:
+    selector: <unary-selector>                        # Optional (absent = all atoms)
+    fillStyle:   { color: <color> }                   # the interior fill (opt-in)
+    borderStyle: { color: <color>, width: <number> }  # the outline
+    textStyle:   { size: <small|normal|large>, color: <color> }  # the atom's label
 ```
 
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
-| `selector` | Yes | string | Unary selector for target atoms |
-| `value` | Yes | string | Any CSS color value |
+| `selector` | No | string | Unary selector for target atoms; absent styles every atom |
+| `fillStyle.color` | No | string | Interior fill color (opt-in; the default is unfilled) |
+| `borderStyle.color` | No | string | Outline color |
+| `borderStyle.width` | No | number | Outline thickness in px (must be > 0) |
+| `textStyle.color` | No | string | Label color |
+| `textStyle.size` | No | enum | `small`/`normal`/`large` — *reserved; not yet applied to the node's own label* |
 
 You can use hex codes, named colors, `rgb()`, `hsl()`, etc.
+
+When several `atomStyle` rules match one atom their set properties **compose**; because a supertype selector already returns subtype atoms, a rule on a supertype and a rule on a subtype both apply (inheritance up the type hierarchy). Setting the *same* property two different ways is an error — no silent override.
+
+> **`atomColor` is the legacy form** and still works: `value`→`borderStyle.color`, so a node keeps its outline exactly as before. It desugars to `atomStyle` with a deprecation warning. Add a `fillStyle` to give a node a real interior fill.
 
 ### Examples
 
 ```yaml
-- atomColor:
+# Filled, thick-bordered Person nodes with dark-red labels
+- atomStyle:
     selector: Person
-    value: "#4a90d9"
+    fillStyle:   { color: "#e0f2ff" }
+    borderStyle: { color: "#0369a1", width: 4 }
+    textStyle:   { color: "#b91c1c" }
 
-- atomColor:
+# Recolor just the outline (border-preserving, like atomColor)
+- atomStyle:
     selector: Error
-    value: red
-
-- atomColor:
-    selector: Warning
-    value: "rgb(255, 165, 0)"
+    borderStyle: { color: red }
 ```
 
-<div class="spytial-diagram" data-height="320" data-caption="Live: each type gets its own atomColor — Person blue, Error red, Warning orange.">
+<div class="spytial-diagram" data-height="320" data-caption="Live: each type gets its own atomStyle — Person filled blue, Error red-bordered, Warning amber fill.">
 <template class="data">
 {
   "atoms": [
@@ -59,9 +69,9 @@ You can use hex codes, named colors, `rgb()`, `hsl()`, etc.
 </template>
 <template class="spec">
 directives:
-  - atomColor: { selector: Person,  value: "#4a90d9" }
-  - atomColor: { selector: Error,   value: "red" }
-  - atomColor: { selector: Warning, value: "rgb(255, 165, 0)" }
+  - atomStyle: { selector: Person,  fillStyle: { color: "#e0f2ff" }, borderStyle: { color: "#4a90d9", width: 3 } }
+  - atomStyle: { selector: Error,   borderStyle: { color: "red", width: 3 } }
+  - atomStyle: { selector: Warning, fillStyle: { color: "rgb(255, 236, 179)" } }
 </template>
 </div>
 

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -2,6 +2,7 @@ import { Group } from "webcola";
 import { RelativeOrientationConstraint, CyclicOrientationConstraint, AlignConstraint, GroupByField, GroupBySelector, RelativeDirection } from "./layoutspec";
 import { EdgeStyle } from "./edge-style";
 import { AttrTextSize } from "./text-extent";
+import type { TextStyle } from "./style/text-style";
 
 export interface LayoutGroup {
     // The name of the group
@@ -96,6 +97,8 @@ export interface LayoutEdge {
     hidden?: boolean;
     /** Highlight color rendered as a wider underlay beneath the edge. Undefined = no highlight. */
     highlight?: string;
+    /** Optional label styling (size / color), applied to the edge's label text. */
+    textStyle?: TextStyle;
     /**
      * For group edges (_g_ prefix), the name of the group this edge was created for.
      * Matches `group.id` in the WebCola translator so routing can look up the group

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -51,6 +51,11 @@ export enum ColorSource {
 export interface LayoutNode {
     id: string;
     label: string;
+    /**
+     * The node's border/outline color. Historically the node's single "color"
+     * (from `atomColor`/`color`), which the renderer draws as the rectangle
+     * stroke; `atomStyle.borderStyle.color` now feeds it too.
+     */
     color : string;
     /**
      * Provenance of `color` (see {@link ColorSource}). Lets the renderer retune
@@ -58,6 +63,24 @@ export interface LayoutNode {
      * colors untouched. Absent is treated as {@link ColorSource.DefaultPalette}.
      */
     colorSource?: ColorSource;
+    /**
+     * Interior fill of the node's rectangle, from `atomStyle.fillStyle.color`.
+     * Absent = the renderer's default (a Tufte canvas-matched fill, so only the
+     * stroke + label mark the node). A real fill is opt-in.
+     */
+    fillColor?: string;
+    /**
+     * Border/stroke width in px, from `atomStyle.borderStyle.width`. Absent = the
+     * renderer's default node stroke width.
+     */
+    borderWidth?: number;
+    /**
+     * Styling for the node's main (name) label, from `atomStyle.textStyle`.
+     * Absent = default. NOTE: only `color` is consumed today; `size` is deferred
+     * because the box sizer (estimateLabelBox) fixes the main label at
+     * MAIN_LABEL_FONT_SIZE — changing it must also re-flow the box.
+     */
+    textStyle?: TextStyle;
     groups?: string[];
     attributes?: Record<string, string[]>;
     /**

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -17,6 +17,10 @@ export interface LayoutGroup {
     // Show label
     showLabel : boolean;
 
+    // Styling for the group's own label, from the group directive's `textStyle`.
+    // Only `color` is consumed today; `size` is deferred (group labels auto-fit).
+    labelTextStyle?: TextStyle;
+
     // The source constraint that created this group (GroupByField or GroupBySelector)
     sourceConstraint?: GroupByField | GroupBySelector;
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -2443,6 +2443,9 @@ export class LayoutInstance {
             let weight = styled.lineStyle?.weight ?? this.getEdgeWeight(relName, dirSource, dirTarget, edgeId);
             let showLabel = styled.showLabel ?? this.getEdgeShowLabel(relName, dirSource, dirTarget, edgeId);
             let highlight = styled.lineStyle?.highlight ?? this.getEdgeHighlight(relName, dirSource, dirTarget, edgeId);
+            // Edge-label styling: inferred edges carry their own textStyle; otherwise
+            // it comes from the resolved edgeStyle (edgeColor has no label styling).
+            let textStyle = this.getInferredEdgeDirective(edgeId)?.textStyle ?? styled.textStyle;
 
             // Skip edges with missing source or target nodes
             if (!source || !target || !edgeId) {
@@ -2460,6 +2463,7 @@ export class LayoutInstance {
                 weight: weight,
                 showLabel: showLabel,
                 highlight: highlight,
+                textStyle: textStyle,
                 // For group edges the graphlib edge label IS the group name (see constructGroupEdgeID).
                 // Carry it forward so the renderer can look up the group directly by ID
                 // without re-parsing the edge ID string or matching fragile leaf indices.

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -22,9 +22,10 @@ import {
     AtomHidingDirective
 } from './layoutspec';
 import { resolveEdgeStyle } from './style/edge-style-spec';
-import type { EdgeStyleSpec } from './style/edge-style-spec';
+import type { EdgeStyleSpec, LineStyle } from './style/edge-style-spec';
 import { resolveAtomStyle } from './style/atom-style-spec';
 import type { AtomStyleRule, AtomStyleSpec } from './style/atom-style-spec';
+import type { TextStyle } from './style/text-style';
 
 
 import IEvaluator from '../evaluators/interfaces';
@@ -668,6 +669,7 @@ export class LayoutInstance {
                             nodeIds: [addToGroup],
                             keyNodeId: groupOn,
                             showLabel: !gc.negated,
+                            labelTextStyle: gc.labelTextStyle,
                             sourceConstraint: gc,
                             negated: gc.negated
                         };
@@ -711,6 +713,7 @@ export class LayoutInstance {
                     nodeIds: selectedElements,
                     keyNodeId: keyNode, //// TODO: I think introducing this random keynode could be a problem. Not sure why or when though.
                     showLabel: !gc.negated,
+                    labelTextStyle: gc.labelTextStyle,
                     sourceConstraint: gc,
                     negated: gc.negated
                 };
@@ -2423,8 +2426,19 @@ export class LayoutInstance {
         // of which way round the underlying graphlib edge was created (the key is
         // the source for 'togroup', the target for 'fromgroup').
         const keyNodeByGroupName = new Map<string, string>();
+        // Map each group's name → the connector styling authored on its
+        // `addEdge` block (the connector is an edge, so it carries a lineStyle +
+        // textStyle). Sourced from the GroupBySelector that created the group.
+        const connectorStyleByGroupName = new Map<string, { lineStyle?: LineStyle, textStyle?: TextStyle }>();
         for (const grp of groups) {
             if (grp.keyNodeId != null) keyNodeByGroupName.set(grp.name, grp.keyNodeId);
+            const src = grp.sourceConstraint;
+            if (src instanceof GroupBySelector && (src.connectorLineStyle || src.connectorTextStyle)) {
+                connectorStyleByGroupName.set(grp.name, {
+                    lineStyle: src.connectorLineStyle,
+                    textStyle: src.connectorTextStyle,
+                });
+            }
         }
 
         return g.edges().map((edge) => {
@@ -2447,17 +2461,22 @@ export class LayoutInstance {
             const dirSource = groupKey !== undefined ? groupKey : edge.v;
             const dirTarget = groupKey !== undefined ? (groupKey === edge.v ? edge.w : edge.v) : edge.w;
 
+            // A group connector edge (`_g_`) is styled by its group's `addEdge`
+            // block; that authored style wins over any incidental edgeStyle match.
+            const connStyle = isGroupEdge ? connectorStyleByGroupName.get(edgeLabel) : undefined;
+            const connLine = connStyle?.lineStyle;
+
             // edgeStyle (resolver-based) takes precedence per-property; whatever it
             // leaves unset falls back to the legacy inferredEdge/edgeColor path.
             const styled = this.resolveEdgeStyleForEdge(relName, dirSource, dirTarget);
-            let color = styled.lineStyle?.color ?? this.getEdgeColor(relName, dirSource, dirTarget, edgeId);
-            let style = styled.lineStyle?.pattern ?? this.getEdgeStyle(relName, dirSource, dirTarget, edgeId);
-            let weight = styled.lineStyle?.weight ?? this.getEdgeWeight(relName, dirSource, dirTarget, edgeId);
+            let color = connLine?.color ?? styled.lineStyle?.color ?? this.getEdgeColor(relName, dirSource, dirTarget, edgeId);
+            let style = connLine?.pattern ?? styled.lineStyle?.pattern ?? this.getEdgeStyle(relName, dirSource, dirTarget, edgeId);
+            let weight = connLine?.weight ?? styled.lineStyle?.weight ?? this.getEdgeWeight(relName, dirSource, dirTarget, edgeId);
             let showLabel = styled.showLabel ?? this.getEdgeShowLabel(relName, dirSource, dirTarget, edgeId);
-            let highlight = styled.lineStyle?.highlight ?? this.getEdgeHighlight(relName, dirSource, dirTarget, edgeId);
-            // Edge-label styling: inferred edges carry their own textStyle; otherwise
-            // it comes from the resolved edgeStyle (edgeColor has no label styling).
-            let textStyle = this.getInferredEdgeDirective(edgeId)?.textStyle ?? styled.textStyle;
+            let highlight = connLine?.highlight ?? styled.lineStyle?.highlight ?? this.getEdgeHighlight(relName, dirSource, dirTarget, edgeId);
+            // Edge-label styling: a group connector's own textStyle wins, then an
+            // inferred edge's, then the resolved edgeStyle (edgeColor has none).
+            let textStyle = connStyle?.textStyle ?? this.getInferredEdgeDirective(edgeId)?.textStyle ?? styled.textStyle;
 
             // Skip edges with missing source or target nodes
             if (!source || !target || !edgeId) {

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -23,6 +23,8 @@ import {
 } from './layoutspec';
 import { resolveEdgeStyle } from './style/edge-style-spec';
 import type { EdgeStyleSpec } from './style/edge-style-spec';
+import { resolveAtomStyle } from './style/atom-style-spec';
+import type { AtomStyleRule, AtomStyleSpec } from './style/atom-style-spec';
 
 
 import IEvaluator from '../evaluators/interfaces';
@@ -1196,7 +1198,10 @@ export class LayoutInstance {
 
         // Recompute visual maps after graph mutations (inferred edges / node removal)
         let nodeIconMap = this.getNodeIconMap(g);
-        let { colorMap: nodeColorMap, explicitlyColored } = this.getNodeColorMap(g, ai);
+        // Resolve atomStyle once: it feeds both the border color (via the color
+        // map) and the node's fill / border-width / label styling below.
+        let atomStyleMap = this.getAtomStyleMap(g, ai);
+        let { colorMap: nodeColorMap, explicitlyColored } = this.getNodeColorMap(g, ai, atomStyleMap);
 
         // Compute the display strings once — single source of truth for "what's
         // drawn inside the box" so the box sizer (getNodeSizeMap) and the
@@ -1246,12 +1251,19 @@ export class LayoutInstance {
                 nodeLabels = atom.labels;
             }
 
+            // Fill / border-width / label styling from the resolved atomStyle
+            // (border *color* already flowed through nodeColorMap → color above).
+            const atomStyle = atomStyleMap[nodeId];
+
             return {
                 id: nodeId,
                 label: label,
                 name: label,
                 color: color,
                 colorSource: colorSource,
+                fillColor: atomStyle?.fillStyle?.color,
+                borderWidth: atomStyle?.borderStyle?.width,
+                textStyle: atomStyle?.textStyle,
                 groups: nodeGroups,
                 attributes: nodeAttributes,
                 attributeSizes: nodeAttributeSizes,
@@ -2649,50 +2661,91 @@ export class LayoutInstance {
 
 
     /**
-     * Builds the node→color map and records which nodes were colored by an
-     * explicit user `color` directive (vs. the default type palette / black
-     * fallback). The renderer uses `explicitlyColored` to decide which colors
-     * may be retuned for a themed canvas and which must be preserved as chosen.
+     * Resolve every atom's `atomStyle` into one concrete style. Each rule's
+     * selector is evaluated to the atoms it matches (absent selector = all
+     * atoms), inverting to a per-atom list of contributing rules; each atom's
+     * rules are then folded through the shared resolver. Because a supertype
+     * selector already returns subtype atoms, gap-fill inheritance up the type
+     * ancestry and the no-silent-override collision both fall out of that fold —
+     * a genuine leaf disagreement throws {@link StyleCollisionError} (the 3.0
+     * contract, surfaced like the old color conflict). Only atoms with at least
+     * one matching rule appear in the map. Legacy `atomColor` desugars into these
+     * rules upstream (border-preserving: value→borderStyle.color).
      */
-    private getNodeColorMap(g: Graph, a: IDataInstance): { colorMap: Record<string, string>, explicitlyColored: Set<string> } {
+    private getAtomStyleMap(g: Graph, a: IDataInstance): Record<string, AtomStyleSpec> {
+        const rules = this._layoutSpec.directives.atomStyles;
+        const styleMap: Record<string, AtomStyleSpec> = {};
+        if (rules.length === 0) return styleMap;
+
+        const allNodeIds = [...g.nodes()];
+        const allNodeIdSet = new Set(allNodeIds);
+        const rulesByNode: Record<string, AtomStyleRule[]> = {};
+
+        rules.forEach((rule) => {
+            let matched: string[];
+            if (!rule.selector) {
+                matched = allNodeIds; // no selector → applies to every atom
+            } else {
+                try {
+                    const selectorRes = this.evaluator.evaluate(rule.selector, { instanceIndex: this.instanceNum });
+                    if (!this.checkSelectorArity(selectorRes, rule.selector, 'unary', 'atomStyle selector')) {
+                        return; // Skip — binary selector in unary position
+                    }
+                    matched = selectorRes.selectedAtoms();
+                } catch (error) {
+                    this.recordSelectorError(rule.selector, 'atomStyle selector', error);
+                    return; // Skip this rule
+                }
+            }
+            matched.forEach((nodeId) => {
+                // Selectors can name atoms that aren't graph nodes (e.g. hidden);
+                // only style atoms actually being laid out.
+                if (!allNodeIdSet.has(nodeId)) return;
+                if (!rulesByNode[nodeId]) rulesByNode[nodeId] = [];
+                rulesByNode[nodeId].push(rule);
+            });
+        });
+
+        for (const nodeId of allNodeIds) {
+            const nodeRules = rulesByNode[nodeId];
+            if (!nodeRules || nodeRules.length === 0) continue;
+            // Throws StyleCollisionError on a genuine leaf disagreement.
+            styleMap[nodeId] = resolveAtomStyle(nodeRules, `atom "${nodeId}"`);
+        }
+
+        return styleMap;
+    }
+
+    /**
+     * Builds the node→color map (the border/outline color) and records which
+     * nodes were colored by an explicit directive (vs. the default type palette /
+     * black fallback). The renderer uses `explicitlyColored` to decide which
+     * colors may be retuned for a themed canvas and which must be preserved.
+     *
+     * The border color comes from the resolved `atomStyle` (`borderStyle.color`)
+     * — which legacy `atomColor` desugars into — so this reads `atomStyleMap`
+     * rather than re-walking directives. Collision detection lives in the
+     * resolver (a leaf disagreement already threw in {@link getAtomStyleMap}).
+     */
+    private getNodeColorMap(g: Graph, a: IDataInstance, atomStyleMap: Record<string, AtomStyleSpec>): { colorMap: Record<string, string>, explicitlyColored: Set<string> } {
         let nodeColorMap: Record<string, string> = {};
         let explicitlyColored = new Set<string>();
 
         // Start by getting the default signature colors
         let sigColors = this.getSigColors(a);
 
-        // Apply color directives first
-        let colorDirectives = this._layoutSpec.directives.atomColors;
-        colorDirectives.forEach((colorDirective) => {
-            let selected: string[];
-            try {
-                const selectorRes = this.evaluator.evaluate(colorDirective.selector, { instanceIndex: this.instanceNum });
-                if (!this.checkSelectorArity(selectorRes, colorDirective.selector, 'unary', 'color selector')) {
-                    return; // Skip — binary selector in unary position
-                }
-                selected = selectorRes.selectedAtoms();
-            } catch (error) {
-                this.recordSelectorError(colorDirective.selector, 'color selector', error);
-                return; // Skip this color directive
-            }
-            let color = colorDirective.color;
+        let graphNodes = [...g.nodes()];
 
-            selected.forEach((nodeId) => {
-                if (nodeColorMap[nodeId]) {
-                    const existingColor = nodeColorMap[nodeId];
-                    if (existingColor !== color) {
-                        throw new Error(
-                            `Color Conflict: "${nodeId}" cannot have multiple colors: ${existingColor}, ${color}.`
-                        );
-                    }
-                }
-                nodeColorMap[nodeId] = color;
+        // A resolved borderStyle.color is the node's explicit outline color.
+        graphNodes.forEach((nodeId) => {
+            const borderColor = atomStyleMap[nodeId]?.borderStyle?.color;
+            if (borderColor) {
+                nodeColorMap[nodeId] = borderColor;
                 explicitlyColored.add(nodeId);
-            });
+            }
         });
 
         // Set default colors for nodes that do not have a color set
-        let graphNodes = [...g.nodes()];
         graphNodes.forEach((nodeId) => {
             if (!nodeColorMap[nodeId]) {
                 let mostSpecificType = this.getMostSpecificType(nodeId, a);

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -21,6 +21,8 @@ import {
     EdgeColorDirective, InferredEdgeDirective, TagDirective,
     AtomHidingDirective
 } from './layoutspec';
+import { resolveEdgeStyle } from './style/edge-style-spec';
+import type { EdgeStyleSpec } from './style/edge-style-spec';
 
 
 import IEvaluator from '../evaluators/interfaces';
@@ -545,10 +547,10 @@ export class LayoutInstance {
             }
         }
         
-        // Also check EdgeStyle directives with hidden: true
+        // Also check edgeStyle rules (including desugared edgeColor) with hidden: true
         if (sourceAtom && targetAtom) {
-            const edgeDirective = this.findEdgeDirective(fieldId, sourceAtom, targetAtom);
-            if (edgeDirective?.hidden === true) {
+            const styled = this.resolveEdgeStyleForEdge(fieldId, sourceAtom, targetAtom);
+            if (styled.hidden === true) {
                 return true;
             }
         }
@@ -2433,11 +2435,14 @@ export class LayoutInstance {
             const dirSource = groupKey !== undefined ? groupKey : edge.v;
             const dirTarget = groupKey !== undefined ? (groupKey === edge.v ? edge.w : edge.v) : edge.w;
 
-            let color = this.getEdgeColor(relName, dirSource, dirTarget, edgeId);
-            let style = this.getEdgeStyle(relName, dirSource, dirTarget, edgeId);
-            let weight = this.getEdgeWeight(relName, dirSource, dirTarget, edgeId);
-            let showLabel = this.getEdgeShowLabel(relName, dirSource, dirTarget, edgeId);
-            let highlight = this.getEdgeHighlight(relName, dirSource, dirTarget, edgeId);
+            // edgeStyle (resolver-based) takes precedence per-property; whatever it
+            // leaves unset falls back to the legacy inferredEdge/edgeColor path.
+            const styled = this.resolveEdgeStyleForEdge(relName, dirSource, dirTarget);
+            let color = styled.lineStyle?.color ?? this.getEdgeColor(relName, dirSource, dirTarget, edgeId);
+            let style = styled.lineStyle?.pattern ?? this.getEdgeStyle(relName, dirSource, dirTarget, edgeId);
+            let weight = styled.lineStyle?.weight ?? this.getEdgeWeight(relName, dirSource, dirTarget, edgeId);
+            let showLabel = styled.showLabel ?? this.getEdgeShowLabel(relName, dirSource, dirTarget, edgeId);
+            let highlight = styled.lineStyle?.highlight ?? this.getEdgeHighlight(relName, dirSource, dirTarget, edgeId);
 
             // Skip edges with missing source or target nodes
             if (!source || !target || !edgeId) {
@@ -2817,6 +2822,67 @@ export class LayoutInstance {
 
         const inferredEdges = this._layoutSpec.directives.inferredEdges;
         return inferredEdges.find((directive) => edgeId.includes(`${inferredEdgePrefix}<:${directive.name}`));
+    }
+
+    /**
+     * Whether an edge directive (edgeColor or edgeStyle — anything keyed by
+     * field + optional selector/filter) applies to the edge (relName, source→target).
+     * Selector matches on the source atom; filter matches on the (source, target) tuple.
+     *
+     * `findEdgeDirective` below still inlines this same logic for edgeColor; that
+     * duplication goes away when edgeColor is shimmed onto edgeStyle.
+     */
+    private edgeDirectiveMatches(
+        directive: { field: string; selector?: string; filter?: string },
+        relName: string,
+        sourceAtom: string,
+        targetAtom?: string,
+    ): boolean {
+        if (directive.field !== relName) {
+            return false;
+        }
+        if (directive.selector) {
+            try {
+                const selectorResult = this.evaluator.evaluate(directive.selector, { instanceIndex: this.instanceNum });
+                if (!selectorResult.selectedAtoms().includes(sourceAtom)) {
+                    return false;
+                }
+            } catch (error) {
+                this.recordSelectorError(directive.selector, 'edge selector', error);
+                return false;
+            }
+        }
+        if (directive.filter && targetAtom) {
+            try {
+                const filterResult = this.evaluator.evaluate(directive.filter, { instanceIndex: this.instanceNum });
+                const matched = filterResult.selectedTwoples().some(
+                    tuple => tuple[0] === sourceAtom && tuple[1] === targetAtom
+                );
+                if (!matched) {
+                    return false;
+                }
+            } catch (error) {
+                this.recordSelectorError(directive.filter, 'edge filter', error);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Resolve the edgeStyle directives matching an edge into one concrete style.
+     * Overlapping edgeStyle rules compose leaf-wise; a genuine disagreement throws
+     * StyleCollisionError (no silent override). Empty when nothing matches, so callers
+     * fall back to the legacy inferredEdge/edgeColor path.
+     */
+    private resolveEdgeStyleForEdge(relName: string, sourceAtom: string, targetAtom: string): EdgeStyleSpec {
+        const rules = this._layoutSpec.directives.edgeStyles.filter(
+            rule => this.edgeDirectiveMatches(rule, relName, sourceAtom, targetAtom)
+        );
+        if (rules.length === 0) {
+            return {};
+        }
+        return resolveEdgeStyle(rules, `edge ${relName} (${sourceAtom} → ${targetAtom})`);
     }
 
     private findEdgeDirective(relName: string, sourceAtom: string, targetAtom?: string): EdgeColorDirective | undefined {

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -1,6 +1,8 @@
 import * as yaml from 'js-yaml';
 import { EdgeStyle } from './edge-style';
 import { AttrTextSize } from './text-extent';
+import { EdgeStyleRule, parseEdgeStyleSpec, edgeColorToEdgeStyleRule } from './style/edge-style-spec';
+import type { TextStyle } from './style/text-style';
 
 export type RelativeDirection = "above" | "below" | "left" | "right" | "directlyAbove" | "directlyBelow" | "directlyLeft" | "directlyRight";
 export type RotationDirection = "clockwise" | "counterclockwise";
@@ -272,11 +274,16 @@ export interface AtomIconDirective extends VisualManipulation {
 
 export interface InferredEdgeDirective extends VisualManipulation {
     name : string;
+    /** Line color. Parsed from `lineStyle.color` (legacy inline `color` still accepted). */
     color?: string;
+    /** Line dash pattern. Parsed from `lineStyle.pattern` (legacy inline `style` still accepted). */
     style?: EdgeStyle;
+    /** Line weight. Parsed from `lineStyle.weight` (legacy inline `weight` still accepted). */
     weight?: number;
     /** Optional highlight color drawn as a wider underlay beneath the edge. */
     highlight?: string;
+    /** Optional label styling. Parsed from the `textStyle` block. */
+    textStyle?: TextStyle;
 }
 
 export interface AtomHidingDirective extends VisualManipulation {
@@ -368,6 +375,7 @@ interface DirectivesBlock {
     sizes: AtomSizeDirective[];
     icons: AtomIconDirective[];
     edgeColors: EdgeColorDirective[];
+    edgeStyles: EdgeStyleRule[];
     attributes: AttributeDirective[];
     tags: TagDirective[];
     hiddenFields: FieldHidingDirective[];
@@ -429,6 +437,7 @@ function DEFAULT_LAYOUT() : LayoutSpec
             sizes: [],
             icons: [],
             edgeColors: [],
+            edgeStyles: [],
             attributes: [],
             tags: [],
             hiddenFields: [],
@@ -853,20 +862,21 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
                     };
                 });
     
-    let edgeColors : EdgeColorDirective[] = typedDirectives.filter(d => d.edgeColor)
-                .map(d => {
-                    return {
-                        color: d.edgeColor.value,
-                        field: d.edgeColor.field,
-                        selector: d.edgeColor.selector,
-                        filter: d.edgeColor.filter,
-                        style: d.edgeColor.style,
-                        weight: d.edgeColor.weight,
-                        showLabel: d.edgeColor.showLabel,
-                        hidden: d.edgeColor.hidden,
-                        highlight: d.edgeColor.highlight
-                    }
-                });
+    // edgeColor is the deprecated flat form of edgeStyle. Desugar each into an
+    // EdgeStyleRule so both forms resolve through the one edgeStyle path (and
+    // compose / collide together). Emit one deprecation warning. `edgeColors` is
+    // kept empty only to satisfy the DirectivesBlock shape; its sole consumer
+    // (findEdgeDirective) then no-ops, and edge styling flows via `edgeStyles`.
+    const rawEdgeColors = typedDirectives.filter(d => d.edgeColor);
+    if (rawEdgeColors.length > 0) {
+        console.warn(
+            "[spytial] 'edgeColor' is deprecated and will be removed in a future major; " +
+            "use 'edgeStyle' with a 'lineStyle' block " +
+            "(value→lineStyle.color, style→lineStyle.pattern, weight→lineStyle.weight, highlight→lineStyle.highlight)."
+        );
+    }
+    const desugaredEdgeColors: EdgeStyleRule[] = rawEdgeColors.map(d => edgeColorToEdgeStyleRule(d.edgeColor));
+    let edgeColors : EdgeColorDirective[] = [];
 
     let attributes : AttributeDirective[]  = typedDirectives.filter(d => d.attribute).map(d => {
         return {
@@ -889,16 +899,32 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
     let hideDisconnected = flags.includes("hideDisconnected");
     let hideDisconnectedBuiltIns = flags.includes("hideDisconnectedBuiltIns");
 
+    // inferredEdge keeps its structural identity (name/selector) but adopts the
+    // shared lineStyle/textStyle blocks. Legacy inline color/style/weight/highlight
+    // still parse (mapped onto the flat fields) but are deprecated.
+    let usedLegacyInferredInline = false;
     let inferredEdges : InferredEdgeDirective[] = typedDirectives.filter(d => d.inferredEdge).map(d => {
-        return {
-            name: d.inferredEdge.name,
-            selector: d.inferredEdge.selector,
-            color: d.inferredEdge.color,
-            style: d.inferredEdge.style,
-            weight: d.inferredEdge.weight,
-            highlight: d.inferredEdge.highlight
+        const ie = d.inferredEdge;
+        const spec = parseEdgeStyleSpec(ie); // extracts lineStyle / textStyle blocks
+        if (ie.color !== undefined || ie.style !== undefined || ie.weight !== undefined || ie.highlight !== undefined) {
+            usedLegacyInferredInline = true;
         }
+        return {
+            name: ie.name,
+            selector: ie.selector,
+            color: spec.lineStyle?.color ?? ie.color,
+            style: spec.lineStyle?.pattern ?? ie.style,
+            weight: spec.lineStyle?.weight ?? ie.weight,
+            highlight: spec.lineStyle?.highlight ?? ie.highlight,
+            textStyle: spec.textStyle,
+        };
     });
+    if (usedLegacyInferredInline) {
+        console.warn(
+            "[spytial] inferredEdge's inline 'color'/'style'/'weight'/'highlight' are deprecated; " +
+            "use a 'lineStyle' block (color, pattern, weight, highlight) instead."
+        );
+    }
 
     let hiddenAtoms : AtomHidingDirective[] = typedDirectives.filter(d => d.hideAtom).map(d => {
         return {
@@ -915,11 +941,23 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
         }
     });
 
+    let edgeStyles : EdgeStyleRule[] = typedDirectives.filter(d => d.edgeStyle).map(d => {
+        return {
+            field: d.edgeStyle.field,
+            selector: d.edgeStyle.selector,
+            filter: d.edgeStyle.filter,
+            style: parseEdgeStyleSpec(d.edgeStyle)
+        }
+    });
+    // Desugared legacy edgeColor rules join the native ones — one resolution path.
+    edgeStyles = [...edgeStyles, ...desugaredEdgeColors];
+
     return {
         atomColors,
         sizes,
         icons,
         edgeColors,
+        edgeStyles,
         attributes,
         tags,
         hiddenFields,

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -892,7 +892,11 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
             "or a 'fillStyle' block for a real interior fill."
         );
     }
-    const desugaredAtomColors: AtomStyleRule[] = rawAtomColors.map(d => atomColorToAtomStyleRule(d.atomColor));
+    // A selectorless (malformed) atomColor desugars to null and is dropped — it
+    // was a no-op before, and must not become a global recolor of every atom.
+    const desugaredAtomColors: AtomStyleRule[] = rawAtomColors
+        .map(d => atomColorToAtomStyleRule(d.atomColor))
+        .filter((rule): rule is AtomStyleRule => rule !== null);
     let atomColors : AtomColorDirective[] = [];
 
     let sizes : AtomSizeDirective[] = typedDirectives.filter(d => d.size)

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -2,6 +2,7 @@ import * as yaml from 'js-yaml';
 import { EdgeStyle } from './edge-style';
 import { AttrTextSize } from './text-extent';
 import { EdgeStyleRule, parseEdgeStyleSpec, edgeColorToEdgeStyleRule } from './style/edge-style-spec';
+import { AtomStyleRule, parseAtomStyleSpec, atomColorToAtomStyleRule } from './style/atom-style-spec';
 import type { TextStyle } from './style/text-style';
 
 export type RelativeDirection = "above" | "below" | "left" | "right" | "directlyAbove" | "directlyBelow" | "directlyLeft" | "directlyRight";
@@ -372,6 +373,7 @@ interface ConstraintsBlock
 
 interface DirectivesBlock {
     atomColors: AtomColorDirective[];
+    atomStyles: AtomStyleRule[];
     sizes: AtomSizeDirective[];
     icons: AtomIconDirective[];
     edgeColors: EdgeColorDirective[];
@@ -434,6 +436,7 @@ function DEFAULT_LAYOUT() : LayoutSpec
         },
         directives: {
             atomColors: [],
+            atomStyles: [],
             sizes: [],
             icons: [],
             edgeColors: [],
@@ -844,13 +847,23 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
                         showLabels: d.icon.showLabels || false 
                     }
                 });
-    let atomColors : AtomColorDirective[] = typedDirectives.filter(d => d.atomColor)
-                .map(d => {
-                    return {
-                        color: d.atomColor.value,
-                        selector: d.atomColor.selector
-                    }
-                });
+    // atomColor is the deprecated flat form of atomStyle. Desugar each into an
+    // AtomStyleRule (border-preserving: value→borderStyle.color, so existing
+    // diagrams stay outlined exactly as before) and resolve through the one
+    // atomStyle path (compose / collide together). Emit one deprecation warning.
+    // `atomColors` is kept empty only to satisfy the DirectivesBlock shape; its
+    // sole consumer (getNodeColorMap) now reads the resolved atomStyle instead,
+    // and atom styling flows via `atomStyles`.
+    const rawAtomColors = typedDirectives.filter(d => d.atomColor);
+    if (rawAtomColors.length > 0) {
+        console.warn(
+            "[spytial] 'atomColor' is deprecated and will be removed in a future major; " +
+            "use 'atomStyle' with a 'borderStyle' block (value→borderStyle.color), " +
+            "or a 'fillStyle' block for a real interior fill."
+        );
+    }
+    const desugaredAtomColors: AtomStyleRule[] = rawAtomColors.map(d => atomColorToAtomStyleRule(d.atomColor));
+    let atomColors : AtomColorDirective[] = [];
 
     let sizes : AtomSizeDirective[] = typedDirectives.filter(d => d.size)
                 .map(d => {
@@ -952,8 +965,20 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
     // Desugared legacy edgeColor rules join the native ones — one resolution path.
     edgeStyles = [...edgeStyles, ...desugaredEdgeColors];
 
+    // atomStyle (composite: fillStyle + borderStyle + textStyle), keyed by an
+    // optional unary selector. Native rules plus desugared legacy atomColor rules
+    // resolve through the one atomStyle path.
+    let atomStyles : AtomStyleRule[] = typedDirectives.filter(d => d.atomStyle).map(d => {
+        return {
+            selector: d.atomStyle.selector,
+            style: parseAtomStyleSpec(d.atomStyle)
+        }
+    });
+    atomStyles = [...atomStyles, ...desugaredAtomColors];
+
     return {
         atomColors,
+        atomStyles,
         sizes,
         icons,
         edgeColors,

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -2,7 +2,9 @@ import * as yaml from 'js-yaml';
 import { EdgeStyle } from './edge-style';
 import { AttrTextSize } from './text-extent';
 import { EdgeStyleRule, parseEdgeStyleSpec, edgeColorToEdgeStyleRule } from './style/edge-style-spec';
+import type { LineStyle } from './style/edge-style-spec';
 import { AtomStyleRule, parseAtomStyleSpec, atomColorToAtomStyleRule } from './style/atom-style-spec';
+import { parseTextStyle } from './style/text-style';
 import type { TextStyle } from './style/text-style';
 
 export type RelativeDirection = "above" | "below" | "left" | "right" | "directlyAbove" | "directlyBelow" | "directlyLeft" | "directlyRight";
@@ -158,6 +160,11 @@ export const GROUP_EDGE_DIRECTIONS: readonly GroupEdgeDirection[] = ['none', 'to
  * behaviour: an edge from the key node into the group). Anything else is `'none'`.
  */
 export function normalizeGroupEdgeDirection(value: unknown): GroupEdgeDirection {
+    // Block form — `addEdge: { points, lineStyle, textStyle }` — carries the
+    // direction in `points`; the bare string/bool form is the direction itself.
+    if (value && typeof value === 'object') {
+        value = (value as Record<string, unknown>).points;
+    }
     if (value === true || value === 'togroup') return 'togroup';
     if (value === 'fromgroup') return 'fromgroup';
     return 'none';
@@ -166,6 +173,17 @@ export function normalizeGroupEdgeDirection(value: unknown): GroupEdgeDirection 
 export class GroupBySelector extends ConstraintOperation{
     name: string;
     addEdge: GroupEdgeDirection;
+    /**
+     * Line styling for the `addEdge` connector (the edge drawn between the key
+     * and the group). Present only when `addEdge` is given in block form
+     * (`addEdge: { points, lineStyle, textStyle }`). The connector is an edge, so
+     * this reuses the shared {@link LineStyle}. Absent = the default edge look.
+     */
+    connectorLineStyle?: LineStyle;
+    /** Label styling for the `addEdge` connector's label (shared {@link TextStyle}). */
+    connectorTextStyle?: TextStyle;
+    /** Styling for the group's own label, from the group's top-level `textStyle`. */
+    labelTextStyle?: TextStyle;
 
     constructor(selector : string, name: string, addEdge: GroupEdgeDirection | boolean = 'none', negated: boolean = false) {
         super(selector, negated);
@@ -780,7 +798,19 @@ function parseConstraints(constraints: unknown[]):   ConstraintsBlock
             }
             // Auto-generate name for negated groups without one
             const name = c.group.name || `_not_group_${c.group.selector}`;
-            return new GroupBySelector(c.group.selector, name, c.group.addEdge, c._negated);
+            const gbs = new GroupBySelector(c.group.selector, name, c.group.addEdge, c._negated);
+            // Block-form `addEdge: { points, lineStyle, textStyle }` styles the
+            // connector — which is an edge — so parse it as an edge spec (the
+            // `points` key is ignored by parseEdgeStyleSpec). A bare string/bool
+            // addEdge stays unstyled (its direction was read above).
+            if (c.group.addEdge && typeof c.group.addEdge === 'object') {
+                const connSpec = parseEdgeStyleSpec(c.group.addEdge);
+                gbs.connectorLineStyle = connSpec.lineStyle;
+                gbs.connectorTextStyle = connSpec.textStyle;
+            }
+            // The group's own label styling (top-level `textStyle`).
+            gbs.labelTextStyle = parseTextStyle(c.group.textStyle);
+            return gbs;
         });
 
     // Remove duplicate group by selector constraints

--- a/src/layout/style/atom-style-spec.ts
+++ b/src/layout/style/atom-style-spec.ts
@@ -1,0 +1,116 @@
+/**
+ * The `atomStyle` directive's sparse payload and its resolution.
+ *
+ * An atom is a composite: a fill ({@link FillStyle}), a border
+ * ({@link BorderStyle}), and its label (the shared {@link TextStyle}). Per the
+ * border-preserving mapping, legacy `atomColor.value` desugars to
+ * `borderStyle.color` (nodes stay outlined by default, matching today's Tufte
+ * rendering); `fillStyle` is an opt-in real fill.
+ *
+ * Resolution is per-atom: gather every atomStyle rule whose selector matches the
+ * atom and fold through the shared {@link resolveStyle}. Because a supertype
+ * selector already returns subtype atoms, type-ancestry inheritance and the
+ * no-override collision fall out of that fold — no explicit ancestry walk.
+ */
+import { parseTextStyle } from './text-style';
+import type { TextStyle } from './text-style';
+import { resolveStyle } from './style-resolver';
+import type { StyleContribution } from './style-resolver';
+
+/** Sparse fill styling of an atom's rectangle. `type`, so it stays assignable to SparseStyle. */
+export type FillStyle = {
+    color?: string;
+};
+
+/** Sparse border styling of an atom's rectangle. `type`, so it stays assignable to SparseStyle. */
+export type BorderStyle = {
+    color?: string;
+    width?: number;
+};
+
+/** The full sparse payload of an `atomStyle` directive. `type`, so it stays assignable to SparseStyle. */
+export type AtomStyleSpec = {
+    fillStyle?: FillStyle;
+    borderStyle?: BorderStyle;
+    textStyle?: TextStyle;
+};
+
+/** A parsed `atomStyle` directive: how it matches atoms, plus its style. */
+export interface AtomStyleRule {
+    /** Optional unary selector narrowing which atoms match (absent = all). */
+    selector?: string;
+    /** The sparse style to apply. */
+    style: AtomStyleSpec;
+}
+
+function parseFillStyle(raw: unknown): FillStyle | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const r = raw as Record<string, unknown>;
+    const fillStyle: FillStyle = {};
+    if (typeof r.color === 'string') fillStyle.color = r.color;
+    return Object.keys(fillStyle).length > 0 ? fillStyle : undefined;
+}
+
+function parseBorderStyle(raw: unknown): BorderStyle | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const r = raw as Record<string, unknown>;
+    const borderStyle: BorderStyle = {};
+    if (typeof r.color === 'string') borderStyle.color = r.color;
+    // Positive widths only (mirrors the edge weight rule); invalid is dropped.
+    if (typeof r.width === 'number' && Number.isFinite(r.width) && r.width > 0) borderStyle.width = r.width;
+    return Object.keys(borderStyle).length > 0 ? borderStyle : undefined;
+}
+
+/**
+ * Build a sparse {@link AtomStyleSpec} from a raw `atomStyle` directive object,
+ * keeping only present, valid leaves. Matching keys (selector) are ignored here.
+ */
+export function parseAtomStyleSpec(raw: unknown): AtomStyleSpec {
+    const spec: AtomStyleSpec = {};
+    if (!raw || typeof raw !== 'object') return spec;
+    const r = raw as Record<string, unknown>;
+
+    const fillStyle = parseFillStyle(r.fillStyle);
+    if (fillStyle) spec.fillStyle = fillStyle;
+
+    const borderStyle = parseBorderStyle(r.borderStyle);
+    if (borderStyle) spec.borderStyle = borderStyle;
+
+    const textStyle = parseTextStyle(r.textStyle);
+    if (textStyle) spec.textStyle = textStyle;
+
+    return spec;
+}
+
+/**
+ * Desugar a legacy `atomColor` directive into an {@link AtomStyleRule}. Per the
+ * border-preserving mapping, `value` → `borderStyle.color` (the node's outline —
+ * what atomColor drives today), so existing diagrams are unchanged.
+ */
+export function atomColorToAtomStyleRule(raw: unknown): AtomStyleRule {
+    const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+    const style: AtomStyleSpec = {};
+    if (typeof r.value === 'string') style.borderStyle = { color: r.value };
+    return {
+        selector: typeof r.selector === 'string' ? r.selector : undefined,
+        style,
+    };
+}
+
+function atomRuleSource(rule: AtomStyleRule): string {
+    return rule.selector ? `atomStyle(${rule.selector})` : 'atomStyle';
+}
+
+/**
+ * Resolve the concrete style for one atom from the rules that match it. The
+ * caller selects which rules match (by selector); this folds them through the
+ * shared resolver, so overlapping rules compose and disagreements throw
+ * {@link StyleCollisionError}.
+ */
+export function resolveAtomStyle(rules: AtomStyleRule[], context?: string): AtomStyleSpec {
+    const contributions: StyleContribution[] = rules.map((rule) => ({
+        source: atomRuleSource(rule),
+        style: rule.style,
+    }));
+    return resolveStyle(contributions, { context }) as AtomStyleSpec;
+}

--- a/src/layout/style/atom-style-spec.ts
+++ b/src/layout/style/atom-style-spec.ts
@@ -86,15 +86,21 @@ export function parseAtomStyleSpec(raw: unknown): AtomStyleSpec {
  * Desugar a legacy `atomColor` directive into an {@link AtomStyleRule}. Per the
  * border-preserving mapping, `value` → `borderStyle.color` (the node's outline —
  * what atomColor drives today), so existing diagrams are unchanged.
+ *
+ * `atomColor`'s selector is REQUIRED: a missing/blank one was always an
+ * error/no-op, never a global recolor. The atomStyle model treats an absent
+ * selector as "every atom", so a selectorless atomColor must NOT desugar into a
+ * rule that would repaint the whole graph — return `null` and let the caller
+ * drop it (matching the legacy no-op).
  */
-export function atomColorToAtomStyleRule(raw: unknown): AtomStyleRule {
+export function atomColorToAtomStyleRule(raw: unknown): AtomStyleRule | null {
     const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+    const selector = typeof r.selector === 'string' ? r.selector : '';
+    if (selector.trim().length === 0) return null;
+
     const style: AtomStyleSpec = {};
     if (typeof r.value === 'string') style.borderStyle = { color: r.value };
-    return {
-        selector: typeof r.selector === 'string' ? r.selector : undefined,
-        style,
-    };
+    return { selector, style };
 }
 
 function atomRuleSource(rule: AtomStyleRule): string {

--- a/src/layout/style/edge-style-spec.ts
+++ b/src/layout/style/edge-style-spec.ts
@@ -1,0 +1,153 @@
+/**
+ * The `edgeStyle` directive's sparse payload and its resolution.
+ *
+ * An edge is a composite: a drawn line ({@link LineStyle}: color / pattern /
+ * weight / highlight), a label (the shared {@link TextStyle}), and behavior
+ * flags (showLabel / hidden). Authors write only what they mean;
+ * {@link parseEdgeStyleSpec} keeps the result sparse, and {@link resolveEdgeStyle}
+ * folds every rule matching an edge through the shared {@link resolveStyle} — so
+ * overlapping edge rules compose, and a genuine disagreement is a hard error
+ * rather than a silent override.
+ *
+ * The `lineStyle` / `textStyle` block vocabulary is shared: `inferredEdge` and a
+ * group's `addEdge` connector reuse the same blocks, and `edgeColor` desugars
+ * onto `edgeStyle` behind a deprecation warning.
+ */
+import type { EdgeStyle } from '../edge-style';
+import { isTextSize } from './text-style';
+import type { TextStyle } from './text-style';
+import { resolveStyle } from './style-resolver';
+import type { StyleContribution } from './style-resolver';
+
+/** Line dash patterns (the `EdgeStyle` union: solid | dashed | dotted). */
+const LINE_PATTERNS: readonly EdgeStyle[] = ['solid', 'dashed', 'dotted'];
+
+function isLinePattern(v: unknown): v is EdgeStyle {
+    return typeof v === 'string' && (LINE_PATTERNS as readonly string[]).includes(v);
+}
+
+/** Sparse styling of an edge's drawn line. `type`, so it stays assignable to SparseStyle. */
+export type LineStyle = {
+    color?: string;
+    /** Dash pattern: solid | dashed | dotted. */
+    pattern?: EdgeStyle;
+    weight?: number;
+    highlight?: string;
+};
+
+/** The full sparse payload of an `edgeStyle` directive. `type`, so it stays assignable to SparseStyle. */
+export type EdgeStyleSpec = {
+    lineStyle?: LineStyle;
+    textStyle?: TextStyle;
+    /** Whether the edge label is shown (behavior, not appearance). */
+    showLabel?: boolean;
+    /** Whether the edge is hidden entirely (behavior, not appearance). */
+    hidden?: boolean;
+};
+
+/** A parsed `edgeStyle` directive: how it matches edges, plus its style. */
+export interface EdgeStyleRule {
+    /** Relation / field whose edges this styles. */
+    field: string;
+    /** Optional unary selector narrowing which source atoms' edges match. */
+    selector?: string;
+    /** Optional tuple filter. */
+    filter?: string;
+    /** The sparse style to apply. */
+    style: EdgeStyleSpec;
+}
+
+function parseLineStyle(raw: unknown): LineStyle | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const r = raw as Record<string, unknown>;
+    const lineStyle: LineStyle = {};
+    if (typeof r.color === 'string') lineStyle.color = r.color;
+    if (isLinePattern(r.pattern)) lineStyle.pattern = r.pattern;
+    // Only positive weights, matching layoutinstance's normalizeEdgeWeight: an
+    // invalid weight is dropped (stays sparse) so it falls back.
+    if (typeof r.weight === 'number' && Number.isFinite(r.weight) && r.weight > 0) lineStyle.weight = r.weight;
+    if (typeof r.highlight === 'string') lineStyle.highlight = r.highlight;
+    return Object.keys(lineStyle).length > 0 ? lineStyle : undefined;
+}
+
+function parseTextStyle(raw: unknown): TextStyle | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const r = raw as Record<string, unknown>;
+    const textStyle: TextStyle = {};
+    if (isTextSize(r.size)) textStyle.size = r.size;
+    if (typeof r.color === 'string') textStyle.color = r.color;
+    return Object.keys(textStyle).length > 0 ? textStyle : undefined;
+}
+
+/**
+ * Build a sparse {@link EdgeStyleSpec} from a raw `edgeStyle` directive object,
+ * keeping only present, valid leaves. Matching keys (field / selector / filter)
+ * are ignored here — they live on {@link EdgeStyleRule}, not in the payload.
+ */
+export function parseEdgeStyleSpec(raw: unknown): EdgeStyleSpec {
+    const spec: EdgeStyleSpec = {};
+    if (!raw || typeof raw !== 'object') return spec;
+    const r = raw as Record<string, unknown>;
+
+    const lineStyle = parseLineStyle(r.lineStyle);
+    if (lineStyle) spec.lineStyle = lineStyle;
+
+    const textStyle = parseTextStyle(r.textStyle);
+    if (textStyle) spec.textStyle = textStyle;
+
+    if (typeof r.showLabel === 'boolean') spec.showLabel = r.showLabel;
+    if (typeof r.hidden === 'boolean') spec.hidden = r.hidden;
+
+    return spec;
+}
+
+/**
+ * Desugar a legacy flat `edgeColor` directive into an {@link EdgeStyleRule}, so
+ * both forms resolve through one path. `value`→`lineStyle.color`,
+ * `style`→`lineStyle.pattern`, `weight`→`lineStyle.weight`,
+ * `highlight`→`lineStyle.highlight`; `showLabel`/`hidden`/`field`/`selector`/
+ * `filter` carry over unchanged. (Legacy `edgeColor` had no label styling.)
+ */
+export function edgeColorToEdgeStyleRule(raw: unknown): EdgeStyleRule {
+    const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+
+    const lineStyle: LineStyle = {};
+    if (typeof r.value === 'string') lineStyle.color = r.value;
+    if (isLinePattern(r.style)) lineStyle.pattern = r.style;
+    if (typeof r.weight === 'number' && Number.isFinite(r.weight) && r.weight > 0) lineStyle.weight = r.weight;
+    if (typeof r.highlight === 'string') lineStyle.highlight = r.highlight;
+
+    const style: EdgeStyleSpec = {};
+    if (Object.keys(lineStyle).length > 0) style.lineStyle = lineStyle;
+    if (typeof r.showLabel === 'boolean') style.showLabel = r.showLabel;
+    if (typeof r.hidden === 'boolean') style.hidden = r.hidden;
+
+    return {
+        field: typeof r.field === 'string' ? r.field : '',
+        selector: typeof r.selector === 'string' ? r.selector : undefined,
+        filter: typeof r.filter === 'string' ? r.filter : undefined,
+        style,
+    };
+}
+
+function edgeRuleSource(rule: EdgeStyleRule): string {
+    return rule.selector
+        ? `edgeStyle(${rule.field} · ${rule.selector})`
+        : `edgeStyle(${rule.field})`;
+}
+
+/**
+ * Resolve the concrete style for one edge from the rules that match it. The
+ * caller selects which rules match (by field, then selector / filter); this
+ * folds them through the shared resolver, so overlaps compose and disagreements
+ * throw {@link StyleCollisionError}.
+ */
+export function resolveEdgeStyle(rules: EdgeStyleRule[], context?: string): EdgeStyleSpec {
+    const contributions: StyleContribution[] = rules.map((rule) => ({
+        source: edgeRuleSource(rule),
+        style: rule.style,
+    }));
+    // The resolved leaves are a subset of what EdgeStyleSpecs contributed, so
+    // the merged result is itself a (concrete) EdgeStyleSpec.
+    return resolveStyle(contributions, { context }) as EdgeStyleSpec;
+}

--- a/src/layout/style/edge-style-spec.ts
+++ b/src/layout/style/edge-style-spec.ts
@@ -14,6 +14,7 @@
  * onto `edgeStyle` behind a deprecation warning.
  */
 import type { EdgeStyle } from '../edge-style';
+import { normalizeEdgeStyle } from '../edge-style';
 import { isTextSize } from './text-style';
 import type { TextStyle } from './text-style';
 import { resolveStyle } from './style-resolver';
@@ -113,7 +114,11 @@ export function edgeColorToEdgeStyleRule(raw: unknown): EdgeStyleRule {
 
     const lineStyle: LineStyle = {};
     if (typeof r.value === 'string') lineStyle.color = r.value;
-    if (isLinePattern(r.style)) lineStyle.pattern = r.style;
+    // Legacy `edgeColor.style` went through normalizeEdgeStyle (trim + lowercase),
+    // so `style: Dashed` / ` dashed ` rendered dashed. Normalize here too rather
+    // than strict-matching, or those specs would silently fall back to solid.
+    const pattern = normalizeEdgeStyle(r.style);
+    if (pattern) lineStyle.pattern = pattern;
     if (typeof r.weight === 'number' && Number.isFinite(r.weight) && r.weight > 0) lineStyle.weight = r.weight;
     if (typeof r.highlight === 'string') lineStyle.highlight = r.highlight;
 

--- a/src/layout/style/style-resolver.ts
+++ b/src/layout/style/style-resolver.ts
@@ -1,0 +1,202 @@
+/**
+ * Pure, instance-free style resolution for the SpyTial directive system.
+ *
+ * A style directive contributes a *sparse partial* — only the leaf
+ * properties the author actually wrote. Many directives can target the same
+ * node (a type and its supertypes, overlapping selectors), so resolving a
+ * node's final style means folding every contribution that reaches it into
+ * one record. The fold obeys three rules, in the spirit of "explicit or
+ * reject" rather than CSS's silent cascade:
+ *
+ *   1. Composition — disjoint leaves merge (fill from one rule, border from
+ *      another) all the way down to the leaf, so blocks combine instead of
+ *      clobbering.
+ *   2. Inheritance — a leaf set by exactly one contribution wins, whether it
+ *      came from the node's own type or an ancestor (gap-filling).
+ *   3. No override — a leaf set to *different* values by two contributions is
+ *      a hard error ({@link StyleCollisionError}), whether those rules are
+ *      comparable (type/supertype) or not. The same value twice is fine.
+ *
+ * Defaults are applied *once, at the end*, filling only leaves still unset —
+ * never seeded up front, or every rule would look like it specified
+ * everything and rules (2)/(3) would collapse into last-writer-wins.
+ *
+ * The core ({@link resolveStyle}) is target-agnostic: it folds an ordered
+ * list of contributions. *How* contributions are gathered is the caller's
+ * job — walk a type ancestry for atoms ({@link resolveTypedStyle}), match
+ * field + selector for edges — so the same mechanism serves every style kind.
+ *
+ * Stays dependency-free (no DOM, no data-instance) so it is node-runnable
+ * for tests and reusable across atom, edge, text, and group styling.
+ */
+
+/** A resolved leaf value. Style trees bottom out in primitives. */
+export type StyleValue = string | number | boolean;
+
+/** A nested partial style: branches are sub-objects, leaves are primitives. */
+export interface SparseStyle {
+    // Values may be `undefined`: a sparse partial only carries the leaves an
+    // author actually wrote, so typed style blocks with optional fields are
+    // assignable and absent/undefined leaves are simply skipped when folding.
+    [key: string]: StyleValue | SparseStyle | undefined;
+}
+
+/** A fully-resolved style — the same nested shape, with defaults applied. */
+export interface ResolvedStyle {
+    [key: string]: StyleValue | ResolvedStyle;
+}
+
+/** One rule's contribution: its sparse partial plus a label for diagnostics. */
+export interface StyleContribution {
+    /** Human-facing identifier of the source rule, e.g. `atomStyle(selector="RedNode")`. */
+    source: string;
+    /** The sparse partial this rule contributes (only authored leaves present). */
+    style: SparseStyle;
+}
+
+/** The rule and value that claimed a given leaf, for collision reporting. */
+export interface StyleSource {
+    source: string;
+    value: StyleValue;
+}
+
+export interface ResolveOptions {
+    /** Default leaves, applied last to anything still unset. */
+    defaults?: SparseStyle;
+    /** Optional description of the target, used only in collision messages. */
+    context?: string;
+}
+
+/**
+ * Thrown when two contributions set the same leaf to different values. This is
+ * deliberate: styles never silently override, so an ambiguous property is
+ * surfaced to the author rather than resolved by declaration order.
+ */
+export class StyleCollisionError extends Error {
+    constructor(
+        public readonly path: string,
+        public readonly existing: StyleSource,
+        public readonly incoming: StyleSource,
+        public readonly context?: string,
+    ) {
+        const where = context ? ` for ${context}` : '';
+        super(
+            `Conflicting style for "${path}"${where}: ` +
+                `${existing.source} sets it to ${JSON.stringify(existing.value)}, ` +
+                `but ${incoming.source} sets it to ${JSON.stringify(incoming.value)}. ` +
+                `Styles never silently override — set "${path}" in exactly one matching rule.`,
+        );
+        this.name = 'StyleCollisionError';
+    }
+}
+
+function isPlainObject(v: unknown): v is { [key: string]: unknown } {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Flatten a nested sparse style into dotted leaf paths.
+ * `{ border: { color: 'red' } }` → `{ 'border.color' => 'red' }`.
+ * `undefined` / `null` leaves are treated as unspecified and dropped, so a
+ * partial only ever carries what the author actually wrote.
+ */
+export function flattenLeaves(style: SparseStyle, prefix = ''): Map<string, StyleValue> {
+    const out = new Map<string, StyleValue>();
+    for (const key of Object.keys(style)) {
+        const val = style[key];
+        if (val === undefined || val === null) continue;
+        const path = prefix ? `${prefix}.${key}` : key;
+        if (isPlainObject(val)) {
+            for (const [leafPath, leafVal] of flattenLeaves(val as SparseStyle, path)) {
+                out.set(leafPath, leafVal);
+            }
+        } else {
+            out.set(path, val);
+        }
+    }
+    return out;
+}
+
+/** Rebuild a nested style from a resolved leaf map. */
+function unflatten(cell: Map<string, StyleSource>): ResolvedStyle {
+    const root: ResolvedStyle = {};
+    for (const [path, { value }] of cell) {
+        const parts = path.split('.');
+        let node: ResolvedStyle = root;
+        for (let i = 0; i < parts.length - 1; i++) {
+            const key = parts[i];
+            const next = node[key];
+            if (isPlainObject(next)) {
+                node = next as ResolvedStyle;
+            } else {
+                const created: ResolvedStyle = {};
+                node[key] = created;
+                node = created;
+            }
+        }
+        node[parts[parts.length - 1]] = value;
+    }
+    return root;
+}
+
+/**
+ * Fold an ordered list of contributions into one resolved style.
+ *
+ * Each leaf is a write-once cell: the first contribution to set it wins, a
+ * later contribution setting it to the *same* value is a harmless duplicate,
+ * and a later contribution setting it to a *different* value throws
+ * {@link StyleCollisionError}. Composition (disjoint leaves) and inheritance
+ * (a single specifier at any level) both fall out of that one pass; defaults
+ * fill only whatever remains unset.
+ */
+export function resolveStyle(
+    contributions: StyleContribution[],
+    options: ResolveOptions = {},
+): ResolvedStyle {
+    const cell = new Map<string, StyleSource>();
+
+    for (const { source, style } of contributions) {
+        for (const [path, value] of flattenLeaves(style)) {
+            const existing = cell.get(path);
+            if (existing === undefined) {
+                cell.set(path, { source, value });
+            } else if (existing.value !== value) {
+                throw new StyleCollisionError(path, existing, { source, value }, options.context);
+            }
+            // Same value from another rule: redundant but consistent — keep the first.
+        }
+    }
+
+    if (options.defaults) {
+        for (const [path, value] of flattenLeaves(options.defaults)) {
+            if (!cell.has(path)) cell.set(path, { source: '(default)', value });
+        }
+    }
+
+    return unflatten(cell);
+}
+
+/**
+ * Resolve an atom's style by walking its type ancestry, most-specific first.
+ *
+ * `typeChain` is exactly what `IDataInstance.getAtomType(id).types` returns —
+ * `[ownType, ...ancestors, 'univ']`. Every rule attached to a type in the
+ * chain is folded through {@link resolveStyle}, so gap-fill inheritance and
+ * the no-override collision rule both emerge from the shared mechanism. A type
+ * may carry several rules (overlapping selectors); a disagreement among them,
+ * or between a type and an ancestor, is a hard error.
+ */
+export function resolveTypedStyle(
+    typeChain: string[],
+    rulesByType: Map<string, StyleContribution[]>,
+    options: ResolveOptions = {},
+): ResolvedStyle {
+    const contributions: StyleContribution[] = [];
+    for (const typeId of typeChain) {
+        const rules = rulesByType.get(typeId);
+        if (rules) contributions.push(...rules);
+    }
+    const context =
+        options.context ?? (typeChain.length > 0 ? `atoms of type ${typeChain[0]}` : undefined);
+    return resolveStyle(contributions, { defaults: options.defaults, context });
+}

--- a/src/layout/style/text-style.ts
+++ b/src/layout/style/text-style.ts
@@ -20,6 +20,20 @@ export function isTextSize(v: unknown): v is AttrTextSize {
 }
 
 /**
+ * Build a sparse {@link TextStyle} from a raw `textStyle` block, keeping only
+ * present, valid leaves. Shared by every directive that carries a label
+ * (edgeStyle, inferredEdge, atomStyle, group, …).
+ */
+export function parseTextStyle(raw: unknown): TextStyle | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const r = raw as Record<string, unknown>;
+    const textStyle: TextStyle = {};
+    if (isTextSize(r.size)) textStyle.size = r.size;
+    if (typeof r.color === 'string') textStyle.color = r.color;
+    return Object.keys(textStyle).length > 0 ? textStyle : undefined;
+}
+
+/**
  * A sparse text style: only the leaves the author set are present. Declared as
  * a `type` (not `interface`) so it carries an implicit index signature and is
  * assignable to the resolver's {@link SparseStyle}.

--- a/src/layout/style/text-style.ts
+++ b/src/layout/style/text-style.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared `text:` style block for the style system. A `text:` block styles any
+ * label — the main node label, attribute/tag lines, edge labels, group labels
+ * — so every directive that renders text reuses this one shape. Add a field
+ * here (e.g. `weight`) and it lights up everywhere at once.
+ *
+ * Sparse: every field is optional. Size tiers reuse {@link AttrTextSize}
+ * (small / normal / large, relative to the node label); see text-extent.ts.
+ */
+import type { AttrTextSize } from '../text-extent';
+
+export type { AttrTextSize };
+
+/** The three text-size tiers, as a runtime list for validation/enumeration. */
+export const TEXT_SIZES = ['small', 'normal', 'large'] as const;
+
+/** Narrow an unknown YAML value to a valid {@link AttrTextSize}. */
+export function isTextSize(v: unknown): v is AttrTextSize {
+    return typeof v === 'string' && (TEXT_SIZES as readonly string[]).includes(v);
+}
+
+/**
+ * A sparse text style: only the leaves the author set are present. Declared as
+ * a `type` (not `interface`) so it carries an implicit index signature and is
+ * assignable to the resolver's {@link SparseStyle}.
+ */
+export type TextStyle = {
+    /** Font-size tier relative to the node label. */
+    size?: AttrTextSize;
+    /** Text color (any CSS color string). */
+    color?: string;
+}

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -15,7 +15,7 @@
  *     - orientation: { selector, directions: [...], hold? }
  *     - cyclic:      { selector, direction, hold? }
  *     - align:       { selector, direction, hold? }
- *     - group:       { selector, name, addEdge?: none|togroup|fromgroup, hold? }  (groupselector)
+ *     - group:       { selector, name, addEdge?: none|togroup|fromgroup | {points,lineStyle,textStyle}, textStyle?:{color}, hold? }  (groupselector)
  *     - group:       { field, groupOn, addToGroup, selector?, hold? }  (groupfield, deprecated)
  *     - size:        { selector, width, height }
  *     - hideAtom:    { selector }
@@ -114,9 +114,12 @@ export const GROUP_EDGE_DIRECTIONS = ['none', 'togroup', 'fromgroup'] as const;
 
 /**
  * Normalise an `addEdge` value into a GROUP_EDGE_DIRECTIONS member. Tolerates
- * the legacy boolean flag (`true` → 'togroup') so older specs keep working.
+ * the legacy boolean flag (`true` → 'togroup') and the block form
+ * (`{ points, lineStyle, textStyle }` → its `points`), so a hand-authored
+ * styled connector keeps its direction when round-tripped through the Builder.
  */
 function normGroupEdge(value: unknown): (typeof GROUP_EDGE_DIRECTIONS)[number] {
+  if (value && typeof value === 'object') value = (value as Record<string, unknown>).points;
   if (value === true || value === 'togroup') return 'togroup';
   if (value === 'fromgroup') return 'fromgroup';
   return 'none';
@@ -272,7 +275,14 @@ const groupselector: ItemDefinition = {
       label: 'Add edge',
       options: GROUP_EDGE_DIRECTIONS,
       default: 'none',
-      help: 'Draw an edge between the group key and the group: "togroup" points key → group, "fromgroup" points group → key, "none" draws nothing.',
+      help: 'Draw an edge between the group key and the group: "togroup" points key → group, "fromgroup" points group → key, "none" draws nothing. (To style that connector, author addEdge as a block — { points, lineStyle, textStyle } — in YAML.)',
+    },
+    {
+      key: 'textStyle',
+      kind: 'group',
+      label: 'Label text style',
+      // Only `color` today — group labels auto-fit their box, so `size` is reserved.
+      children: [{ key: 'color', kind: 'color', label: 'Color' }],
     },
   ],
   summary(params) {
@@ -289,6 +299,14 @@ const groupselector: ItemDefinition = {
     const edge = normGroupEdge(params.addEdge);
     if (edge !== 'none') {
       node.addEdge = edge;
+    }
+    // The group's own label styling (sparse — drop empty leaves).
+    if (isRecord(params.textStyle)) {
+      const ts: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(params.textStyle)) {
+        if (v !== undefined && v !== null && v !== '') ts[k] = v;
+      }
+      if (Object.keys(ts).length > 0) node.textStyle = ts;
     }
     if (params.hold !== undefined) {
       node.hold = params.hold;
@@ -309,6 +327,10 @@ const groupselector: ItemDefinition = {
     };
     if (group.name !== undefined) {
       params.name = asString(group.name);
+    }
+    // Preserve the group's own label styling (whatever leaves were authored).
+    if (isRecord(group.textStyle)) {
+      params.textStyle = { ...group.textStyle };
     }
     if (group.hold !== undefined) {
       params.hold = group.hold;

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -634,11 +634,55 @@ const atomColor: ItemDefinition = {
   },
 };
 
+/**
+ * Shared `lineStyle` block children — reused by edgeStyle, inferredEdge, and a
+ * group's connector. No `default`s: style blocks must stay sparse (a seeded
+ * default would emit as an authored value and break the resolver's compose /
+ * collision rules).
+ */
+const LINE_STYLE_FIELDS: readonly FieldSpec[] = [
+  { key: 'color', kind: 'color', label: 'Color' },
+  { key: 'pattern', kind: 'enum', options: EDGE_STYLES, label: 'Pattern' },
+  { key: 'weight', kind: 'number', label: 'Weight' },
+  { key: 'highlight', kind: 'color', label: 'Highlight' },
+];
+
+/** Shared `textStyle` block children — reused wherever a label is styled. No defaults. */
+const TEXT_STYLE_FIELDS: readonly FieldSpec[] = [
+  { key: 'size', kind: 'enum', options: TEXT_SIZE_OPTIONS, label: 'Size' },
+  { key: 'color', kind: 'color', label: 'Color' },
+];
+
+const edgeStyle: ItemDefinition = {
+  kind: 'directive',
+  type: 'edgeStyle',
+  label: 'Edge style',
+  description: 'Style the edges of a field/relation — line and label.',
+  fields: [
+    { key: 'field', kind: 'relationName', label: 'Field', required: true },
+    { key: 'selector', kind: 'selector', label: 'Selector', selectorArity: 'unary' },
+    { key: 'filter', kind: 'selector', label: 'Filter', selectorArity: 'binary' },
+    { key: 'lineStyle', kind: 'group', label: 'Line style', children: LINE_STYLE_FIELDS },
+    { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
+    { key: 'showLabel', kind: 'boolean', label: 'Show label' },
+    { key: 'hidden', kind: 'boolean', label: 'Hidden' },
+  ],
+  summary(params) {
+    const field = asString(params.field);
+    const line = (params.lineStyle ?? {}) as Record<string, unknown>;
+    const color = asString(line.color);
+    const base = field ? (color ? `${field}: ${color}` : field) : color || 'edge';
+    const selector = asString(params.selector);
+    return selector ? `${base} · ${selector}` : base;
+  },
+};
+
 const edgeColor: ItemDefinition = {
   kind: 'directive',
   type: 'edgeColor',
   label: 'Edge color',
-  description: 'Style edges of a field/relation.',
+  description: 'Deprecated — use Edge style (edgeStyle). Still parsed/rendered for back-compat.',
+  deprecated: true,
   fields: [
     {
       key: 'field',
@@ -785,6 +829,7 @@ const DEFINITIONS: readonly ItemDefinition[] = [
   hideField,
   icon,
   atomColor,
+  edgeStyle,
   edgeColor,
   inferredEdge,
   tag,

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -785,7 +785,7 @@ const inferredEdge: ItemDefinition = {
   kind: 'directive',
   type: 'inferredEdge',
   label: 'Inferred edge',
-  description: 'Draw an inferred edge from a selector.',
+  description: 'Draw an inferred edge from a selector — line and label.',
   fields: [
     {
       key: 'name',
@@ -799,29 +799,19 @@ const inferredEdge: ItemDefinition = {
       label: 'Selector',
       selectorArity: 'binary',
     },
-    {
-      key: 'color',
-      kind: 'color',
-      label: 'Color',
-      default: DEFAULT_COLOR,
-    },
-    {
-      key: 'style',
-      kind: 'enum',
-      label: 'Style',
-      options: EDGE_STYLES,
-    },
-    {
-      key: 'weight',
-      kind: 'number',
-      label: 'Weight',
-    },
+    // Same shared blocks as edgeStyle. The engine still accepts the legacy flat
+    // color/style/weight (deprecated + warned), so old specs keep working.
+    { key: 'lineStyle', kind: 'group', label: 'Line style', children: LINE_STYLE_FIELDS },
+    { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
   ],
   summary(params) {
     const name = asString(params.name);
     const selector = asString(params.selector);
+    const line = (params.lineStyle ?? {}) as Record<string, unknown>;
+    const color = asString(line.color);
     const base = name || '(no name)';
-    return selector ? `${base} · ${selector}` : base;
+    const withColor = color ? `${base}: ${color}` : base;
+    return selector ? `${withColor} · ${selector}` : withColor;
   },
 };
 

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -24,9 +24,11 @@
  *     - attribute:    { field, selector?, filter? }
  *     - hideField:    { field, selector?, filter? }
  *     - icon:         { path, selector?, showLabels? }
- *     - atomColor:    { value, selector? }
- *     - edgeColor:    { value, field, selector?, filter?, style?, weight?, showLabel?, hidden?, highlight? }
- *     - inferredEdge: { name, selector?, color?, style?, weight?, highlight? }
+ *     - atomStyle:    { selector?, fillStyle?:{color}, borderStyle?:{color,width}, textStyle?:{size,color} }
+ *     - atomColor:    { value, selector? }  (deprecated → atomStyle)
+ *     - edgeStyle:    { field, selector?, filter?, lineStyle?:{color,pattern,weight,highlight}, textStyle?:{size,color}, showLabel?, hidden? }
+ *     - edgeColor:    { value, field, selector?, filter?, style?, weight?, showLabel?, hidden?, highlight? }  (deprecated → edgeStyle)
+ *     - inferredEdge: { name, selector?, lineStyle?:{color,pattern,weight,highlight}, textStyle?:{size,color} }
  *     - tag:          { toTag, name, value }
  *
  * This module is framework-agnostic — no React.
@@ -610,7 +612,8 @@ const atomColor: ItemDefinition = {
   kind: 'directive',
   type: 'atomColor',
   label: 'Atom color',
-  description: 'Color matching atoms.',
+  description: 'Deprecated — use Atom style (atomStyle). Still parsed/rendered for back-compat (value → border color).',
+  deprecated: true,
   fields: [
     {
       key: 'value',
@@ -653,6 +656,17 @@ const TEXT_STYLE_FIELDS: readonly FieldSpec[] = [
   { key: 'color', kind: 'color', label: 'Color' },
 ];
 
+/** Shared `fillStyle` block children — an atom's interior fill. No defaults (sparse). */
+const FILL_STYLE_FIELDS: readonly FieldSpec[] = [
+  { key: 'color', kind: 'color', label: 'Color' },
+];
+
+/** Shared `borderStyle` block children — an atom's outline color + width. No defaults (sparse). */
+const BORDER_STYLE_FIELDS: readonly FieldSpec[] = [
+  { key: 'color', kind: 'color', label: 'Color' },
+  { key: 'width', kind: 'number', label: 'Width' },
+];
+
 const edgeStyle: ItemDefinition = {
   kind: 'directive',
   type: 'edgeStyle',
@@ -673,6 +687,27 @@ const edgeStyle: ItemDefinition = {
     const color = asString(line.color);
     const base = field ? (color ? `${field}: ${color}` : field) : color || 'edge';
     const selector = asString(params.selector);
+    return selector ? `${base} · ${selector}` : base;
+  },
+};
+
+const atomStyle: ItemDefinition = {
+  kind: 'directive',
+  type: 'atomStyle',
+  label: 'Atom style',
+  description: 'Style matching atoms — fill, border, and label.',
+  fields: [
+    { key: 'selector', kind: 'selector', label: 'Selector', selectorArity: 'unary' },
+    { key: 'fillStyle', kind: 'group', label: 'Fill style', children: FILL_STYLE_FIELDS },
+    { key: 'borderStyle', kind: 'group', label: 'Border style', children: BORDER_STYLE_FIELDS },
+    { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
+  ],
+  summary(params) {
+    const fill = (params.fillStyle ?? {}) as Record<string, unknown>;
+    const border = (params.borderStyle ?? {}) as Record<string, unknown>;
+    const color = asString(fill.color) || asString(border.color);
+    const selector = asString(params.selector);
+    const base = color || 'atom';
     return selector ? `${base} · ${selector}` : base;
   },
 };
@@ -828,6 +863,7 @@ const DEFINITIONS: readonly ItemDefinition[] = [
   attribute,
   hideField,
   icon,
+  atomStyle,
   atomColor,
   edgeStyle,
   edgeColor,

--- a/src/spec-editor/core/types.ts
+++ b/src/spec-editor/core/types.ts
@@ -33,7 +33,8 @@ export type FieldKind =
   | 'number'
   | 'color'
   | 'text'
-  | 'boolean';
+  | 'boolean'
+  | 'group'; // a nested block (lineStyle / textStyle / …); renders its `children` recursively
 
 export interface FieldSpec {
   /** params key */
@@ -51,6 +52,8 @@ export interface FieldSpec {
   help?: string;
   /** for 'selector' fields */
   selectorArity?: 'unary' | 'binary';
+  /** for 'group' fields: the nested block's child fields (rendered recursively). */
+  children?: readonly FieldSpec[];
 }
 
 // ---- diagnostics ----

--- a/src/spec-editor/core/yaml-codec.ts
+++ b/src/spec-editor/core/yaml-codec.ts
@@ -360,9 +360,29 @@ export function parseYamlToState(yamlStr: string): SpecDocumentState {
 
 // ---- emission ------------------------------------------------------------
 
-/** Sanitize params: drop undefined values so emission stays clean. */
+/** A plain object (a nested block) — not an array or primitive. */
+function isPlainRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Sanitize params for emission: drop `undefined`, and recursively drop empty
+ * nested blocks. Recursion keeps nested style blocks (lineStyle / textStyle / …)
+ * sparse — an added-but-empty block, or one whose only leaves were cleared, is
+ * omitted rather than emitted as `{}` or `key: null`.
+ */
 function sanitizeParams(params: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined));
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    if (isPlainRecord(value)) {
+      const nested = sanitizeParams(value);
+      if (Object.keys(nested).length > 0) out[key] = nested;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 /** Build the YAML node for a single item (used for both serialize and diffing). */

--- a/src/spec-editor/ui/FieldRenderer.tsx
+++ b/src/spec-editor/ui/FieldRenderer.tsx
@@ -62,6 +62,11 @@ function asStringArray(value: unknown): string[] {
   return [String(value)];
 }
 
+/** Whether a value is a plain object (a nested block). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 const fieldDiagnostics = (
   diagnostics: readonly Diagnostic[] | undefined,
   key: string
@@ -111,6 +116,22 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
   return (
     <div className={`spytial-ed-fields${className ? ` ${className}` : ''}`}>
       {fields.map((field) => {
+        // Nested blocks render as their own sub-fieldset (or an "add" chip),
+        // outside the standard label+control row.
+        if (field.kind === 'group') {
+          return (
+            <GroupField
+              key={field.key}
+              field={field}
+              value={values[field.key]}
+              onChange={onChange}
+              options={options}
+              selectorProps={selectorProps}
+              diagnostics={diagnostics}
+              disabled={disabled}
+            />
+          );
+        }
         const fieldId = `${groupId}-${field.key}`;
         const labelId = `${fieldId}-label`;
         const diagId = `${fieldId}-diag`;
@@ -168,6 +189,88 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
     </div>
   );
 };
+
+/**
+ * A `group` field — a nested style block (lineStyle / textStyle / …). When the
+ * block is absent and optional, renders a progressive-disclosure "+ Label" chip;
+ * when present, a labeled sub-fieldset of the block's children (recursing through
+ * {@link FieldRenderer}) with a remove control. Children are kept sparse: a
+ * cleared leaf is dropped, and an emptied block is removed on emit by the codec.
+ */
+function GroupField({
+  field,
+  value,
+  onChange,
+  options,
+  selectorProps,
+  diagnostics,
+  disabled,
+}: {
+  field: FieldSpec;
+  value: unknown;
+  onChange: (key: string, value: unknown) => void;
+  options?: FieldRendererOptions;
+  selectorProps?: (field: FieldSpec) => SelectorFieldExtras | undefined;
+  diagnostics?: readonly Diagnostic[];
+  disabled: boolean;
+}): React.ReactElement {
+  const groupValue = isRecord(value) ? value : undefined;
+  const removable = !field.required;
+
+  if (groupValue === undefined) {
+    return (
+      <button
+        type="button"
+        className="spytial-ed-group-add"
+        onClick={() => onChange(field.key, {})}
+        disabled={disabled}
+        title={field.help}
+      >
+        + {field.label}
+      </button>
+    );
+  }
+
+  const setChild = (childKey: string, childVal: unknown) => {
+    const next: Record<string, unknown> = { ...groupValue };
+    const empty =
+      childVal === undefined ||
+      childVal === '' ||
+      (Array.isArray(childVal) && childVal.length === 0);
+    if (empty) delete next[childKey];
+    else next[childKey] = childVal;
+    onChange(field.key, next);
+  };
+
+  return (
+    <fieldset className="spytial-ed-group">
+      <legend className="spytial-ed-group-legend">
+        <span>{field.label}</span>
+        {removable ? (
+          <button
+            type="button"
+            className="spytial-ed-group-remove"
+            onClick={() => onChange(field.key, undefined)}
+            disabled={disabled}
+            aria-label={`Remove ${field.label}`}
+            title={`Remove ${field.label}`}
+          >
+            ×
+          </button>
+        ) : null}
+      </legend>
+      <FieldRenderer
+        fields={field.children ?? []}
+        values={groupValue}
+        onChange={setChild}
+        options={options}
+        selectorProps={selectorProps}
+        diagnostics={diagnostics}
+        disabled={disabled}
+      />
+    </fieldset>
+  );
+}
 
 interface ControlCtx {
   fieldId: string;

--- a/src/spec-editor/ui/spec-editor.css
+++ b/src/spec-editor/ui/spec-editor.css
@@ -1420,3 +1420,47 @@
     transition: none !important;
   }
 }
+
+/* ---- nested style blocks (lineStyle / textStyle / …) ---- */
+.spytial-ed-group {
+  border: 1px solid var(--spytial-ed-border, #d0d7de);
+  border-radius: 6px;
+  padding: 0.25rem 0.6rem 0.4rem;
+  margin: 0.25rem 0;
+  min-inline-size: 0;
+}
+.spytial-ed-group-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding-inline: 0.3rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--spytial-ed-muted, #656d76);
+}
+.spytial-ed-group-remove {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 0.15rem;
+  color: var(--spytial-ed-muted, #656d76);
+}
+.spytial-ed-group-remove:hover {
+  color: var(--spytial-ed-danger, #cf222e);
+}
+.spytial-ed-group-add {
+  align-self: flex-start;
+  border: 1px dashed var(--spytial-ed-border, #d0d7de);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  padding: 0.3rem 0.6rem;
+  margin: 0.15rem 0;
+  font-size: 0.78rem;
+  color: var(--spytial-ed-accent, #0969da);
+}
+.spytial-ed-group-add:hover {
+  background: var(--spytial-ed-hover, #f6f8fa);
+}

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -405,19 +405,37 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   }
 
   /**
-   * Node rectangle fill. Tufte: fill matches the canvas so only stroke + label
-   * distinguish a node. Transparent for hidden nodes and icon-only nodes.
+   * Node rectangle fill. Hidden and icon-only nodes stay transparent. An
+   * explicit `atomStyle.fillStyle.color` (d.fillColor) is an opt-in real fill,
+   * preserved exactly as chosen. Otherwise Tufte: the fill matches the canvas so
+   * only stroke + label distinguish a node.
    */
   private nodeFillColor(d: any): string {
     const isHidden = this.isHiddenNode(d);
     const hasIcon = !!d.icon;
     const showLabels = d.showLabels;
-    return isHidden || (hasIcon && !showLabels) ? 'transparent' : this.getCanvasBackground();
+    if (isHidden || (hasIcon && !showLabels)) return 'transparent';
+    return d.fillColor ?? this.getCanvasBackground();
   }
 
   /** Edge stroke (themed): preserves chosen colors, themes the implicit default. */
   private edgeStrokeColor(d: any): string | null {
     return this.isAlignmentEdge(d) ? 'none' : this.themedDataColor(d.color, '--cnd-edge-color', null);
+  }
+
+  /**
+   * Node border stroke width. An explicit `atomStyle.borderStyle.width`
+   * (d.borderWidth) wins; otherwise null so the constant default (NODE_STROKE_WIDTH)
+   * applies. Consumed via `.style()` (not `.attr()`) so it beats any node-rect
+   * CSS class rule — the same reason edge stroke-width uses `.style()`.
+   */
+  private nodeStrokeWidth(d: any): string | null {
+    return d.borderWidth != null ? `${d.borderWidth}px` : null;
+  }
+
+  /** Node main-label fill from `atomStyle.textStyle.color`; null = inherit the default label color. */
+  private nodeLabelColor(d: any): string | null {
+    return d.textStyle?.color ?? null;
   }
 
   /**
@@ -4004,6 +4022,8 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       .attr("rx", WebColaCnDGraph.NODE_BORDER_RADIUS)
       .attr("ry", WebColaCnDGraph.NODE_BORDER_RADIUS)
       .attr("stroke-width", WebColaCnDGraph.NODE_STROKE_WIDTH)
+      // atomStyle.borderStyle.width override via .style() so it beats CSS rules; null = keep the default above.
+      .style("stroke-width", (d: any) => this.nodeStrokeWidth(d))
       .attr("fill", (d: any) => this.nodeFillColor(d));
   }
 
@@ -4171,6 +4191,8 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
           .attr("class", "main-label-tspan")
           .style("font-weight", "bold")
           .style("font-size", `${MAIN_LABEL_FONT_SIZE}px`)
+          // atomStyle.textStyle.color for the node's own label; null = inherit the default black.
+          .style("fill", this.nodeLabelColor(d))
           .text(displayLabel);
 
         // Skolem-style labels: italic, comma-separated values per key. These are

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -438,6 +438,11 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     return d.textStyle?.color ?? null;
   }
 
+  /** Group label fill from the group directive's `textStyle.color`; null = keep the default (#333). */
+  private groupLabelColor(d: any): string | null {
+    return d.labelTextStyle?.color ?? null;
+  }
+
   /**
    * Re-apply the data-driven themed colors (node border/fill, type-label fill,
    * edge stroke) to the live DOM. The `--cnd-*` slots auto-update via CSS
@@ -3905,6 +3910,8 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       })
       .attr("font-weight", "bold")
       .attr("fill", "#333")
+      // Group directive's textStyle.color override via .style() (beats the attr default); null = keep #333.
+      .style("fill", (d: any) => this.groupLabelColor(d))
       .attr("pointer-events", "none")
       .text((d: any) => {
         const shouldShowGroupLabel = d.showLabel || false;

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -3252,6 +3252,16 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       .style("pointer-events", "none");
   }
 
+  /** Edge-label font size from its textStyle tier, or null → CSS default (.linklabel). */
+  private edgeLabelFontSize(d: any): string | null {
+    return d?.textStyle?.size ? `${resolveAttrFontSize(d.textStyle.size)}px` : null;
+  }
+
+  /** Edge-label fill from its textStyle color, or null → CSS default (.linklabel). */
+  private edgeLabelFill(d: any): string | null {
+    return d?.textStyle?.color ?? null;
+  }
+
   private getEdgeDasharray(style?: string): string | null {
     if (!style) {
       return null;
@@ -3287,6 +3297,11 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       .attr("text-anchor", "middle")
       .attr("dominant-baseline", "middle")
       .attr("font-family", this.getFontFamily())
+      // Edge-label styling from the edge's textStyle block. Use .style() (not
+      // .attr) so the inline value overrides the .linklabel CSS rule — a
+      // presentation attribute would lose to it. null → the CSS default applies.
+      .style("font-size", (d: any) => this.edgeLabelFontSize(d))
+      .style("fill", (d: any) => this.edgeLabelFill(d))
       .attr("pointer-events", "none")
       .text((d: any) => d.label || d.relName || "");
   }

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -52,6 +52,12 @@ type NodeWithMetadata = Node & {
   color: string,
   /** Provenance of `color` (default palette vs. user directive). See {@link ColorSource}. */
   colorSource?: ColorSource,
+  /** Interior fill from `atomStyle.fillStyle.color`; absent = renderer's canvas-matched default. */
+  fillColor?: string,
+  /** Border/stroke width in px from `atomStyle.borderStyle.width`; absent = renderer default. */
+  borderWidth?: number,
+  /** Main-label styling from `atomStyle.textStyle` (only `color` consumed today; see LayoutNode). */
+  textStyle?: TextStyle,
   icon: string,
   mostSpecificType: string,
   showLabels: boolean,
@@ -691,6 +697,9 @@ export class WebColaLayout {
       id: node.id,
       color: node.color,
       colorSource: node.colorSource ?? ColorSource.DefaultPalette,
+      fillColor: node.fillColor,
+      borderWidth: node.borderWidth,
+      textStyle: node.textStyle,
       attributes: node.attributes || {},
       attributeSizes: node.attributeSizes || {},
       labels: node.labels,

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -1060,13 +1060,17 @@ export class WebColaLayout {
 
       let groupsAndSubgroups = this.determineGroupsAndSubgroups(groupsAsRecord);
 
-      groupsAndSubgroups.forEach((group) => {
+      // `group` gets dynamic layout fields (keyNode/id/showLabel/labelTextStyle)
+      // stamped onto it below, so it's typed loosely here.
+      groupsAndSubgroups.forEach((group: any) => {
         let grp: LayoutGroup = groups.find(g => g.name === group.name);
         let keyNode = grp.keyNodeId;
         let keyIndex = this.getNodeIndex(keyNode);
         group['keyNode'] = keyIndex;
         group['id'] = grp.name;
         group['showLabel'] = grp.showLabel;
+        // Group's own label styling (only color consumed today; size auto-fits).
+        group['labelTextStyle'] = grp.labelTextStyle;
       });
 
       return groupsAndSubgroups;

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -1,6 +1,7 @@
 import { Node, Group, Link, Rectangle } from 'webcola';
 import { InstanceLayout, LayoutNode, LayoutEdge, LayoutConstraint, LayoutGroup, LeftConstraint, TopConstraint, AlignmentConstraint, isLeftConstraint, isTopConstraint, isAlignmentConstraint, isBoundingBoxConstraint, isGroupBoundaryConstraint, ColorSource } from '../../layout/interfaces';
 import { EdgeStyle } from '../../layout/edge-style';
+import type { TextStyle } from '../../layout/style/text-style';
 import type { AttrTextSize } from '../../layout/text-extent';
 import { LayoutInstance } from '../../layout/layoutinstance';
 import type { IDataInstance } from '../../data-instance/interfaces';
@@ -72,6 +73,8 @@ type EdgeWithMetadata = Link<NodeWithMetadata> & {
   /** Highlight color rendered as a wider underlay beneath the edge. Undefined = no highlight. */
   highlight?: string,
   showLabel?: boolean, // Whether to show the edge label (default: true)
+  /** Optional label styling (size / color) for the edge's label text. */
+  textStyle?: TextStyle,
   bidirectional?: boolean, // Flag to indicate if this edge represents a bidirectional relationship
   /**
    * For group edges (id starts with `_g_`), the name of the group this edge
@@ -727,6 +730,7 @@ export class WebColaLayout {
       weight: edge.weight,
       highlight: edge.highlight,
       showLabel: edge.showLabel,
+      textStyle: edge.textStyle,
       groupId: edge.groupId,
       keyNodeId: edge.keyNodeId,
     }

--- a/tests/atom-style-directive.test.ts
+++ b/tests/atom-style-directive.test.ts
@@ -202,4 +202,17 @@ directives:
         expect(warn).toHaveBeenCalledWith(expect.stringContaining("'atomColor' is deprecated"));
         warn.mockRestore();
     });
+
+    it('drops a selectorless atomColor instead of desugaring it into a global rule', () => {
+        // atomColor's selector is required; a missing one was a no-op, so it must
+        // NOT become an atomStyle that recolors every atom.
+        const spec = parseLayoutSpec("directives:\n  - atomColor: { value: '#f00' }");
+        expect(spec.directives.atomStyles).toEqual([]);
+    });
+
+    it('a selectorless atomColor does not recolor every node (end to end)', () => {
+        const { layout } = layoutFor("directives:\n  - atomColor: { value: '#f00' }")();
+        expect(nodeById(layout, 'n1').color).not.toBe('#f00');
+        expect(nodeById(layout, 'r1').color).not.toBe('#f00');
+    });
 });

--- a/tests/atom-style-directive.test.ts
+++ b/tests/atom-style-directive.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Integration tests for the `atomStyle` directive end-to-end: parse → match
+ * (selector) → resolve (compose / collide, inheritance via selectors) →
+ * LayoutNode fields (`color` = border outline, `fillColor`, `borderWidth`,
+ * `textStyle`). Also pins the border-preserving `atomColor` desugar.
+ *
+ * `RedNode` is a subtype of `Node`, so a `Node` selector already returns the
+ * `RedNode` atom — that's how gap-fill inheritance up the type ancestry falls
+ * out of ordinary selector matching, with no explicit ancestry walk.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { ColorSource } from '../src/layout/interfaces';
+import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
+import { StyleCollisionError } from '../src/layout/style/style-resolver';
+
+const data: IJsonDataInstance = {
+    atoms: [
+        { id: 'n1', type: 'Node', label: 'n1' },
+        { id: 'r1', type: 'RedNode', label: 'r1' },
+    ],
+    relations: [
+        {
+            id: 'link',
+            name: 'link',
+            types: ['Node', 'Node'],
+            tuples: [{ atoms: ['n1', 'r1'], types: ['Node', 'RedNode'] }],
+        },
+    ],
+    // Type `atoms` carry full atom objects (not id strings); RedNode extends Node
+    // so a `Node` selector already returns r1 — the basis of the inheritance test.
+    types: [
+        { id: 'Node', types: ['Node'], atoms: [{ id: 'n1', type: 'Node', label: 'n1' }], isBuiltin: false },
+        { id: 'RedNode', types: ['RedNode', 'Node'], atoms: [{ id: 'r1', type: 'RedNode', label: 'r1' }], isBuiltin: false },
+    ],
+};
+
+function layoutFor(specStr: string) {
+    const layoutSpec = parseLayoutSpec(specStr);
+    const instance = new JSONDataInstance(data);
+    const evaluator = new SGraphQueryEvaluator();
+    evaluator.initialize({ sourceData: instance });
+    const layoutInstance = new LayoutInstance(layoutSpec, evaluator, 0, true);
+    return () => layoutInstance.generateLayout(instance);
+}
+
+const nodeById = (layout: any, id: string) => layout.nodes.find((n: any) => n.id === id);
+
+describe('atomStyle directive — end to end', () => {
+    it('carries fillColor, border color+width, and label textStyle onto the LayoutNode', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: n1
+      fillStyle:
+        color: '#eef'
+      borderStyle:
+        color: '#33c'
+        width: 3
+      textStyle:
+        color: '#003'
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.fillColor).toBe('#eef');
+        expect(n.color).toBe('#33c'); // borderStyle.color drives the node's outline color
+        expect(n.colorSource).toBe(ColorSource.Directive); // explicit → renderer preserves it
+        expect(n.borderWidth).toBe(3);
+        expect(n.textStyle).toEqual({ color: '#003' });
+    });
+
+    it('styles only atoms matching the selector; others keep the default palette', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: n1
+      fillStyle:
+        color: '#eef'
+`)();
+        expect(nodeById(layout, 'n1').fillColor).toBe('#eef');
+        const r = nodeById(layout, 'r1');
+        expect(r.fillColor).toBeUndefined();
+        expect(r.borderWidth).toBeUndefined();
+        expect(r.colorSource).toBe(ColorSource.DefaultPalette);
+    });
+
+    it('inherits a supertype rule and composes it with a subtype rule (no explicit ancestry walk)', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: Node
+      fillStyle:
+        color: '#eef'
+  - atomStyle:
+      selector: RedNode
+      borderStyle:
+        color: red
+`)();
+        const r = nodeById(layout, 'r1');
+        expect(r.fillColor).toBe('#eef'); // inherited from the Node rule (RedNode is-a Node)
+        expect(r.color).toBe('red'); // from the RedNode rule
+        // n1 matches only the Node rule.
+        expect(nodeById(layout, 'n1').fillColor).toBe('#eef');
+    });
+
+    it('HARD ERRORS when a supertype and subtype rule disagree on the same leaf', () => {
+        const run = layoutFor(`
+directives:
+  - atomStyle:
+      selector: Node
+      borderStyle:
+        color: blue
+  - atomStyle:
+      selector: RedNode
+      borderStyle:
+        color: red
+`);
+        expect(run).toThrow(StyleCollisionError); // r1 sees blue (from Node) vs red (from RedNode)
+    });
+
+    it('composes two overlapping rules on the same selector leaf-wise', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: n1
+      fillStyle:
+        color: '#eef'
+  - atomStyle:
+      selector: n1
+      borderStyle:
+        width: 4
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.fillColor).toBe('#eef');
+        expect(n.borderWidth).toBe(4);
+    });
+
+    it('desugars a legacy atomColor into the border color (border-preserving, no fill)', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomColor:
+      selector: n1
+      value: '#f80'
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.color).toBe('#f80'); // outline preserved exactly as before
+        expect(n.colorSource).toBe(ColorSource.Directive);
+        expect(n.fillColor).toBeUndefined(); // no interior fill
+    });
+
+    it('composes a legacy atomColor border with an atomStyle fill', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomColor:
+      selector: n1
+      value: '#111'
+  - atomStyle:
+      selector: n1
+      fillStyle:
+        color: '#eef'
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.color).toBe('#111'); // from the desugared atomColor
+        expect(n.fillColor).toBe('#eef'); // from the atomStyle
+    });
+
+    it('HARD ERRORS when a legacy atomColor and an atomStyle disagree on the border color', () => {
+        const run = layoutFor(`
+directives:
+  - atomColor:
+      selector: n1
+      value: '#111'
+  - atomStyle:
+      selector: n1
+      borderStyle:
+        color: '#222'
+`);
+        expect(run).toThrow(StyleCollisionError);
+    });
+});
+
+describe('atomColor → atomStyle desugar (parse level)', () => {
+    it('desugars a standalone atomColor into a border-preserving atomStyle rule (and empties atomColors)', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - atomColor:
+      selector: Root
+      value: '#f80'
+`);
+        expect(spec.directives.atomColors).toEqual([]);
+        expect(spec.directives.atomStyles).toHaveLength(1);
+        expect(spec.directives.atomStyles[0]).toEqual({
+            selector: 'Root',
+            style: { borderStyle: { color: '#f80' } },
+        });
+    });
+
+    it('warns that atomColor is deprecated', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        parseLayoutSpec("directives:\n  - atomColor: { selector: Root, value: '#f80' }");
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("'atomColor' is deprecated"));
+        warn.mockRestore();
+    });
+});

--- a/tests/atom-style-render.test.ts
+++ b/tests/atom-style-render.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Renderer-level coverage for atom styling: proves a node datum's atomStyle
+ * fields carry through webcola-cnd-graph into the SVG presentation attributes —
+ * the interior fill (`fillColor`), the border width (`borderWidth`, via
+ * `.style()` so it beats CSS class rules), and the main-label color
+ * (`textStyle.color`). This is the durable form of the manual browser check: the
+ * datum fields here are exactly what the webcola translator produces from a
+ * resolved `atomStyle`.
+ *
+ * Uses prototype injection (the codebase's idiom for renderer internals — see
+ * edge-style-render.test.ts) rather than a full jsdom mount.
+ */
+import { describe, it, expect } from 'vitest';
+import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
+import { WebColaLayout } from '../src/translators/webcola/webcolatranslator';
+
+const proto = WebColaCnDGraph.prototype as any;
+
+describe('webcola-cnd-graph — node fill color', () => {
+    // A themed default canvas; nodeFillColor falls back to it when no fill is set.
+    const base = { isHiddenNode: () => false, getCanvasBackground: () => '#fafafa' };
+    const fill = (thisArg: any, d: any) => proto.nodeFillColor.call(thisArg, d);
+
+    it('uses an explicit atomStyle fill color', () => {
+        expect(fill(base, { fillColor: '#eef', showLabels: true })).toBe('#eef');
+    });
+
+    it('falls back to the canvas background (Tufte) when no fill is set', () => {
+        expect(fill(base, { showLabels: true })).toBe('#fafafa');
+    });
+
+    it('stays transparent for a hidden node even if a fill is set', () => {
+        const hidden = { ...base, isHiddenNode: () => true };
+        expect(fill(hidden, { fillColor: '#eef', showLabels: true })).toBe('transparent');
+    });
+
+    it('stays transparent for an icon-only node (icon, labels hidden)', () => {
+        expect(fill(base, { fillColor: '#eef', icon: 'x', showLabels: false })).toBe('transparent');
+    });
+});
+
+describe('webcola-cnd-graph — node border width', () => {
+    const width = (d: unknown) => proto.nodeStrokeWidth.call({}, d);
+
+    it('maps an atomStyle border width to a px string', () => {
+        expect(width({ borderWidth: 3 })).toBe('3px');
+    });
+
+    it('returns null when no border width is set (→ the default stroke width applies)', () => {
+        expect(width({})).toBeNull();
+        expect(width({ borderWidth: undefined })).toBeNull();
+    });
+});
+
+describe('webcola-cnd-graph — node label color', () => {
+    const color = (d: unknown) => proto.nodeLabelColor.call({}, d);
+
+    it('passes an atomStyle textStyle color to the label fill', () => {
+        expect(color({ textStyle: { color: '#003' } })).toBe('#003');
+    });
+
+    it('returns null when no label color is set (→ inherit the default black)', () => {
+        expect(color({ textStyle: {} })).toBeNull();
+        expect(color({})).toBeNull();
+    });
+});
+
+describe('webcola translator — LayoutNode atomStyle reaches the render datum', () => {
+    // toColaNode only needs positioning state; the style fields pass straight
+    // through to the NodeWithMetadata the renderer reads.
+    const stubThis = {
+        DEFAULT_X: 0,
+        DEFAULT_Y: 0,
+        priorPositionMap: new Map(),
+        lockUnconstrainedNodes: false,
+        dagre_graph: null,
+    };
+    const toColaNode = (node: any) => (WebColaLayout.prototype as any).toColaNode.call(stubThis, node);
+
+    it('carries color (border), fillColor, borderWidth, and textStyle onto the datum', () => {
+        const datum = toColaNode({
+            id: 'n1',
+            label: 'n1',
+            color: '#33c',
+            fillColor: '#eef',
+            borderWidth: 3,
+            textStyle: { color: '#003' },
+            width: 100,
+            height: 60,
+            mostSpecificType: 'Node',
+            showLabels: true,
+        });
+        expect(datum).toMatchObject({
+            color: '#33c',
+            fillColor: '#eef',
+            borderWidth: 3,
+            textStyle: { color: '#003' },
+        });
+    });
+
+    it('leaves the style fields undefined when the node has no atomStyle', () => {
+        const datum = toColaNode({
+            id: 'n2',
+            label: 'n2',
+            color: 'black',
+            width: 100,
+            height: 60,
+            mostSpecificType: 'Node',
+            showLabels: true,
+        });
+        expect(datum.fillColor).toBeUndefined();
+        expect(datum.borderWidth).toBeUndefined();
+        expect(datum.textStyle).toBeUndefined();
+    });
+});

--- a/tests/atom-style-spec.test.ts
+++ b/tests/atom-style-spec.test.ts
@@ -43,6 +43,12 @@ describe('atomColorToAtomStyleRule — border-preserving desugar', () => {
             style: { borderStyle: { color: '#eef' } },
         });
     });
+
+    it('returns null for a missing/blank selector (atomColor requires one — never a global recolor)', () => {
+        expect(atomColorToAtomStyleRule({ value: '#eef' })).toBeNull();
+        expect(atomColorToAtomStyleRule({ value: '#eef', selector: '' })).toBeNull();
+        expect(atomColorToAtomStyleRule({ value: '#eef', selector: '   ' })).toBeNull();
+    });
 });
 
 describe('resolveAtomStyle — compose + collide', () => {

--- a/tests/atom-style-spec.test.ts
+++ b/tests/atom-style-spec.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+    parseAtomStyleSpec,
+    resolveAtomStyle,
+    atomColorToAtomStyleRule,
+} from '../src/layout/style/atom-style-spec';
+import type { AtomStyleRule } from '../src/layout/style/atom-style-spec';
+import { StyleCollisionError } from '../src/layout/style/style-resolver';
+
+describe('parseAtomStyleSpec', () => {
+    it('extracts fillStyle / borderStyle / textStyle blocks', () => {
+        expect(
+            parseAtomStyleSpec({
+                fillStyle: { color: '#eef' },
+                borderStyle: { color: '#33c', width: 2 },
+                textStyle: { size: 'large', color: '#003' },
+            }),
+        ).toEqual({
+            fillStyle: { color: '#eef' },
+            borderStyle: { color: '#33c', width: 2 },
+            textStyle: { size: 'large', color: '#003' },
+        });
+    });
+
+    it('is sparse — omits unset keys and blocks', () => {
+        expect(parseAtomStyleSpec({ fillStyle: { color: '#eef' } })).toEqual({ fillStyle: { color: '#eef' } });
+        expect(parseAtomStyleSpec({})).toEqual({});
+        expect(parseAtomStyleSpec(undefined)).toEqual({});
+    });
+
+    it('drops a non-positive border width', () => {
+        expect(parseAtomStyleSpec({ borderStyle: { width: 0 } })).toEqual({});
+        expect(parseAtomStyleSpec({ borderStyle: { color: '#000', width: -1 } })).toEqual({
+            borderStyle: { color: '#000' },
+        });
+    });
+});
+
+describe('atomColorToAtomStyleRule — border-preserving desugar', () => {
+    it('maps value → borderStyle.color (preserves the outline behavior)', () => {
+        expect(atomColorToAtomStyleRule({ value: '#eef', selector: 'Person' })).toEqual({
+            selector: 'Person',
+            style: { borderStyle: { color: '#eef' } },
+        });
+    });
+});
+
+describe('resolveAtomStyle — compose + collide', () => {
+    it('composes fill from one rule with border from another (inheritance via selectors)', () => {
+        const rules: AtomStyleRule[] = [
+            { selector: 'Node', style: { fillStyle: { color: '#eef' } } },
+            { selector: 'RedNode', style: { borderStyle: { color: 'red' } } },
+        ];
+        expect(resolveAtomStyle(rules)).toEqual({
+            fillStyle: { color: '#eef' },
+            borderStyle: { color: 'red' },
+        });
+    });
+
+    it('HARD ERRORS when two matching rules disagree on a leaf', () => {
+        const rules: AtomStyleRule[] = [
+            { selector: 'Node', style: { borderStyle: { color: 'blue' } } },
+            { selector: 'RedNode', style: { borderStyle: { color: 'red' } } },
+        ];
+        expect(() => resolveAtomStyle(rules)).toThrow(StyleCollisionError);
+    });
+});

--- a/tests/edge-style-directive.test.ts
+++ b/tests/edge-style-directive.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration tests for the `edgeStyle` directive end-to-end: parse → match
+ * (field/selector/filter) → resolve (compose / collide) → LayoutEdge fields.
+ * Also pins the additive precedence over the legacy `edgeColor` path.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
+import { StyleCollisionError } from '../src/layout/style/style-resolver';
+
+const treeData: IJsonDataInstance = {
+    atoms: [
+        { id: 'Node0', type: 'Node', label: 'Node0' },
+        { id: 'Node1', type: 'Node', label: 'Node1' },
+        { id: 'Node2', type: 'Node', label: 'Node2' },
+        { id: 'Node3', type: 'Node', label: 'Node3' },
+        { id: 'Node4', type: 'Node', label: 'Node4' },
+    ],
+    relations: [
+        {
+            id: 'left',
+            name: 'left',
+            types: ['Node', 'Node'],
+            tuples: [
+                { atoms: ['Node3', 'Node1'], types: ['Node', 'Node'] },
+                { atoms: ['Node4', 'Node2'], types: ['Node', 'Node'] },
+            ],
+        },
+        {
+            id: 'right',
+            name: 'right',
+            types: ['Node', 'Node'],
+            tuples: [{ atoms: ['Node1', 'Node4'], types: ['Node', 'Node'] }],
+        },
+    ],
+};
+
+function layoutFor(specStr: string) {
+    const layoutSpec = parseLayoutSpec(specStr);
+    const instance = new JSONDataInstance(treeData);
+    const evaluator = new SGraphQueryEvaluator();
+    evaluator.initialize({ sourceData: instance });
+    const layoutInstance = new LayoutInstance(layoutSpec, evaluator, 0, true);
+    return () => layoutInstance.generateLayout(instance);
+}
+
+describe('edgeStyle directive — end to end', () => {
+    it('applies line color / pattern / weight to every matching edge', () => {
+        const { layout } = layoutFor(`
+directives:
+  - edgeStyle:
+      field: left
+      lineStyle:
+        color: '#3366cc'
+        pattern: dashed
+        weight: 3
+`)();
+        const left = layout.edges.filter((e) => e.relationName === 'left');
+        expect(left).toHaveLength(2);
+        for (const e of left) {
+            expect(e.color).toBe('#3366cc');
+            expect(e.style).toBe('dashed');
+            expect(e.weight).toBe(3);
+        }
+        // 'right' edges are untouched — legacy default color, no style.
+        const right = layout.edges.filter((e) => e.relationName === 'right');
+        expect(right[0].color).toBe('black');
+        expect(right[0].style).toBeUndefined();
+    });
+
+    it('honors the selector, styling only edges from matching sources', () => {
+        const { layout } = layoutFor(`
+directives:
+  - edgeStyle:
+      field: left
+      selector: Node3
+      lineStyle:
+        color: '#ff0000'
+`)();
+        const styled = layout.edges.find((e) => e.relationName === 'left' && e.source.id === 'Node3');
+        const other = layout.edges.find((e) => e.relationName === 'left' && e.source.id === 'Node4');
+        expect(styled?.color).toBe('#ff0000');
+        expect(other?.color).toBe('black');
+    });
+
+    it('composes two overlapping rules leaf-wise (color from one, weight from the other)', () => {
+        const { layout } = layoutFor(`
+directives:
+  - edgeStyle:
+      field: left
+      lineStyle:
+        color: '#3366cc'
+  - edgeStyle:
+      field: left
+      lineStyle:
+        weight: 5
+`)();
+        const e = layout.edges.find((edge) => edge.relationName === 'left');
+        expect(e?.color).toBe('#3366cc');
+        expect(e?.weight).toBe(5);
+    });
+
+    it('HARD ERRORS when two matching rules disagree on a leaf', () => {
+        const run = layoutFor(`
+directives:
+  - edgeStyle:
+      field: left
+      lineStyle:
+        color: '#3366cc'
+  - edgeStyle:
+      field: left
+      lineStyle:
+        color: '#ff0000'
+`);
+        expect(run).toThrow(StyleCollisionError);
+    });
+
+    it('composes a legacy edgeColor with an edgeStyle (different properties)', () => {
+        const { layout } = layoutFor(`
+directives:
+  - edgeColor:
+      field: left
+      value: '#111111'
+  - edgeStyle:
+      field: left
+      lineStyle:
+        weight: 5
+`)();
+        const e = layout.edges.find((edge) => edge.relationName === 'left');
+        expect(e?.color).toBe('#111111'); // from the desugared edgeColor
+        expect(e?.weight).toBe(5); // from the edgeStyle
+    });
+
+    it('HARD ERRORS when a legacy edgeColor and an edgeStyle disagree on a property', () => {
+        const run = layoutFor(`
+directives:
+  - edgeColor:
+      field: left
+      value: '#111111'
+  - edgeStyle:
+      field: left
+      lineStyle:
+        color: '#3366cc'
+`);
+        expect(run).toThrow(StyleCollisionError);
+    });
+});
+
+describe('edgeColor → edgeStyle desugar', () => {
+    it('desugars a standalone edgeColor into an edgeStyle rule (and empties edgeColors)', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - edgeColor:
+      field: left
+      value: '#111111'
+      style: dashed
+      weight: 2
+`);
+        expect(spec.directives.edgeColors).toEqual([]);
+        expect(spec.directives.edgeStyles).toHaveLength(1);
+        expect(spec.directives.edgeStyles[0].style).toEqual({
+            lineStyle: { color: '#111111', pattern: 'dashed', weight: 2 },
+        });
+    });
+
+    it('warns that edgeColor is deprecated', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        parseLayoutSpec("directives:\n  - edgeColor: { field: left, value: '#111111' }");
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("'edgeColor' is deprecated"));
+        warn.mockRestore();
+    });
+});
+
+describe('inferredEdge — lineStyle/textStyle block adoption', () => {
+    it('parses lineStyle + textStyle blocks onto the inferred edge', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - inferredEdge:
+      name: reachable
+      selector: '^next'
+      lineStyle:
+        color: '#a0f'
+        pattern: dotted
+        weight: 2
+      textStyle:
+        size: small
+`);
+        expect(spec.directives.inferredEdges).toHaveLength(1);
+        const ie = spec.directives.inferredEdges[0];
+        expect(ie.name).toBe('reachable');
+        expect(ie.color).toBe('#a0f'); // lineStyle.color → flat color field (unchanged consumption)
+        expect(ie.style).toBe('dotted'); // lineStyle.pattern → flat style field
+        expect(ie.weight).toBe(2);
+        expect(ie.textStyle).toEqual({ size: 'small' });
+    });
+
+    it('still accepts legacy inline color/style/weight and warns', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const spec = parseLayoutSpec(`
+directives:
+  - inferredEdge:
+      name: reachable
+      selector: '^next'
+      color: '#a0f'
+      style: dotted
+`);
+        const ie = spec.directives.inferredEdges[0];
+        expect(ie.color).toBe('#a0f');
+        expect(ie.style).toBe('dotted');
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("inferredEdge's inline"));
+        warn.mockRestore();
+    });
+
+    it('prefers the lineStyle block over a legacy inline value', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - inferredEdge:
+      name: reachable
+      selector: '^next'
+      color: '#000'
+      lineStyle:
+        color: '#a0f'
+`);
+        expect(spec.directives.inferredEdges[0].color).toBe('#a0f');
+    });
+});

--- a/tests/edge-style-directive.test.ts
+++ b/tests/edge-style-directive.test.ts
@@ -184,6 +184,19 @@ directives:
         expect(warn).toHaveBeenCalledWith(expect.stringContaining("'edgeColor' is deprecated"));
         warn.mockRestore();
     });
+
+    it('preserves a capitalized legacy style (Dashed → dashed) through to the LayoutEdge', () => {
+        // The old edgeColor path lowercased via normalizeEdgeStyle; the desugar must too.
+        const { layout } = layoutFor(`
+directives:
+  - edgeColor:
+      field: left
+      value: '#111111'
+      style: Dashed
+`)();
+        const e = layout.edges.find((edge) => edge.relationName === 'left');
+        expect(e?.style).toBe('dashed');
+    });
 });
 
 describe('inferredEdge — lineStyle/textStyle block adoption', () => {

--- a/tests/edge-style-directive.test.ts
+++ b/tests/edge-style-directive.test.ts
@@ -70,6 +70,19 @@ directives:
         expect(right[0].style).toBeUndefined();
     });
 
+    it('carries textStyle (edge-label styling) onto the LayoutEdge', () => {
+        const { layout } = layoutFor(`
+directives:
+  - edgeStyle:
+      field: left
+      textStyle:
+        size: large
+        color: '#a00'
+`)();
+        const e = layout.edges.find((edge) => edge.relationName === 'left');
+        expect(e?.textStyle).toEqual({ size: 'large', color: '#a00' });
+    });
+
     it('honors the selector, styling only edges from matching sources', () => {
         const { layout } = layoutFor(`
 directives:

--- a/tests/edge-style-render.test.ts
+++ b/tests/edge-style-render.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Renderer-level coverage for edge styling: proves an edge datum's style
+ * carries through webcola-cnd-graph into the SVG presentation attributes
+ * (stroke-dasharray from the line pattern, stroke from the color). This is the
+ * durable form of the manual browser check — the datum fields here are exactly
+ * what the webcola translator produces from a resolved `edgeStyle` (LayoutEdge
+ * .style/.color → datum .style/.color).
+ *
+ * Uses prototype injection (the codebase's idiom for renderer internals — see
+ * edge-routing-taut.test.ts) rather than a full jsdom mount.
+ */
+import { describe, it, expect } from 'vitest';
+import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
+import { WebColaLayout } from '../src/translators/webcola/webcolatranslator';
+
+const proto = WebColaCnDGraph.prototype as any;
+
+describe('webcola-cnd-graph — line pattern → stroke-dasharray', () => {
+    const dash = (pattern?: string) => proto.getEdgeDasharray.call({}, pattern);
+
+    it('maps dashed → "6,4"', () => expect(dash('dashed')).toBe('6,4'));
+    it('maps dotted → "1,4"', () => expect(dash('dotted')).toBe('1,4'));
+    it('maps solid → null (no dashes)', () => expect(dash('solid')).toBeNull());
+    it('maps a missing pattern → null', () => expect(dash(undefined)).toBeNull());
+    it('is case-insensitive', () => expect(dash('Dashed')).toBe('6,4'));
+});
+
+describe('webcola-cnd-graph — edge color → stroke', () => {
+    // A theme-less `this`: no slots defined, so themedDataColor returns the
+    // chosen color verbatim (its theming branch only fires for the implicit
+    // black default under an active theme slot).
+    const themeless = {
+        isAlignmentEdge: () => false,
+        themedDataColor: proto.themedDataColor,
+        themeOverrides: {},
+        activeSlots: () => ({}),
+    };
+
+    it('passes a chosen edge color straight through to the stroke', () => {
+        expect(proto.edgeStrokeColor.call(themeless, { color: '#e63946' })).toBe('#e63946');
+    });
+
+    it('renders no stroke for an alignment edge', () => {
+        const alignmentThis = { ...themeless, isAlignmentEdge: () => true };
+        expect(proto.edgeStrokeColor.call(alignmentThis, { color: '#e63946' })).toBe('none');
+    });
+});
+
+describe('webcola translator — LayoutEdge style reaches the render datum', () => {
+    // toColaEdge only needs getNodeIndex; the rest of the fields pass straight
+    // through to the EdgeWithMetadata the renderer reads.
+    const toColaEdge = (edge: any) =>
+        (WebColaLayout.prototype as any).toColaEdge.call({ getNodeIndex: (_id: string) => 0 }, edge);
+
+    it('carries color, pattern (style), weight, highlight, showLabel onto the datum', () => {
+        const datum = toColaEdge({
+            source: { id: 'A' },
+            target: { id: 'B' },
+            relationName: 'knows',
+            id: 'e1',
+            label: 'knows',
+            color: '#e63946',
+            style: 'dashed',
+            weight: 4,
+            highlight: '#fc0',
+            showLabel: true,
+        });
+        expect(datum).toMatchObject({
+            color: '#e63946',
+            style: 'dashed',
+            weight: 4,
+            highlight: '#fc0',
+            showLabel: true,
+        });
+    });
+});

--- a/tests/edge-style-render.test.ts
+++ b/tests/edge-style-render.test.ts
@@ -52,7 +52,7 @@ describe('webcola translator — LayoutEdge style reaches the render datum', () 
     const toColaEdge = (edge: any) =>
         (WebColaLayout.prototype as any).toColaEdge.call({ getNodeIndex: (_id: string) => 0 }, edge);
 
-    it('carries color, pattern (style), weight, highlight, showLabel onto the datum', () => {
+    it('carries color, pattern (style), weight, highlight, showLabel, textStyle onto the datum', () => {
         const datum = toColaEdge({
             source: { id: 'A' },
             target: { id: 'B' },
@@ -64,6 +64,7 @@ describe('webcola translator — LayoutEdge style reaches the render datum', () 
             weight: 4,
             highlight: '#fc0',
             showLabel: true,
+            textStyle: { size: 'large', color: '#a00' },
         });
         expect(datum).toMatchObject({
             color: '#e63946',
@@ -71,6 +72,29 @@ describe('webcola translator — LayoutEdge style reaches the render datum', () 
             weight: 4,
             highlight: '#fc0',
             showLabel: true,
+            textStyle: { size: 'large', color: '#a00' },
         });
+    });
+});
+
+describe('webcola-cnd-graph — edge label textStyle → font-size / fill', () => {
+    const fontSize = (d: unknown) => proto.edgeLabelFontSize.call({}, d);
+    const fill = (d: unknown) => proto.edgeLabelFill.call({}, d);
+
+    it('maps a textStyle size tier to a px font size', () => {
+        expect(fontSize({ textStyle: { size: 'small' } })).toBe('9px');
+        expect(fontSize({ textStyle: { size: 'normal' } })).toBe('11px');
+        expect(fontSize({ textStyle: { size: 'large' } })).toBe('16px');
+    });
+
+    it('returns null font-size when no size tier is set (→ CSS default)', () => {
+        expect(fontSize({ textStyle: {} })).toBeNull();
+        expect(fontSize({})).toBeNull();
+    });
+
+    it('passes a textStyle color to the label fill, else null', () => {
+        expect(fill({ textStyle: { color: '#a00' } })).toBe('#a00');
+        expect(fill({ textStyle: {} })).toBeNull();
+        expect(fill({})).toBeNull();
     });
 });

--- a/tests/edge-style-spec.test.ts
+++ b/tests/edge-style-spec.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { parseEdgeStyleSpec, resolveEdgeStyle } from '../src/layout/style/edge-style-spec';
+import type { EdgeStyleRule } from '../src/layout/style/edge-style-spec';
+import { StyleCollisionError } from '../src/layout/style/style-resolver';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+
+describe('parseEdgeStyleSpec', () => {
+    it('extracts the nested lineStyle block', () => {
+        expect(
+            parseEdgeStyleSpec({ lineStyle: { color: '#36c', pattern: 'dashed', weight: 2, highlight: '#fc0' } }),
+        ).toEqual({ lineStyle: { color: '#36c', pattern: 'dashed', weight: 2, highlight: '#fc0' } });
+    });
+
+    it('extracts the textStyle block and behavior flags', () => {
+        expect(
+            parseEdgeStyleSpec({ textStyle: { size: 'small', color: '#666' }, showLabel: true, hidden: false }),
+        ).toEqual({ textStyle: { size: 'small', color: '#666' }, showLabel: true, hidden: false });
+    });
+
+    it('is sparse — omits keys the author did not set', () => {
+        expect(parseEdgeStyleSpec({ lineStyle: { color: '#36c' } })).toEqual({ lineStyle: { color: '#36c' } });
+    });
+
+    it('drops an invalid line pattern rather than inventing one', () => {
+        expect(parseEdgeStyleSpec({ lineStyle: { pattern: 'zigzag' } })).toEqual({});
+    });
+
+    it('drops an invalid text size', () => {
+        expect(parseEdgeStyleSpec({ textStyle: { size: 'huge' } })).toEqual({});
+    });
+
+    it('drops a non-positive or non-finite weight', () => {
+        expect(parseEdgeStyleSpec({ lineStyle: { weight: 0 } })).toEqual({});
+        expect(parseEdgeStyleSpec({ lineStyle: { weight: -3 } })).toEqual({});
+        expect(parseEdgeStyleSpec({ lineStyle: { color: '#000', weight: 2 } })).toEqual({
+            lineStyle: { color: '#000', weight: 2 },
+        });
+    });
+
+    it('ignores field/selector/filter (matching keys, not style)', () => {
+        expect(
+            parseEdgeStyleSpec({ field: 'knows', selector: 'Person', filter: 'x', lineStyle: { color: '#000' } }),
+        ).toEqual({ lineStyle: { color: '#000' } });
+    });
+
+    it('produces an empty spec for empty or non-object input', () => {
+        expect(parseEdgeStyleSpec({})).toEqual({});
+        expect(parseEdgeStyleSpec(undefined)).toEqual({});
+        expect(parseEdgeStyleSpec('nope')).toEqual({});
+    });
+});
+
+describe('resolveEdgeStyle', () => {
+    it('merges disjoint leaves from two matching rules', () => {
+        const rules: EdgeStyleRule[] = [
+            { field: 'knows', selector: 'A', style: { lineStyle: { color: '#36c' } } },
+            { field: 'knows', selector: 'B', style: { textStyle: { size: 'small' } } },
+        ];
+        expect(resolveEdgeStyle(rules)).toEqual({ lineStyle: { color: '#36c' }, textStyle: { size: 'small' } });
+    });
+
+    it('merges lineStyle sub-leaves without collision', () => {
+        const rules: EdgeStyleRule[] = [
+            { field: 'knows', selector: 'A', style: { lineStyle: { color: '#36c' } } },
+            { field: 'knows', selector: 'B', style: { lineStyle: { weight: 2 } } },
+        ];
+        expect(resolveEdgeStyle(rules)).toEqual({ lineStyle: { color: '#36c', weight: 2 } });
+    });
+
+    it('HARD ERRORS when two matching rules disagree on a leaf', () => {
+        const rules: EdgeStyleRule[] = [
+            { field: 'knows', selector: 'A', style: { lineStyle: { color: '#36c' } } },
+            { field: 'knows', selector: 'B', style: { lineStyle: { color: '#c33' } } },
+        ];
+        expect(() => resolveEdgeStyle(rules)).toThrow(StyleCollisionError);
+    });
+});
+
+describe('parseLayoutSpec — edgeStyle directive', () => {
+    it('parses an edgeStyle directive into directives.edgeStyles', () => {
+        const yaml = [
+            'directives:',
+            '  - edgeStyle:',
+            '      field: knows',
+            '      selector: Person',
+            '      lineStyle:',
+            "        color: '#36c'",
+            '        pattern: dashed',
+            '        weight: 2',
+            '      textStyle:',
+            '        size: small',
+        ].join('\n');
+
+        const spec = parseLayoutSpec(yaml);
+        expect(spec.directives.edgeStyles).toHaveLength(1);
+        const rule = spec.directives.edgeStyles[0];
+        expect(rule.field).toBe('knows');
+        expect(rule.selector).toBe('Person');
+        expect(rule.style).toEqual({
+            lineStyle: { color: '#36c', pattern: 'dashed', weight: 2 },
+            textStyle: { size: 'small' },
+        });
+    });
+
+    it('defaults to an empty edgeStyles list when none are present', () => {
+        expect(parseLayoutSpec('').directives.edgeStyles).toEqual([]);
+    });
+});

--- a/tests/edge-style-spec.test.ts
+++ b/tests/edge-style-spec.test.ts
@@ -1,8 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { parseEdgeStyleSpec, resolveEdgeStyle } from '../src/layout/style/edge-style-spec';
+import { parseEdgeStyleSpec, resolveEdgeStyle, edgeColorToEdgeStyleRule } from '../src/layout/style/edge-style-spec';
 import type { EdgeStyleRule } from '../src/layout/style/edge-style-spec';
 import { StyleCollisionError } from '../src/layout/style/style-resolver';
 import { parseLayoutSpec } from '../src/layout/layoutspec';
+
+describe('edgeColorToEdgeStyleRule — legacy style normalization', () => {
+    it('normalizes a capitalized/padded legacy style like normalizeEdgeStyle did', () => {
+        expect(edgeColorToEdgeStyleRule({ field: 'r', value: 'red', style: 'Dashed' }).style.lineStyle?.pattern).toBe('dashed');
+        expect(edgeColorToEdgeStyleRule({ field: 'r', value: 'red', style: '  dotted  ' }).style.lineStyle?.pattern).toBe('dotted');
+    });
+
+    it('drops an unrecognized legacy style (no pattern) rather than inventing one', () => {
+        expect(edgeColorToEdgeStyleRule({ field: 'r', value: 'red', style: 'zigzag' }).style.lineStyle?.pattern).toBeUndefined();
+    });
+});
 
 describe('parseEdgeStyleSpec', () => {
     it('extracts the nested lineStyle block', () => {

--- a/tests/field-renderer-group.test.tsx
+++ b/tests/field-renderer-group.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Renderer coverage for the nested `group` field kind (progressive "+" blocks).
+ * Verifies the add-chip → onChange({}) and the present-block fieldset → remove,
+ * i.e. the Builder UI for lineStyle/textStyle/… blocks.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FieldRenderer } from '../src/spec-editor/ui/FieldRenderer';
+import type { FieldSpec } from '../src/spec-editor/core/types';
+
+const lineStyleGroup: FieldSpec = {
+    key: 'lineStyle',
+    kind: 'group',
+    label: 'Line style',
+    children: [
+        { key: 'color', kind: 'color', label: 'Color' },
+        { key: 'pattern', kind: 'enum', options: ['solid', 'dashed', 'dotted'], label: 'Pattern' },
+    ],
+};
+
+describe('FieldRenderer — nested group blocks', () => {
+    it('renders an "add" chip when the optional block is absent, and adds it on click', () => {
+        const onChange = vi.fn();
+        render(<FieldRenderer fields={[lineStyleGroup]} values={{}} onChange={onChange} />);
+        const add = screen.getByRole('button', { name: /\+ line style/i });
+        fireEvent.click(add);
+        expect(onChange).toHaveBeenCalledWith('lineStyle', {});
+    });
+
+    it("renders the block's children when present, and removes the whole block", () => {
+        const onChange = vi.fn();
+        render(
+            <FieldRenderer
+                fields={[lineStyleGroup]}
+                values={{ lineStyle: { color: '#3366cc' } }}
+                onChange={onChange}
+            />,
+        );
+        // child fields are shown
+        expect(screen.getByText('Color')).toBeTruthy();
+        expect(screen.getByText('Pattern')).toBeTruthy();
+        // the remove control drops the entire block (sets it undefined)
+        const remove = screen.getByRole('button', { name: /remove line style/i });
+        fireEvent.click(remove);
+        expect(onChange).toHaveBeenCalledWith('lineStyle', undefined);
+    });
+});

--- a/tests/field-selectors.test.ts
+++ b/tests/field-selectors.test.ts
@@ -33,13 +33,14 @@ constraints:
 
     const layoutSpec = parseLayoutSpec(layoutSpecStr);
     
-    // Test edge color directive with selector
-    expect(layoutSpec.directives.edgeColors).toHaveLength(1);
-    expect(layoutSpec.directives.edgeColors[0].field).toBe('name');
-    expect(layoutSpec.directives.edgeColors[0].color).toBe('red');
-    expect(layoutSpec.directives.edgeColors[0].selector).toBe('Person');
-    expect(layoutSpec.directives.edgeColors[0].style).toBe('dashed');
-    expect(layoutSpec.directives.edgeColors[0].weight).toBe(2);
+    // edgeColor desugars into an edgeStyle rule (edgeColors is left empty)
+    expect(layoutSpec.directives.edgeColors).toEqual([]);
+    expect(layoutSpec.directives.edgeStyles).toHaveLength(1);
+    expect(layoutSpec.directives.edgeStyles[0].field).toBe('name');
+    expect(layoutSpec.directives.edgeStyles[0].selector).toBe('Person');
+    expect(layoutSpec.directives.edgeStyles[0].style).toEqual({
+      lineStyle: { color: 'red', pattern: 'dashed', weight: 2 },
+    });
 
     expect(layoutSpec.directives.inferredEdges).toHaveLength(1);
     expect(layoutSpec.directives.inferredEdges[0].name).toBe('transitive');
@@ -75,11 +76,12 @@ directives:
 
     const layoutSpec = parseLayoutSpec(layoutSpecStr);
     
-    // Test legacy directives work
-    expect(layoutSpec.directives.edgeColors).toHaveLength(1);
-    expect(layoutSpec.directives.edgeColors[0].field).toBe('name');
-    expect(layoutSpec.directives.edgeColors[0].color).toBe('blue');
-    expect(layoutSpec.directives.edgeColors[0].selector).toBeUndefined();
+    // Legacy edgeColor still works — it desugars into an edgeStyle rule
+    expect(layoutSpec.directives.edgeColors).toEqual([]);
+    expect(layoutSpec.directives.edgeStyles).toHaveLength(1);
+    expect(layoutSpec.directives.edgeStyles[0].field).toBe('name');
+    expect(layoutSpec.directives.edgeStyles[0].selector).toBeUndefined();
+    expect(layoutSpec.directives.edgeStyles[0].style).toEqual({ lineStyle: { color: 'blue' } });
     
     expect(layoutSpec.directives.attributes).toHaveLength(1);
     expect(layoutSpec.directives.attributes[0].field).toBe('age');

--- a/tests/group-style-directive.test.ts
+++ b/tests/group-style-directive.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Coverage for the group directive's two style surfaces:
+ *   1. the `addEdge` connector (an edge) — block form
+ *      `addEdge: { points, lineStyle, textStyle }` styles its line + label;
+ *   2. the group's own label — top-level `textStyle`.
+ * The legacy `addEdge: <string>` shorthand still sets the direction, unstyled.
+ *
+ * Tested at parse (GroupBySelector fields), computed layout (the `_g_` connector
+ * LayoutEdge + the LayoutGroup), and renderer (group-label color mapping).
+ */
+import { describe, it, expect } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
+import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
+
+const data: IJsonDataInstance = {
+    atoms: [
+        { id: 'k1', type: 'Node', label: 'k1' },
+        { id: 'a', type: 'Node', label: 'a' },
+        { id: 'b', type: 'Node', label: 'b' },
+    ],
+    relations: [
+        {
+            id: 'mem',
+            name: 'mem',
+            types: ['Node', 'Node'],
+            tuples: [
+                { atoms: ['k1', 'a'], types: ['Node', 'Node'] },
+                { atoms: ['k1', 'b'], types: ['Node', 'Node'] },
+            ],
+        },
+    ],
+};
+
+function layoutFor(specStr: string) {
+    const layoutSpec = parseLayoutSpec(specStr);
+    const instance = new JSONDataInstance(data);
+    const evaluator = new SGraphQueryEvaluator();
+    evaluator.initialize({ sourceData: instance });
+    const layoutInstance = new LayoutInstance(layoutSpec, evaluator, 0, true);
+    return layoutInstance.generateLayout(instance);
+}
+
+describe('group directive — parse (block addEdge + top-level textStyle)', () => {
+    it('parses connector lineStyle/textStyle from a block addEdge and the group label textStyle', () => {
+        const spec = parseLayoutSpec(`
+constraints:
+  - group:
+      selector: mem
+      name: Cluster
+      addEdge:
+        points: togroup
+        lineStyle:
+          color: '#0aa'
+          pattern: dashed
+        textStyle:
+          color: '#a00'
+      textStyle:
+        color: '#333'
+`);
+        const gbs = spec.constraints.grouping.byselector[0];
+        expect(gbs.addEdge).toBe('togroup'); // direction read from points
+        expect(gbs.connectorLineStyle).toEqual({ color: '#0aa', pattern: 'dashed' });
+        expect(gbs.connectorTextStyle).toEqual({ color: '#a00' });
+        expect(gbs.labelTextStyle).toEqual({ color: '#333' });
+    });
+
+    it('still accepts the legacy string addEdge (direction only, no connector style)', () => {
+        const spec = parseLayoutSpec('constraints:\n  - group: { selector: mem, name: Cluster, addEdge: togroup }');
+        const gbs = spec.constraints.grouping.byselector[0];
+        expect(gbs.addEdge).toBe('togroup');
+        expect(gbs.connectorLineStyle).toBeUndefined();
+        expect(gbs.connectorTextStyle).toBeUndefined();
+        expect(gbs.labelTextStyle).toBeUndefined();
+    });
+});
+
+describe('group directive — computed layout', () => {
+    it('applies the addEdge block style to the connector edge and the textStyle to the group label', () => {
+        const { layout } = layoutFor(`
+constraints:
+  - group:
+      selector: mem
+      name: Cluster
+      addEdge:
+        points: togroup
+        lineStyle:
+          color: '#0aa'
+          pattern: dashed
+          weight: 3
+        textStyle:
+          size: small
+          color: '#a00'
+      textStyle:
+        color: '#333'
+`);
+        // The connector is a `_g_` edge; its line + label carry the authored style.
+        const connector = layout.edges.find((e) => e.id.startsWith('_g_'));
+        expect(connector).toBeDefined();
+        expect(connector?.color).toBe('#0aa');
+        expect(connector?.style).toBe('dashed');
+        expect(connector?.weight).toBe(3);
+        expect(connector?.textStyle).toEqual({ size: 'small', color: '#a00' });
+
+        // The group's own label carries its textStyle.
+        const grp = layout.groups.find((g) => g.name.startsWith('Cluster'));
+        expect(grp?.labelTextStyle).toEqual({ color: '#333' });
+    });
+
+    it('leaves the connector unstyled (default) for a legacy string addEdge', () => {
+        const { layout } = layoutFor('constraints:\n  - group: { selector: mem, name: Cluster, addEdge: togroup }');
+        const connector = layout.edges.find((e) => e.id.startsWith('_g_'));
+        expect(connector).toBeDefined();
+        expect(connector?.color).toBe('black'); // default edge color
+        expect(connector?.textStyle).toBeUndefined();
+        const grp = layout.groups.find((g) => g.name.startsWith('Cluster'));
+        expect(grp?.labelTextStyle).toBeUndefined();
+    });
+});
+
+describe('webcola-cnd-graph — group label color', () => {
+    const proto = WebColaCnDGraph.prototype as any;
+    const color = (d: unknown) => proto.groupLabelColor.call({}, d);
+
+    it('maps a group label textStyle color to the fill', () => {
+        expect(color({ labelTextStyle: { color: '#333' } })).toBe('#333');
+    });
+
+    it('returns null when no group label color is set (→ keep the default)', () => {
+        expect(color({ labelTextStyle: {} })).toBeNull();
+        expect(color({})).toBeNull();
+    });
+});

--- a/tests/selector-arity-validation.test.ts
+++ b/tests/selector-arity-validation.test.ts
@@ -194,7 +194,8 @@ directives:
             const { selectorErrors } = layoutInstance.generateLayout(instance);
 
             expect(selectorErrors.length).toBeGreaterThan(0);
-            const arityError = selectorErrors.find(e => e.selector === 'next' && e.context === 'color selector');
+            // atomColor desugars to atomStyle, so the arity check runs under that context now.
+            const arityError = selectorErrors.find(e => e.selector === 'next' && e.context === 'atomStyle selector');
             expect(arityError).toBeDefined();
             expect(arityError!.errorMessage).toContain('unary');
         });

--- a/tests/size-hideatom-dual-syntax.test.ts
+++ b/tests/size-hideatom-dual-syntax.test.ts
@@ -220,7 +220,10 @@ directives:
       // Check directives (including size and hideAtom from constraints)
       expect(layoutSpec.directives.sizes).toHaveLength(1);
       expect(layoutSpec.directives.hiddenAtoms).toHaveLength(1);
-      expect(layoutSpec.directives.atomColors).toHaveLength(1);
+      // atomColor now desugars into a border-preserving atomStyle rule (atomColors emptied).
+      expect(layoutSpec.directives.atomColors).toHaveLength(0);
+      expect(layoutSpec.directives.atomStyles).toHaveLength(1);
+      expect(layoutSpec.directives.atomStyles[0].style.borderStyle?.color).toBe('#FF0000');
     });
   });
 

--- a/tests/spec-editor-atom-style-nesting.test.ts
+++ b/tests/spec-editor-atom-style-nesting.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Builder/registry coverage for the nested `atomStyle` directive: it's registered
+ * with nested fillStyle/borderStyle/textStyle blocks, `atomColor` is hidden from
+ * the add menu (deprecated), nested params round-trip through the codec, and
+ * emission stays sparse (empty blocks dropped, no seeded defaults). Mirrors
+ * spec-editor-style-nesting.test.ts for the edge side.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    parseYamlToState,
+    serializeStateToYaml,
+    getDefinitions,
+    defaultParamsFor,
+} from '../src/spec-editor';
+
+describe('registry — atomStyle registration + atomColor deprecation', () => {
+    it('offers atomStyle in the directive add-menu and hides deprecated atomColor', () => {
+        const menu = getDefinitions('directive').map((d) => d.type);
+        expect(menu).toContain('atomStyle');
+        expect(menu).not.toContain('atomColor');
+    });
+
+    it('still resolves atomColor when deprecated entries are requested', () => {
+        const all = getDefinitions('directive', { includeDeprecated: true }).map((d) => d.type);
+        expect(all).toContain('atomColor');
+        expect(all).toContain('atomStyle');
+    });
+
+    it('seeds no defaults for atomStyle — style blocks stay sparse', () => {
+        expect(defaultParamsFor('atomStyle')).toEqual({});
+    });
+});
+
+describe('codec — nested atomStyle blocks', () => {
+    const NESTED = [
+        'directives:',
+        '  - atomStyle:',
+        '      selector: Person',
+        '      fillStyle:',
+        "        color: '#e0f2ff'",
+        '      borderStyle:',
+        "        color: '#0369a1'",
+        '        width: 4',
+        '      textStyle:',
+        "        color: '#b91c1c'",
+    ].join('\n');
+
+    it('ingests nested fillStyle/borderStyle/textStyle into nested params', () => {
+        const state = parseYamlToState(NESTED);
+        const item = state.directives.find((d) => d.type === 'atomStyle');
+        expect(item?.params).toEqual({
+            selector: 'Person',
+            fillStyle: { color: '#e0f2ff' },
+            borderStyle: { color: '#0369a1', width: 4 },
+            textStyle: { color: '#b91c1c' },
+        });
+    });
+
+    it('round-trips the nested blocks (emit → parse is stable)', () => {
+        const first = parseYamlToState(NESTED);
+        const out = serializeStateToYaml(first);
+        const second = parseYamlToState(out);
+        expect(second.directives.find((d) => d.type === 'atomStyle')?.params).toEqual(
+            first.directives.find((d) => d.type === 'atomStyle')?.params,
+        );
+    });
+
+    it('drops an added-but-empty block on emit (sparse)', () => {
+        const withEmpty = [
+            'directives:',
+            '  - atomStyle:',
+            '      selector: Person',
+            "      fillStyle: { color: '#e0f2ff' }",
+            '      borderStyle: {}',
+        ].join('\n');
+        const out = serializeStateToYaml(parseYamlToState(withEmpty));
+        expect(out).toContain('fillStyle');
+        expect(out).not.toContain('borderStyle'); // empty block omitted
+    });
+});

--- a/tests/spec-editor-codec.test.ts
+++ b/tests/spec-editor-codec.test.ts
@@ -109,8 +109,10 @@ describe('yaml-codec — real-world round trips', () => {
   it('round-trips field-selector directives + deprecated group-by-field', () => {
     const out = assertRoundTrips(FIELD_SELECTORS_SPEC);
     const spec = parseLayoutSpec(out);
-    expect(spec.directives.edgeColors).toHaveLength(1);
-    expect(spec.directives.edgeColors[0].color).toBe('red');
+    // edgeColor round-trips through the codec, then desugars to edgeStyle on parse.
+    expect(spec.directives.edgeColors).toEqual([]);
+    expect(spec.directives.edgeStyles).toHaveLength(1);
+    expect(spec.directives.edgeStyles[0].style.lineStyle?.color).toBe('red');
     expect(spec.directives.inferredEdges).toHaveLength(1);
     expect(spec.directives.attributes).toHaveLength(1);
     expect(spec.directives.hiddenFields).toHaveLength(1);

--- a/tests/spec-editor-group-style.test.ts
+++ b/tests/spec-editor-group-style.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Builder coverage for the group directive's style surfaces:
+ *   - the group's own label `textStyle` round-trips through the codec;
+ *   - a block-form `addEdge` (`{ points, lineStyle, textStyle }`) authored in
+ *     YAML keeps its direction when ingested (the Builder doesn't yet model the
+ *     connector's own styling, but must not lose the direction).
+ */
+import { describe, it, expect } from 'vitest';
+import { parseYamlToState, serializeStateToYaml } from '../src/spec-editor';
+
+describe('group Builder — label textStyle', () => {
+    const YAML = [
+        'constraints:',
+        '  - group:',
+        '      selector: Team.members',
+        '      name: Team',
+        '      textStyle:',
+        "        color: '#7c3aed'",
+    ].join('\n');
+
+    it('ingests the group label textStyle', () => {
+        const state = parseYamlToState(YAML);
+        const item = state.constraints.find((c) => c.type === 'groupselector');
+        expect(item?.params.textStyle).toEqual({ color: '#7c3aed' });
+    });
+
+    it('round-trips the group label textStyle (emit → parse is stable)', () => {
+        const first = parseYamlToState(YAML);
+        const out = serializeStateToYaml(first);
+        const second = parseYamlToState(out);
+        expect(second.constraints.find((c) => c.type === 'groupselector')?.params.textStyle).toEqual({
+            color: '#7c3aed',
+        });
+    });
+});
+
+describe('group Builder — block addEdge direction is preserved', () => {
+    it('keeps the connector direction from a block-form addEdge', () => {
+        const YAML = [
+            'constraints:',
+            '  - group:',
+            '      selector: Team.members',
+            '      name: Team',
+            '      addEdge:',
+            '        points: togroup',
+            "        lineStyle: { color: '#0aa', pattern: dashed }",
+        ].join('\n');
+        const state = parseYamlToState(YAML);
+        const item = state.constraints.find((c) => c.type === 'groupselector');
+        expect(item?.params.addEdge).toBe('togroup'); // direction survives (styling is YAML-only for now)
+    });
+});

--- a/tests/spec-editor-inferred-edge-nesting.test.ts
+++ b/tests/spec-editor-inferred-edge-nesting.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The inferredEdge Builder def now uses the shared nested lineStyle/textStyle
+ * blocks (like edgeStyle), instead of flat color/style/weight fields. This
+ * verifies the nested params round-trip through the codec and that the emitted
+ * (nested) form parses cleanly — i.e. the Builder no longer emits the deprecated
+ * inline shape.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { parseYamlToState, serializeStateToYaml } from '../src/spec-editor';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+
+const NESTED = [
+    'directives:',
+    '  - inferredEdge:',
+    '      name: reachable',
+    "      selector: '^next'",
+    '      lineStyle:',
+    "        color: '#a0f'",
+    '        pattern: dotted',
+    '        weight: 2',
+    '      textStyle:',
+    '        size: small',
+].join('\n');
+
+describe('inferredEdge Builder — nested lineStyle/textStyle', () => {
+    it('ingests nested blocks into nested params', () => {
+        const state = parseYamlToState(NESTED);
+        const item = state.directives.find((d) => d.type === 'inferredEdge');
+        expect(item?.params).toEqual({
+            name: 'reachable',
+            selector: '^next',
+            lineStyle: { color: '#a0f', pattern: 'dotted', weight: 2 },
+            textStyle: { size: 'small' },
+        });
+    });
+
+    it('round-trips the nested blocks (emit → parse is stable)', () => {
+        const first = parseYamlToState(NESTED);
+        const out = serializeStateToYaml(first);
+        const second = parseYamlToState(out);
+        expect(second.directives.find((d) => d.type === 'inferredEdge')?.params).toEqual(
+            first.directives.find((d) => d.type === 'inferredEdge')?.params,
+        );
+    });
+
+    it('the Builder-emitted (nested) form parses with no deprecation warning', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const out = serializeStateToYaml(parseYamlToState(NESTED));
+        parseLayoutSpec(out);
+        expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("inferredEdge's inline"));
+        warn.mockRestore();
+    });
+});

--- a/tests/spec-editor-roundtrip-pbt.test.ts
+++ b/tests/spec-editor-roundtrip-pbt.test.ts
@@ -58,6 +58,17 @@ function arbValueForField(field: FieldSpec): fc.Arbitrary<unknown> {
       return fc.boolean();
     case 'color':
       return fc.constantFrom('#ff0000', '#00ff00', '#123abc', 'red', 'blue');
+    case 'group': {
+      // A nested block (lineStyle/textStyle/fillStyle/borderStyle): recurse over
+      // the children so we generate a real nested object, not a bare string.
+      // Custom codecs (e.g. groupselector.textStyle) expect an object and drop
+      // scalars — generating a string here masked that path.
+      const children = field.children ?? [];
+      const entries = children.map(
+        (c) => fc.tuple(fc.constant(c.key), arbValueForField(c)) as fc.Arbitrary<[string, unknown]>,
+      );
+      return fc.tuple(...entries).map((pairs) => Object.fromEntries(pairs));
+    }
     case 'selector':
     case 'relationName':
     case 'typeName':

--- a/tests/spec-editor-style-nesting.test.ts
+++ b/tests/spec-editor-style-nesting.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Builder/registry coverage for the nested style directives: `edgeStyle` is
+ * registered with nested lineStyle/textStyle blocks, `edgeColor` is hidden from
+ * the add menu (deprecated), nested params round-trip through the codec, and
+ * emission stays sparse (empty blocks dropped, no seeded defaults).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    parseYamlToState,
+    serializeStateToYaml,
+    getDefinitions,
+    defaultParamsFor,
+} from '../src/spec-editor';
+
+describe('registry — edgeStyle registration + edgeColor deprecation', () => {
+    it('offers edgeStyle in the directive add-menu and hides deprecated edgeColor', () => {
+        const menu = getDefinitions('directive').map((d) => d.type);
+        expect(menu).toContain('edgeStyle');
+        expect(menu).not.toContain('edgeColor');
+    });
+
+    it('still resolves edgeColor when deprecated entries are requested', () => {
+        const all = getDefinitions('directive', { includeDeprecated: true }).map((d) => d.type);
+        expect(all).toContain('edgeColor');
+        expect(all).toContain('edgeStyle');
+    });
+
+    it('seeds no defaults for edgeStyle — style blocks stay sparse', () => {
+        expect(defaultParamsFor('edgeStyle')).toEqual({});
+    });
+});
+
+describe('codec — nested edgeStyle blocks', () => {
+    const NESTED = [
+        'directives:',
+        '  - edgeStyle:',
+        '      field: knows',
+        '      lineStyle:',
+        "        color: '#3366cc'",
+        '        pattern: dashed',
+        '      textStyle:',
+        '        size: small',
+    ].join('\n');
+
+    it('ingests nested lineStyle/textStyle into nested params', () => {
+        const state = parseYamlToState(NESTED);
+        const item = state.directives.find((d) => d.type === 'edgeStyle');
+        expect(item?.params).toEqual({
+            field: 'knows',
+            lineStyle: { color: '#3366cc', pattern: 'dashed' },
+            textStyle: { size: 'small' },
+        });
+    });
+
+    it('round-trips the nested blocks (emit → parse is stable)', () => {
+        const first = parseYamlToState(NESTED);
+        const out = serializeStateToYaml(first);
+        const second = parseYamlToState(out);
+        expect(second.directives.find((d) => d.type === 'edgeStyle')?.params).toEqual(
+            first.directives.find((d) => d.type === 'edgeStyle')?.params,
+        );
+    });
+
+    it('drops an added-but-empty block on emit (sparse)', () => {
+        const withEmpty = [
+            'directives:',
+            '  - edgeStyle:',
+            '      field: knows',
+            "      lineStyle: { color: '#3366cc' }",
+            '      textStyle: {}',
+        ].join('\n');
+        const out = serializeStateToYaml(parseYamlToState(withEmpty));
+        expect(out).toContain('lineStyle');
+        expect(out).not.toContain('textStyle'); // empty block omitted
+    });
+});

--- a/tests/style-resolver.test.ts
+++ b/tests/style-resolver.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import {
+    resolveStyle,
+    resolveTypedStyle,
+    flattenLeaves,
+    StyleCollisionError,
+} from '../src/layout/style/style-resolver';
+import type { StyleContribution, SparseStyle } from '../src/layout/style/style-resolver';
+
+/** Terse contribution builder for the tests. */
+const rule = (source: string, style: SparseStyle): StyleContribution => ({ source, style });
+/** Flattened leaves as a plain object, for readable assertions. */
+const leaves = (s: SparseStyle) => Object.fromEntries(flattenLeaves(s));
+
+describe('flattenLeaves', () => {
+    it('flattens nested blocks into dotted leaf paths', () => {
+        expect(leaves({ border: { color: 'red', width: 2 } })).toEqual({
+            'border.color': 'red',
+            'border.width': 2,
+        });
+    });
+
+    it('keeps top-level leaves as-is', () => {
+        expect(leaves({ hidden: true })).toEqual({ hidden: true });
+    });
+
+    it('treats null/undefined leaves as unspecified (sparse)', () => {
+        expect(leaves({ a: undefined as unknown as string, b: 'x' })).toEqual({ b: 'x' });
+    });
+
+    it('produces nothing for an empty partial', () => {
+        expect(leaves({})).toEqual({});
+    });
+});
+
+describe('resolveStyle — composition of partial styles', () => {
+    it('merges disjoint leaves from two rules', () => {
+        const out = resolveStyle([
+            rule('A', { fill: { color: 'gray' } }),
+            rule('B', { border: { color: 'red' } }),
+        ]);
+        expect(out).toEqual({ fill: { color: 'gray' }, border: { color: 'red' } });
+    });
+
+    it('deep-merges different leaves inside the same block (no collision)', () => {
+        const out = resolveStyle([
+            rule('A', { border: { color: 'blue' } }),
+            rule('B', { border: { width: 2 } }),
+        ]);
+        expect(out).toEqual({ border: { color: 'blue', width: 2 } });
+    });
+
+    it('an empty partial contributes nothing', () => {
+        expect(resolveStyle([rule('A', {})])).toEqual({});
+    });
+});
+
+describe('resolveStyle — no silent override', () => {
+    it('accepts the same leaf set to the SAME value by two rules', () => {
+        const out = resolveStyle([
+            rule('A', { border: { color: 'red' } }),
+            rule('B', { border: { color: 'red' } }),
+        ]);
+        expect(out).toEqual({ border: { color: 'red' } });
+    });
+
+    it('throws when two rules set the same leaf to DIFFERENT values', () => {
+        expect(() =>
+            resolveStyle([
+                rule('A', { border: { color: 'blue' } }),
+                rule('B', { border: { color: 'red' } }),
+            ]),
+        ).toThrow(StyleCollisionError);
+    });
+
+    it('detects the collision regardless of contribution order', () => {
+        const a = rule('A', { border: { color: 'blue' } });
+        const b = rule('B', { border: { color: 'red' } });
+        expect(() => resolveStyle([a, b])).toThrow(StyleCollisionError);
+        expect(() => resolveStyle([b, a])).toThrow(StyleCollisionError);
+    });
+
+    it('reports the dotted path, both sources, and both values', () => {
+        let err: unknown;
+        try {
+            resolveStyle([
+                rule('atomStyle(Node)', { border: { color: 'blue' } }),
+                rule('atomStyle(RedNode)', { border: { color: 'red' } }),
+            ]);
+        } catch (e) {
+            err = e;
+        }
+        expect(err).toBeInstanceOf(StyleCollisionError);
+        const c = err as StyleCollisionError;
+        expect(c.path).toBe('border.color');
+        expect(c.existing.value).toBe('blue');
+        expect(c.incoming.value).toBe('red');
+        expect(new Set([c.existing.source, c.incoming.source])).toEqual(
+            new Set(['atomStyle(Node)', 'atomStyle(RedNode)']),
+        );
+    });
+});
+
+describe('resolveStyle — defaults applied last', () => {
+    it('fills only leaves left unset', () => {
+        const out = resolveStyle([rule('A', { line: { weight: 3 } })], {
+            defaults: { line: { weight: 1, style: 'solid' } },
+        });
+        expect(out).toEqual({ line: { weight: 3, style: 'solid' } });
+    });
+
+    it('a default never collides with an explicit value', () => {
+        expect(() =>
+            resolveStyle([rule('A', { line: { weight: 3 } })], {
+                defaults: { line: { weight: 1 } },
+            }),
+        ).not.toThrow();
+    });
+});
+
+describe('resolveTypedStyle — inheritance along the type ancestry', () => {
+    // getAtomType(id).types is most-specific first: [ownType, ...ancestors, 'univ'].
+    const chain = ['RedNode', 'Node', 'univ'];
+
+    it('gap-fills: a supertype supplies leaves the subtype leaves unset', () => {
+        const rules = new Map<string, StyleContribution[]>([
+            ['Node', [rule('atomStyle(Node)', { fill: { color: 'gray' } })]],
+            ['RedNode', [rule('atomStyle(RedNode)', { border: { color: 'red' } })]],
+        ]);
+        expect(resolveTypedStyle(chain, rules)).toEqual({
+            fill: { color: 'gray' },
+            border: { color: 'red' },
+        });
+    });
+
+    it('inherits a leaf specified only on an ancestor', () => {
+        const rules = new Map<string, StyleContribution[]>([
+            ['Node', [rule('atomStyle(Node)', { fill: { color: 'gray' } })]],
+        ]);
+        expect(resolveTypedStyle(chain, rules)).toEqual({ fill: { color: 'gray' } });
+    });
+
+    it('HARD ERRORS when a subtype and its supertype set the same leaf differently', () => {
+        // The canonical example: no override, ever — even for comparable types.
+        const rules = new Map<string, StyleContribution[]>([
+            ['Node', [rule('atomStyle(Node)', { border: { color: 'blue' } })]],
+            ['RedNode', [rule('atomStyle(RedNode)', { border: { color: 'red' } })]],
+        ]);
+        expect(() => resolveTypedStyle(chain, rules)).toThrow(StyleCollisionError);
+    });
+
+    it('allows a subtype and supertype to AGREE on a leaf', () => {
+        const rules = new Map<string, StyleContribution[]>([
+            ['Node', [rule('atomStyle(Node)', { border: { color: 'red' } })]],
+            ['RedNode', [rule('atomStyle(RedNode)', { border: { color: 'red' } })]],
+        ]);
+        expect(resolveTypedStyle(chain, rules)).toEqual({ border: { color: 'red' } });
+    });
+
+    it('HARD ERRORS on two rules at the same level that disagree', () => {
+        const rules = new Map<string, StyleContribution[]>([
+            [
+                'Node',
+                [
+                    rule('atomStyle(Node)#1', { fill: { color: 'blue' } }),
+                    rule('atomStyle(Node)#2', { fill: { color: 'green' } }),
+                ],
+            ],
+        ]);
+        expect(() => resolveTypedStyle(['Node', 'univ'], rules)).toThrow(StyleCollisionError);
+    });
+
+    it('ignores types in the chain that carry no rules', () => {
+        const rules = new Map<string, StyleContribution[]>([
+            ['RedNode', [rule('atomStyle(RedNode)', { fill: { color: 'red' } })]],
+        ]);
+        expect(resolveTypedStyle(chain, rules)).toEqual({ fill: { color: 'red' } });
+    });
+
+    it('applies defaults after inheritance', () => {
+        const rules = new Map<string, StyleContribution[]>([
+            ['RedNode', [rule('atomStyle(RedNode)', { fill: { color: 'red' } })]],
+        ]);
+        expect(
+            resolveTypedStyle(chain, rules, {
+                defaults: { fill: { color: 'white' }, opacity: 1 },
+            }),
+        ).toEqual({ fill: { color: 'red' }, opacity: 1 });
+    });
+});

--- a/tests/yaml-generation-size-hideatom.test.ts
+++ b/tests/yaml-generation-size-hideatom.test.ts
@@ -192,7 +192,10 @@ describe('YAML Generation for Size and HideAtom', () => {
     const parsed = parseLayoutSpec(yaml);
     expect(parsed.constraints.orientation.relative).toHaveLength(1);
     expect(parsed.directives.sizes).toHaveLength(1);
-    expect(parsed.directives.atomColors).toHaveLength(1);
+    // atomColor now desugars into a border-preserving atomStyle rule (atomColors emptied).
+    expect(parsed.directives.atomColors).toHaveLength(0);
+    expect(parsed.directives.atomStyles).toHaveLength(1);
+    expect(parsed.directives.atomStyles[0].style.borderStyle?.color).toBe('#FF0000');
     expect(parsed.directives.hiddenAtoms).toHaveLength(1);
   });
 


### PR DESCRIPTION
## What & why

Foundation for the **3.0 unified style system**: a single, reusable style-resolution core plus the first directive (`edgeStyle`) built on it, and the `edgeColor`/`inferredEdge` desugars onto the shared blocks. Motivation: style knobs were hand-rolled per directive and already drifting (`atomColor.value` vs `inferredEdge.color`; edge appearance duplicated across `edgeColor`/`inferredEdge`; Builder fields lagging the parser).

**Backward-compatible** — every legacy form still parses; deprecated ones emit a `console.warn`. No version bump; the 3.0 major lands when the deprecations are removed.

## The style algebra (`src/layout/style/`)

`style-resolver.ts` is instance-free and folds an ordered list of contributions into one resolved style:
- **Compose** — disjoint leaves merge (a `lineStyle.color` from one rule + a `textStyle.size` from another combine).
- **Inherit** — a leaf set by exactly one rule wins, whether from the node's own type or an ancestor (`resolveTypedStyle` folds along `getAtomType().types`).
- **No override** — two rules disagreeing on a leaf is a hard error (`StyleCollisionError`), never a silent last-writer-wins.
- **Defaults last** — applied once at the end, never seeded (or compose/collision would collapse).

## `edgeStyle` directive

Nested vocabulary — `lineStyle {color, pattern, weight, highlight}` + `textStyle {size, color}` + `showLabel`/`hidden`:

```yaml
- edgeStyle:
    field: knows
    lineStyle: { color: '#36c', pattern: dashed, weight: 2 }
    textStyle: { size: small }
```

Resolved per edge (field/selector/filter match → compose/collide), applied in `layoutinstance` with per-property fallback to the legacy getters.

## Desugars (deprecate-and-warn)

- **`edgeColor`** desugars at parse into `edgeStyle` rules (`value`→`lineStyle.color`, `style`→`lineStyle.pattern`, …); `edgeColors` left empty; `isHiddenField` rerouted through the resolver; warns on use. So `edgeColor` and `edgeStyle` now share one resolution path (compose/collide together).
- **`inferredEdge`** keeps its structural identity (`name`/`selector`) but adopts the `lineStyle`/`textStyle` blocks (mapped onto its existing flat fields — consumption untouched); legacy inline `color`/`style`/`weight`/`highlight` still parse + warn.

## Tests — every hop, YAML → SVG

| Level | File | Proves |
|---|---|---|
| Algebra | `style-resolver.test.ts` | compose / inherit / collide / defaults |
| Parse | `edge-style-spec.test.ts` | sparse `lineStyle`/`textStyle`, validation |
| Computed layout | `edge-style-directive.test.ts` | spec → `generateLayout` → `LayoutEdge`; compose, collide, edgeColor desugar, inferredEdge blocks |
| Translator + renderer | `edge-style-render.test.ts` | `LayoutEdge` → datum passthrough; `pattern`→`stroke-dasharray`, `color`→`stroke` (prototype injection) |

Also browser-verified live (the `knows` edge renders red/dashed/4px). Updated `field-selectors`/`spec-editor-codec` to the desugared representation.

## Reviewer notes

- One intentional behavior change: two directives (any mix of `edgeColor`/`edgeStyle`) that set the **same** edge property to **different** values now hard-error instead of first-wins — this is the "no silent override" principle. Different properties compose.
- `findEdgeDirective` in `layoutinstance` keeps a small duplicated matcher; it folds into `edgeDirectiveMatches` when the getters are fully retired.
- **Not** in this PR (tracked follow-ups): the Builder/registry nesting pass (recursive `group` FieldKind + progressive "+" for optional blocks; registering `edgeStyle` and marking `edgeColor` deprecated together so the add-menu always has an edge-styling option), edge-label `textStyle` renderer consumption, and `atomStyle`/`group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)