### PR TITLE
chore(deps): update simple-graph-query to 2.8.2, bump to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "2.9.1",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "2.9.1",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/d3": "^4.13.12",
@@ -27,7 +27,7 @@
         "lodash": "^4.17.21",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "simple-graph-query": "^2.7.2",
+        "simple-graph-query": "^2.8.2",
         "webcola": "^3.4.0"
       },
       "devDependencies": {
@@ -8940,9 +8940,9 @@
       "peer": true
     },
     "node_modules/simple-graph-query": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/simple-graph-query/-/simple-graph-query-2.7.2.tgz",
-      "integrity": "sha512-QrSvr1swp+1+KEG3k3qdQ3pNnTpLKuv3Y5/w5QLywIQMQQMReSmQeVFDnW+Tn1EsEi6UTeDwW5lTPM0efecJFg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/simple-graph-query/-/simple-graph-query-2.8.2.tgz",
+      "integrity": "sha512-OvFX13eb4xC/ckqVwRWXBVEdKlvQRZ8IsgyjPighYkxssLRuT03xjNhfDsuIYqwjWI8+q+MR5IjjQolM/88HIg==",
       "dependencies": {
         "@types/lodash": "^4.17.16",
         "@types/node": "^22.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",
@@ -147,7 +147,7 @@
     "lodash": "^4.17.21",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "simple-graph-query": "^2.7.2",
+    "simple-graph-query": "^2.8.2",
     "webcola": "^3.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- Update `simple-graph-query` from `^2.7.2` to `^2.8.2` (latest)
- Bump package version `3.0.0` → `3.0.1` (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)