### PR TITLE
feat(directives): attribute/tag adopt the shared textStyle block (size + color)

### DIFF
--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -693,7 +693,9 @@ Converts edge relationships into node attributes (displayed as key-value pairs o
     field: <field-name>          # Required: Relation to convert to attribute
     selector: <unary-selector>   # Optional: Filter which source atoms apply
     filter: <n-ary-selector>     # Optional: Filter which tuples to include
-    textSize: <size>             # Optional: small | normal | large (default: normal)
+    textStyle:                   # Optional: style the attribute line (shared block)
+      size: <small|normal|large> #   font size relative to the node label (default: normal)
+      color: <color>             #   text color (any CSS color)
 ```
 
 **Fields:**
@@ -703,13 +705,14 @@ Converts edge relationships into node attributes (displayed as key-value pairs o
 | `field` | ✅ Yes | string | Name of the relation to display as attribute |
 | `selector` | ❌ No | string | Unary selector to filter source atoms |
 | `filter` | ❌ No | string | N-ary selector to filter specific tuples |
-| `textSize` | ❌ No | `small` \| `normal` \| `large` | Size of this attribute's text, relative to the node label. Default `normal`. |
+| `textStyle.size` | ❌ No | `small` \| `normal` \| `large` | Size of this attribute's text, relative to the node label. Default `normal`. |
+| `textStyle.color` | ❌ No | string | Text color of this attribute's line (any CSS color). Default inherits the node label color. |
 
 **Behavior:**
 - Removes the edge from the graph
 - Displays the target value as an attribute on the source node
 - Multiple targets become a list
-- `textSize` controls the line's font size: `large` renders **bigger** than the node's label, `normal` is the default (smaller than the label), and `small` is smaller still. The node box grows/shrinks to fit.
+- `textStyle` is the same shared block edges and atoms use. `size` controls the line's font size: `large` renders **bigger** than the node's label, `normal` is the default (smaller than the label), and `small` is smaller still — the node box grows/shrinks to fit. `color` sets the line's text color (unset = inherit the node's label color, so dark mode still adapts).
 
 **Examples:**
 
@@ -728,10 +731,10 @@ Converts edge relationships into node attributes (displayed as key-value pairs o
     field: status
     filter: 'status & (univ -> Active)'
 
-# Emphasize a key attribute — rendered larger than the node label
+# Emphasize a key attribute — larger than the node label, in red
 - attribute:
     field: balance
-    textSize: large
+    textStyle: { size: large, color: "#c0392b" }
 ```
 
 ---
@@ -745,7 +748,9 @@ Adds computed attributes to nodes based on selector evaluation. Unlike `attribut
     toTag: <unary-selector>      # Required: Selector for atoms to receive the tag
     name: <attribute-name>       # Required: Name of the attribute to display
     value: <n-ary-selector>      # Required: Selector whose result becomes the value
-    textSize: <size>             # Optional: small | normal | large (default: normal)
+    textStyle:                   # Optional: style the tag line (shared block)
+      size: <small|normal|large> #   font size relative to the node label (default: normal)
+      color: <color>             #   text color (any CSS color)
 ```
 
 **Fields:**
@@ -755,13 +760,14 @@ Adds computed attributes to nodes based on selector evaluation. Unlike `attribut
 | `toTag` | ✅ Yes | string | Unary selector for atoms that receive this tag |
 | `name` | ✅ Yes | string | Attribute name to display |
 | `value` | ✅ Yes | string | N-ary selector returning the attribute values |
-| `textSize` | ❌ No | `small` \| `normal` \| `large` | Size of this tag's text, relative to the node label. Default `normal`. |
+| `textStyle.size` | ❌ No | `small` \| `normal` \| `large` | Size of this tag's text, relative to the node label. Default `normal`. |
+| `textStyle.color` | ❌ No | string | Text color of this tag's line (any CSS color). Default inherits the node label color. |
 
 **Behavior:**
 - Does NOT remove edges (unlike `attribute`)
 - For binary results: displays as `name: value`
 - For n-ary results: displays as `name[key1][key2]: value`
-- `textSize` controls the line's font size: `large` renders **bigger** than the node's label, `normal` is the default (smaller than the label), and `small` is smaller still.
+- `textStyle` is the same shared block edges and atoms use. `size` controls the line's font size: `large` renders **bigger** than the node's label, `normal` is the default (smaller than the label), and `small` is smaller still. `color` sets the line's text color (unset = inherit the node's label color).
 
 **Examples:**
 
@@ -778,12 +784,12 @@ Adds computed attributes to nodes based on selector evaluation. Unlike `attribut
     name: score
     value: grades
 
-# De-emphasize a secondary tag — rendered smaller than the default
+# De-emphasize a secondary tag — smaller than the default, muted gray
 - tag:
     toTag: Person
     name: id
     value: internalId
-    textSize: small
+    textStyle: { size: small, color: "#888" }
 ```
 
 ---

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -3,7 +3,7 @@
   "description": "Canonical YAML specification for CnD layout",
   "file": "docs/YAML_SPECIFICATION.md",
   "cdn_url": "https://cdn.jsdelivr.net/gh/sidprasad/cnd-core@main/docs/YAML_SPECIFICATION.md",
-  "pinned_example": "https://cdn.jsdelivr.net/gh/sidprasad/cnd-core@v1.8.0/docs/YAML_SPECIFICATION.md",
+  "pinned_example": "https://cdn.jsdelivr.net/gh/sidprasad/cnd-core@v1.9.0/docs/YAML_SPECIFICATION.md",
   "content_type": "text/markdown",
-  "version": "1.8.0"
+  "version": "1.9.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/d3": "^4.13.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/site/directives.md
+++ b/site/directives.md
@@ -453,7 +453,9 @@ Converts an edge relationship into a **label on the source node**. The edge is r
     field: <field-name>          # Required
     selector: <unary-selector>   # Optional
     filter: <n-ary-selector>     # Optional
-    textSize: <size>             # Optional: small | normal | large
+    textStyle:                   # Optional: shared text-style block
+      size: <small|normal|large> #   font size relative to the node label
+      color: <color>             #   text color (any CSS color)
 ```
 
 | Field | Required | Type | Description |
@@ -461,14 +463,15 @@ Converts an edge relationship into a **label on the source node**. The edge is r
 | `field` | Yes | string | Relation to display as an attribute |
 | `selector` | No | string | Filter by source atom type |
 | `filter` | No | string | Filter specific tuples |
-| `textSize` | No | `small` \| `normal` \| `large` | Size of the attribute text relative to the node label (default `normal`) |
+| `textStyle.size` | No | `small` \| `normal` \| `large` | Size of the attribute text relative to the node label (default `normal`) |
+| `textStyle.color` | No | string | Text color of the attribute line (default inherits the node label color) |
 
 ### What Happens
 
 - The edge for this field is **removed** from the graph
 - The target value appears as `field: value` on the source node
 - Multiple targets become a comma-separated list
-- `textSize` scales the line's font: `large` is bigger than the node label, `normal` (default) is smaller, `small` smaller still; the node box resizes to fit
+- `textStyle` is the same shared block edges and atoms use. `size` scales the line's font (`large` bigger than the node label, `normal` default, `small` smaller still; the node box resizes to fit); `color` sets its text color (unset = inherit the node label color)
 
 ### Examples
 
@@ -524,7 +527,9 @@ Adds computed labels to nodes **without** removing edges. Unlike `attribute`, th
     toTag: <unary-selector>      # Required
     name: <attribute-name>       # Required
     value: <n-ary-selector>      # Required
-    textSize: <size>             # Optional: small | normal | large
+    textStyle:                   # Optional: shared text-style block
+      size: <small|normal|large> #   font size relative to the node label
+      color: <color>             #   text color (any CSS color)
 ```
 
 | Field | Required | Type | Description |
@@ -532,14 +537,15 @@ Adds computed labels to nodes **without** removing edges. Unlike `attribute`, th
 | `toTag` | Yes | string | Selector for atoms that receive the tag |
 | `name` | Yes | string | Label name to display |
 | `value` | Yes | string | Selector whose result becomes the value |
-| `textSize` | No | `small` \| `normal` \| `large` | Size of the tag text relative to the node label (default `normal`) |
+| `textStyle.size` | No | `small` \| `normal` \| `large` | Size of the tag text relative to the node label (default `normal`) |
+| `textStyle.color` | No | string | Text color of the tag line (default inherits the node label color) |
 
 ### Behavior
 
 - Does **NOT** remove edges (unlike `attribute`)
 - For binary results: displays as `name: value`
 - For higher-arity results: displays as `name[key1][key2]: value`
-- `textSize` scales the line's font: `large` is bigger than the node label, `normal` (default) is smaller, `small` smaller still
+- `textStyle` is the same shared block edges and atoms use. `size` scales the line's font (`large` bigger than the node label, `normal` default, `small` smaller still); `color` sets its text color (unset = inherit the node label color)
 
 ### Examples
 

--- a/site/yaml-reference.md
+++ b/site/yaml-reference.md
@@ -108,11 +108,13 @@ directives:
   - attribute:
       field: age
       selector: Person
+      textStyle: { size: large, color: "#c0392b" }  # optional: shared size + color block
 
   - tag:
       toTag: Student
       name: grade
       value: currentGrade
+      textStyle: { size: small, color: "#2980b9" }
 
   - icon:
       selector: File

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -1,7 +1,6 @@
 import { Group } from "webcola";
 import { RelativeOrientationConstraint, CyclicOrientationConstraint, AlignConstraint, GroupByField, GroupBySelector, RelativeDirection } from "./layoutspec";
 import { EdgeStyle } from "./edge-style";
-import { AttrTextSize } from "./text-extent";
 import type { TextStyle } from "./style/text-style";
 
 export interface LayoutGroup {
@@ -88,11 +87,12 @@ export interface LayoutNode {
     groups?: string[];
     attributes?: Record<string, string[]>;
     /**
-     * Per-attribute-key text-size tier (from the `textSize` field of an
-     * `attribute` or `tag` directive). Keyed by the same attribute key as
-     * {@link attributes}. Absent keys render at the normal secondary size.
+     * Per-attribute-key text style (the shared `textStyle` block: size + color)
+     * from an `attribute` or `tag` directive. Keyed by the same attribute key as
+     * {@link attributes}. Absent keys render at the normal secondary size with
+     * the inherited label color.
      */
-    attributeSizes?: Record<string, AttrTextSize>;
+    attributeTextStyles?: Record<string, TextStyle>;
     /**
      * Labels associated with this node from the data instance (e.g., Skolems).
      * These are displayed prominently on nodes, typically styled in the node's color.

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -34,7 +34,7 @@ import type { IEvaluatorResult } from '../evaluators/interfaces';
 import { ColorPicker } from './colorpicker';
 import { type ConstraintError, type ErrorMessages, ConstraintValidator, orientationConstraintToString } from './constraint-validator';
 import { QualitativeConstraintValidator } from './qualitative-constraint-validator';
-import { estimateLabelBox, resolveAttrFontSize, AttrTextSize, SecondaryLine } from './text-extent';
+import { estimateLabelBox, resolveAttrFontSize, SecondaryLine } from './text-extent';
 
 /** The strings the renderer will draw inside a node's box. Used to size the box. */
 type NodeDisplayContent = {
@@ -820,12 +820,12 @@ export class LayoutInstance {
      */
     private generateAttributesAndRemoveEdges(g: Graph): {
         attributes: Record<string, Record<string, string[]>>;
-        sizes: Record<string, Record<string, AttrTextSize>>;
+        textStyles: Record<string, Record<string, TextStyle>>;
     } {
         // Node : [] of attributes
         let attributes: Record<string, Record<string, string[]>> = {};
-        // Node : attrKey -> text-size tier (parallel to `attributes`).
-        let sizes: Record<string, Record<string, AttrTextSize>> = {};
+        // Node : attrKey -> shared TextStyle (size + color), parallel to `attributes`.
+        let textStyles: Record<string, Record<string, TextStyle>> = {};
 
         let graphEdges = [...g.edges()];
         // Go through all edge labels in the graph
@@ -868,24 +868,29 @@ export class LayoutInstance {
                 }
                 nodeAttributes[attributeKey].push(targetLabel);
 
-                // Record the text-size tier from the matching attribute directive.
-                const nodeSizes = sizes[source] || (sizes[source] = {});
-                nodeSizes[attributeKey] = this.getAttributeTextSize(relName, sourceAtom, targetAtom);
+                // Record the text style (size + color) from the matching attribute directive.
+                const style = this.getAttributeTextStyle(relName, sourceAtom, targetAtom);
+                if (style) {
+                    const nodeStyles = textStyles[source] || (textStyles[source] = {});
+                    nodeStyles[attributeKey] = style;
+                }
 
                 // Now remove the edge from the graph
                 g.removeEdge(edge.v, edge.w, edgeId);
             }
         });
 
-        return { attributes, sizes };
+        return { attributes, textStyles };
     }
 
     /**
-     * Text-size tier for an attribute field, taken from the first matching
-     * `attribute` directive (mirroring {@link isAttributeField}'s selector/filter
-     * matching). Defaults to `normal` when no matching directive sets `textSize`.
+     * Text style (the shared `textStyle` block: size + color) for an attribute
+     * field, taken from the first matching `attribute` directive (mirroring
+     * {@link isAttributeField}'s selector/filter matching). Returns `undefined`
+     * when no matching directive sets a `textStyle`, so the line falls back to
+     * the default secondary size and inherited label color.
      */
-    private getAttributeTextSize(fieldId: string, sourceAtom: string, targetAtom: string): AttrTextSize {
+    private getAttributeTextStyle(fieldId: string, sourceAtom: string, targetAtom: string): TextStyle | undefined {
         const matchingDirectives = this._layoutSpec.directives.attributes.filter((ad) => ad.field === fieldId);
 
         for (const directive of matchingDirectives) {
@@ -913,10 +918,10 @@ export class LayoutInstance {
             }
             if (!filterMatches) continue;
 
-            return directive.textSize ?? 'normal';
+            return directive.textStyle;
         }
 
-        return 'normal';
+        return undefined;
     }
 
     /**
@@ -938,29 +943,30 @@ export class LayoutInstance {
     private generateTagsForNodes(
         g: Graph,
         existingAttributes: Record<string, Record<string, string[]>>,
-        existingSizes: Record<string, Record<string, AttrTextSize>>
+        existingTextStyles: Record<string, Record<string, TextStyle>>
     ): {
         attributes: Record<string, Record<string, string[]>>;
-        sizes: Record<string, Record<string, AttrTextSize>>;
+        textStyles: Record<string, Record<string, TextStyle>>;
     } {
         const tagDirectives = this._layoutSpec.directives.tags;
 
         if (!tagDirectives || tagDirectives.length === 0) {
-            return { attributes: existingAttributes, sizes: existingSizes };
+            return { attributes: existingAttributes, textStyles: existingTextStyles };
         }
 
         const attributes = { ...existingAttributes };
-        const sizes = { ...existingSizes };
+        const textStyles = { ...existingTextStyles };
         const graphNodes = new Set(g.nodes());
 
-        // Stamp the tag's text-size tier onto its attribute key (parallel to `attributes`).
-        const recordSize = (atomId: string, attrKey: string, size: AttrTextSize) => {
-            const nodeSizes = sizes[atomId] || (sizes[atomId] = {});
-            nodeSizes[attrKey] = size;
+        // Stamp the tag's TextStyle (size + color) onto its attribute key (parallel to `attributes`).
+        const recordStyle = (atomId: string, attrKey: string, style: TextStyle | undefined) => {
+            if (!style) return;
+            const nodeStyles = textStyles[atomId] || (textStyles[atomId] = {});
+            nodeStyles[attrKey] = style;
         };
 
         for (const directive of tagDirectives) {
-            const tagSize: AttrTextSize = directive.textSize ?? 'normal';
+            const tagStyle: TextStyle | undefined = directive.textStyle;
             try {
                 // First, evaluate the toTag selector to get which nodes receive this tag
                 const toTagResult = this.evaluator.evaluate(directive.toTag, { instanceIndex: this.instanceNum });
@@ -1000,7 +1006,7 @@ export class LayoutInstance {
                             // For unary, the value is the atom label itself
                             const nodeLabel = g.node(atomId)?.label || atomId;
                             attributes[atomId][attrKey].push(String(nodeLabel));
-                            recordSize(atomId, attrKey, tagSize);
+                            recordStyle(atomId, attrKey, tagStyle);
                         } else if (tuple.length === 2) {
                             // Binary tuple: name: lastValue
                             const attrKey = directive.name;
@@ -1013,7 +1019,7 @@ export class LayoutInstance {
                                 ? (g.node(String(lastValue))?.label || String(lastValue))
                                 : String(lastValue);
                             attributes[atomId][attrKey].push(valueLabel);
-                            recordSize(atomId, attrKey, tagSize);
+                            recordStyle(atomId, attrKey, tagStyle);
                         } else {
                             // N-ary tuple (n > 2): name[mid1][mid2]...: lastValue
                             // The key includes all middle elements
@@ -1042,7 +1048,7 @@ export class LayoutInstance {
                                 ? (g.node(String(lastValue))?.label || String(lastValue))
                                 : String(lastValue);
                             attributes[atomId][attrKey].push(valueLabel);
-                            recordSize(atomId, attrKey, tagSize);
+                            recordStyle(atomId, attrKey, tagStyle);
                         }
                     }
                 }
@@ -1055,7 +1061,7 @@ export class LayoutInstance {
             }
         }
 
-        return { attributes, sizes };
+        return { attributes, textStyles };
     }
 
     /**
@@ -1186,10 +1192,10 @@ export class LayoutInstance {
         // We apply built-in hiding afterwards in `ensureNoExtraNodes` so inferred edges can reconnect them.
         let g: Graph = ai.generateGraph(this.hideDisconnected, false);
 
-        let { attributes, sizes: attributeSizes } = this.generateAttributesAndRemoveEdges(g);
+        let { attributes, textStyles: attributeTextStyles } = this.generateAttributesAndRemoveEdges(g);
 
-        // Generate and merge tags into attributes (carrying per-key text sizes alongside)
-        ({ attributes, sizes: attributeSizes } = this.generateTagsForNodes(g, attributes, attributeSizes));
+        // Generate and merge tags into attributes (carrying per-key text styles alongside)
+        ({ attributes, textStyles: attributeTextStyles } = this.generateTagsForNodes(g, attributes, attributeTextStyles));
 
         // This is where we add the inferred edges to the graph.
         this.addinferredEdges(g);
@@ -1209,7 +1215,7 @@ export class LayoutInstance {
         // Compute the display strings once — single source of truth for "what's
         // drawn inside the box" so the box sizer (getNodeSizeMap) and the
         // LayoutNode mapping below see the same content.
-        let contentByNode = this.getNodeDisplayContent(g, ai, attributes, attributeSizes);
+        let contentByNode = this.getNodeDisplayContent(g, ai, attributes, attributeTextStyles);
         let nodeSizeMap = this.getNodeSizeMap(g, contentByNode);
 
         let dcN = this.getDisconnectedNodes(g);
@@ -1244,7 +1250,7 @@ export class LayoutInstance {
                 .filter((group) => group.nodeIds.includes(nodeId))
                 .map((group) => group.name);
             let nodeAttributes = attributes[nodeId] || {};
-            let nodeAttributeSizes = attributeSizes[nodeId] || {};
+            let nodeAttributeTextStyles = attributeTextStyles[nodeId] || {};
 
             // Get labels from the data instance (e.g., Skolems in Alloy)
             let nodeLabels: Record<string, string[]> | undefined = undefined;
@@ -1269,7 +1275,7 @@ export class LayoutInstance {
                 textStyle: atomStyle?.textStyle,
                 groups: nodeGroups,
                 attributes: nodeAttributes,
-                attributeSizes: nodeAttributeSizes,
+                attributeTextStyles: nodeAttributeTextStyles,
                 labels: nodeLabels,
                 icon: iconPath,
                 height: height,
@@ -2583,7 +2589,7 @@ export class LayoutInstance {
         g: Graph,
         ai: IDataInstance,
         attributes: Record<string, Record<string, string[]>>,
-        attributeSizes: Record<string, Record<string, AttrTextSize>>
+        attributeTextStyles: Record<string, Record<string, TextStyle>>
     ): Record<string, NodeDisplayContent> {
         const result: Record<string, NodeDisplayContent> = {};
         const atoms = ai.getAtoms();
@@ -2593,12 +2599,12 @@ export class LayoutInstance {
             const label = nodeMetadata?.label || nodeId;
 
             const nodeAttrs = attributes[nodeId] || {};
-            const nodeSizes = attributeSizes[nodeId] || {};
+            const nodeStyles = attributeTextStyles[nodeId] || {};
             // Sort once so line text and its font size stay index-aligned.
             const sortedAttrEntries = Object.entries(nodeAttrs)
                 .sort(([a], [b]) => a.localeCompare(b));
             const attributeLines = sortedAttrEntries.map(([key, values]) => `${key}: ${values.join(', ')}`);
-            const attributeFontSizes = sortedAttrEntries.map(([key]) => resolveAttrFontSize(nodeSizes[key]));
+            const attributeFontSizes = sortedAttrEntries.map(([key]) => resolveAttrFontSize(nodeStyles[key]?.size));
 
             const atom = atoms.find((x) => x.id === nodeId);
             const skolemLines: string[] = [];

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -1,6 +1,5 @@
 import * as yaml from 'js-yaml';
 import { EdgeStyle } from './edge-style';
-import { AttrTextSize } from './text-extent';
 import { EdgeStyleRule, parseEdgeStyleSpec, edgeColorToEdgeStyleRule } from './style/edge-style-spec';
 import type { LineStyle } from './style/edge-style-spec';
 import { AtomStyleRule, parseAtomStyleSpec, atomColorToAtomStyleRule } from './style/atom-style-spec';
@@ -325,8 +324,12 @@ export interface FieldDirective extends Operation {
 
 
 export interface AttributeDirective extends FieldDirective {
-    /** Text-size tier for this attribute's line on the node. Defaults to `normal`. */
-    textSize?: AttrTextSize;
+    /**
+     * Styling for this attribute's line on the node, from the shared `textStyle`
+     * block (`size` tier + `color`). Absent leaves fall back to the defaults
+     * (normal size, inherited label color).
+     */
+    textStyle?: TextStyle;
 }
 
 /**
@@ -347,8 +350,12 @@ export interface TagDirective extends Operation {
     name: string;
     /** N-ary selector whose result becomes the attribute value */
     value: string;
-    /** Text-size tier for this tag's line on the node. Defaults to `normal`. */
-    textSize?: AttrTextSize;
+    /**
+     * Styling for this tag's line on the node, from the shared `textStyle`
+     * block (`size` tier + `color`). Absent leaves fall back to the defaults
+     * (normal size, inherited label color).
+     */
+    textStyle?: TextStyle;
 }
 
 export interface FieldHidingDirective extends FieldDirective {}
@@ -403,15 +410,6 @@ interface DirectivesBlock {
     hiddenAtoms: AtomHidingDirective[];
     hideDisconnected : boolean;
     hideDisconnectedBuiltIns : boolean;
-}
-
-/**
- * Coerce a raw `textSize` value from YAML into a valid {@link AttrTextSize}.
- * Missing or unrecognized values fall back to `normal`, so an authoring typo
- * degrades to the historical default rather than throwing.
- */
-function normalizeAttrTextSize(value: unknown): AttrTextSize {
-    return value === 'small' || value === 'large' ? value : 'normal';
 }
 
 function assertPositiveSizeDimension(value: unknown, label: string): void {
@@ -930,7 +928,7 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
             field: d.attribute.field,
             selector: d.attribute.selector,
             filter: d.attribute.filter,
-            textSize: normalizeAttrTextSize(d.attribute.textSize)
+            textStyle: parseTextStyle(d.attribute.textStyle)
         }
     });
 
@@ -984,7 +982,7 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
             toTag: d.tag.toTag,
             name: d.tag.name,
             value: d.tag.value,
-            textSize: normalizeAttrTextSize(d.tag.textSize)
+            textStyle: parseTextStyle(d.tag.textStyle)
         }
     });
 

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -21,7 +21,7 @@
  *     - hideAtom:    { selector }
  *   directives:
  *     - flag: <scalar string>
- *     - attribute:    { field, selector?, filter? }
+ *     - attribute:    { field, selector?, filter?, textStyle?:{size,color} }
  *     - hideField:    { field, selector?, filter? }
  *     - icon:         { path, selector?, showLabels? }
  *     - atomStyle:    { selector?, fillStyle?:{color}, borderStyle?:{color,width}, textStyle?:{size,color} }
@@ -29,7 +29,7 @@
  *     - edgeStyle:    { field, selector?, filter?, lineStyle?:{color,pattern,weight,highlight}, textStyle?:{size,color}, showLabel?, hidden? }
  *     - edgeColor:    { value, field, selector?, filter?, style?, weight?, showLabel?, hidden?, highlight? }  (deprecated → edgeStyle)
  *     - inferredEdge: { name, selector?, lineStyle?:{color,pattern,weight,highlight}, textStyle?:{size,color} }
- *     - tag:          { toTag, name, value }
+ *     - tag:          { toTag, name, value, textStyle?:{size,color} }
  *
  * This module is framework-agnostic — no React.
  */

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -97,13 +97,24 @@ export const ALIGN_DIRECTIONS = ['horizontal', 'vertical'] as const;
 export const EDGE_STYLES = ['solid', 'dashed', 'dotted'] as const;
 
 /**
- * Text-size tiers for an `attribute` / `tag` line, relative to the node label.
- * `large` renders bigger than the label, `normal` (the engine default) smaller,
- * `small` smaller still. (Mirrors AttrTextSize in text-extent.ts.) No field
- * `default` is set on these — an unset value is omitted from YAML and the engine
- * treats it as `normal`, so specs stay clean.
+ * Text-size tiers for a label line, relative to the node label. `large` renders
+ * bigger than the label, `normal` (the engine default) smaller, `small` smaller
+ * still. (Mirrors AttrTextSize in text-extent.ts.) Used as the `size` option in
+ * the shared `textStyle` block ({@link TEXT_STYLE_FIELDS}). No field `default` is
+ * set — an unset value is omitted from YAML and the engine treats it as `normal`,
+ * so specs stay clean.
  */
 export const TEXT_SIZE_OPTIONS = ['small', 'normal', 'large'] as const;
+
+/**
+ * Shared `textStyle` block children — reused wherever a label is styled
+ * (attribute, tag, edgeStyle, atomStyle, group). No defaults (sparse). Declared
+ * here, ahead of the directive definitions, so every consumer can reference it.
+ */
+const TEXT_STYLE_FIELDS: readonly FieldSpec[] = [
+  { key: 'size', kind: 'enum', options: TEXT_SIZE_OPTIONS, label: 'Size' },
+  { key: 'color', kind: 'color', label: 'Color' },
+];
 
 /**
  * Direction of the optional edge a group-by-selector draws between the group
@@ -553,13 +564,8 @@ const attribute: ItemDefinition = {
       label: 'Selector',
       selectorArity: 'unary',
     },
-    {
-      key: 'textSize',
-      kind: 'enum',
-      options: TEXT_SIZE_OPTIONS,
-      label: 'Text size',
-      help: 'Font size of this attribute line: large is bigger than the node label, normal (default) is smaller, small is smaller still.',
-    },
+    // Shared text-style block (size + color), same shape edgeStyle/atomStyle use.
+    { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
   ],
   summary(params) {
     const field = asString(params.field);
@@ -670,12 +676,6 @@ const LINE_STYLE_FIELDS: readonly FieldSpec[] = [
   { key: 'pattern', kind: 'enum', options: EDGE_STYLES, label: 'Pattern' },
   { key: 'weight', kind: 'number', label: 'Weight' },
   { key: 'highlight', kind: 'color', label: 'Highlight' },
-];
-
-/** Shared `textStyle` block children — reused wherever a label is styled. No defaults. */
-const TEXT_STYLE_FIELDS: readonly FieldSpec[] = [
-  { key: 'size', kind: 'enum', options: TEXT_SIZE_OPTIONS, label: 'Size' },
-  { key: 'color', kind: 'color', label: 'Color' },
 ];
 
 /** Shared `fillStyle` block children — an atom's interior fill. No defaults (sparse). */
@@ -843,13 +843,8 @@ const tag: ItemDefinition = {
       required: true,
       help: 'Selector whose result becomes the attribute value.',
     },
-    {
-      key: 'textSize',
-      kind: 'enum',
-      options: TEXT_SIZE_OPTIONS,
-      label: 'Text size',
-      help: 'Font size of this tag line: large is bigger than the node label, normal (default) is smaller, small is smaller still.',
-    },
+    // Shared text-style block (size + color), same shape edgeStyle/atomStyle use.
+    { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
   ],
   summary(params) {
     const name = asString(params.name);

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -4151,11 +4151,13 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
           .sort(([a], [b]) => a.localeCompare(b));
         const labelEntries = Object.entries(d.labels || {});
 
-        // Per-attribute text size (small/normal/large tiers → px). Each line
-        // gets its own line-height, so the secondary block is no longer a
-        // uniform grid; we track heights per line to place baselines.
+        // Per-attribute text style (the shared `textStyle` block: size + color).
+        // Size (small/normal/large tiers → px) drives each line's own line-height,
+        // so the secondary block is no longer a uniform grid; we track heights per
+        // line to place baselines. Color is applied as the tspan fill below.
+        const attributeStyles = d.attributeTextStyles || {};
         const attributeFontSizes = attributeEntries.map(
-          ([key]) => resolveAttrFontSize((d.attributeSizes || {})[key])
+          ([key]) => resolveAttrFontSize(attributeStyles[key]?.size)
         );
         // Secondary line-heights in DOM order: Skolem labels first, then attributes.
         const secondaryHeights = [
@@ -4226,6 +4228,9 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
             .attr("x", 0)
             .attr("dy", `${tspanDys[1 + labelEntries.length + idx]}px`)
             .style("font-size", `${fontSize}px`)
+            // textStyle.color for this attribute/tag line; null = inherit the
+            // themed parent `.label` fill (so dark mode still lightens it).
+            .style("fill", attributeStyles[key]?.color ?? null)
             .text(`${key}: ${value}`);
         });
       });

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -2,7 +2,6 @@ import { Node, Group, Link, Rectangle } from 'webcola';
 import { InstanceLayout, LayoutNode, LayoutEdge, LayoutConstraint, LayoutGroup, LeftConstraint, TopConstraint, AlignmentConstraint, isLeftConstraint, isTopConstraint, isAlignmentConstraint, isBoundingBoxConstraint, isGroupBoundaryConstraint, ColorSource } from '../../layout/interfaces';
 import { EdgeStyle } from '../../layout/edge-style';
 import type { TextStyle } from '../../layout/style/text-style';
-import type { AttrTextSize } from '../../layout/text-extent';
 import { LayoutInstance } from '../../layout/layoutinstance';
 import type { IDataInstance } from '../../data-instance/interfaces';
 import type { SequencePolicy } from './sequence-policy';
@@ -42,8 +41,8 @@ type NodeWithMetadata = Node & {
   label: string, // This is the label that will be displayed on the node
   id: string,
   attributes: Record<string, string[]>,
-  /** Per-attribute-key text-size tier; drives the rendered font size of each attribute line. */
-  attributeSizes?: Record<string, AttrTextSize>,
+  /** Per-attribute-key text style (size + color); drives the font size and fill of each attribute line. */
+  attributeTextStyles?: Record<string, TextStyle>,
   /**
    * Labels from the data instance (e.g., Skolems in Alloy).
    * These are displayed prominently on nodes, styled in the node's color.
@@ -701,7 +700,7 @@ export class WebColaLayout {
       borderWidth: node.borderWidth,
       textStyle: node.textStyle,
       attributes: node.attributes || {},
-      attributeSizes: node.attributeSizes || {},
+      attributeTextStyles: node.attributeTextStyles || {},
       labels: node.labels,
       // Inflate width/height by padding on each side so WebCola's avoidOverlaps
       // engine keeps a visible gap between nodes. Disconnected nodes get larger

--- a/tests/attribute-tag-textstyle.test.ts
+++ b/tests/attribute-tag-textstyle.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration tests for the shared `textStyle` block (size + color) on the
+ * `attribute` and `tag` directives: parse → LayoutNode.attributeTextStyles.
+ *
+ * #491 introduced text sizing for these directives with no test coverage; this
+ * pins the full shared block (size + color) end to end, including the sparse
+ * (color-only) and absent cases.
+ */
+import { describe, it, expect } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
+
+const data: IJsonDataInstance = {
+    atoms: [
+        { id: 'p1', type: 'Person', label: 'Alice' },
+        { id: 'p2', type: 'Person', label: 'Bob' },
+        { id: 'n30', type: 'Int', label: '30' },
+        { id: 'n27', type: 'Int', label: '27' },
+    ],
+    relations: [
+        {
+            id: 'age',
+            name: 'age',
+            types: ['Person', 'Int'],
+            tuples: [
+                { atoms: ['p1', 'n30'], types: ['Person', 'Int'] },
+                { atoms: ['p2', 'n27'], types: ['Person', 'Int'] },
+            ],
+        },
+    ],
+};
+
+function layoutFor(specStr: string) {
+    const layoutSpec = parseLayoutSpec(specStr);
+    const instance = new JSONDataInstance(data);
+    const evaluator = new SGraphQueryEvaluator();
+    evaluator.initialize({ sourceData: instance });
+    const layoutInstance = new LayoutInstance(layoutSpec, evaluator, 0, true);
+    return layoutInstance.generateLayout(instance);
+}
+
+const nodeById = (layout: any, id: string) => layout.nodes.find((n: any) => n.id === id);
+
+describe('attribute directive — textStyle parsing', () => {
+    it('parses size + color into the shared textStyle block', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - attribute:
+      field: age
+      textStyle:
+        size: large
+        color: '#c0392b'
+`);
+        expect(spec.directives.attributes[0].textStyle).toEqual({ size: 'large', color: '#c0392b' });
+    });
+
+    it('keeps textStyle sparse — color only, no size', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - attribute:
+      field: age
+      textStyle:
+        color: '#2980b9'
+`);
+        expect(spec.directives.attributes[0].textStyle).toEqual({ color: '#2980b9' });
+    });
+
+    it('leaves textStyle undefined when omitted', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - attribute:
+      field: age
+`);
+        expect(spec.directives.attributes[0].textStyle).toBeUndefined();
+    });
+});
+
+describe('tag directive — textStyle parsing', () => {
+    it('parses size + color into the shared textStyle block', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - tag:
+      toTag: Person
+      name: years
+      value: age
+      textStyle:
+        size: small
+        color: '#2980b9'
+`);
+        expect(spec.directives.tags[0].textStyle).toEqual({ size: 'small', color: '#2980b9' });
+    });
+});
+
+describe('attribute directive — textStyle end to end', () => {
+    it('carries size + color onto the source node attributeTextStyles', () => {
+        const { layout } = layoutFor(`
+directives:
+  - attribute:
+      field: age
+      textStyle:
+        size: large
+        color: '#c0392b'
+`);
+        const p1 = nodeById(layout, 'p1');
+        expect(p1.attributeTextStyles).toBeDefined();
+        // Keyed by the attribute line's key; assert on the value to stay robust.
+        expect(Object.values(p1.attributeTextStyles)).toContainEqual({ size: 'large', color: '#c0392b' });
+    });
+
+    it('leaves attributeTextStyles empty when no textStyle is set', () => {
+        const { layout } = layoutFor(`
+directives:
+  - attribute:
+      field: age
+`);
+        const p1 = nodeById(layout, 'p1');
+        // The attribute still renders; it just carries no per-line style overrides.
+        expect(p1.attributes && Object.keys(p1.attributes).length).toBeGreaterThan(0);
+        expect(Object.keys(p1.attributeTextStyles ?? {})).toHaveLength(0);
+    });
+});
+
+describe('tag directive — textStyle end to end', () => {
+    it('carries size + color onto the tagged node attributeTextStyles', () => {
+        const { layout } = layoutFor(`
+directives:
+  - tag:
+      toTag: Person
+      name: years
+      value: age
+      textStyle:
+        size: small
+        color: '#2980b9'
+`);
+        const p1 = nodeById(layout, 'p1');
+        expect(Object.values(p1.attributeTextStyles ?? {})).toContainEqual({ size: 'small', color: '#2980b9' });
+    });
+});

--- a/tests/spec-editor-style-nesting.test.ts
+++ b/tests/spec-editor-style-nesting.test.ts
@@ -74,3 +74,60 @@ describe('codec — nested edgeStyle blocks', () => {
         expect(out).not.toContain('textStyle'); // empty block omitted
     });
 });
+
+describe('codec — nested attribute/tag textStyle blocks', () => {
+    it('registers the textStyle group on attribute and tag', () => {
+        const byType = (t: string) => getDefinitions('directive').find((d) => d.type === t);
+        for (const type of ['attribute', 'tag']) {
+            const ts = byType(type)?.fields.find((f) => f.key === 'textStyle');
+            expect(ts, `${type} should expose a textStyle field`).toBeDefined();
+            expect(ts?.kind).toBe('group');
+            expect(ts?.children?.map((c) => c.key)).toEqual(['size', 'color']);
+        }
+    });
+
+    it('ingests + round-trips an attribute textStyle block (size + color)', () => {
+        const yaml = [
+            'directives:',
+            '  - attribute:',
+            '      field: age',
+            '      textStyle:',
+            '        size: large',
+            "        color: '#c0392b'",
+        ].join('\n');
+        const first = parseYamlToState(yaml);
+        expect(first.directives.find((d) => d.type === 'attribute')?.params).toEqual({
+            field: 'age',
+            textStyle: { size: 'large', color: '#c0392b' },
+        });
+        // emit → parse is stable
+        const second = parseYamlToState(serializeStateToYaml(first));
+        expect(second.directives.find((d) => d.type === 'attribute')?.params).toEqual(
+            first.directives.find((d) => d.type === 'attribute')?.params,
+        );
+    });
+
+    it('ingests + round-trips a tag textStyle block (size + color)', () => {
+        const yaml = [
+            'directives:',
+            '  - tag:',
+            '      toTag: Person',
+            '      name: role',
+            '      value: role',
+            '      textStyle:',
+            '        size: small',
+            "        color: '#2980b9'",
+        ].join('\n');
+        const first = parseYamlToState(yaml);
+        expect(first.directives.find((d) => d.type === 'tag')?.params).toEqual({
+            toTag: 'Person',
+            name: 'role',
+            value: 'role',
+            textStyle: { size: 'small', color: '#2980b9' },
+        });
+        const second = parseYamlToState(serializeStateToYaml(first));
+        expect(second.directives.find((d) => d.type === 'tag')?.params).toEqual(
+            first.directives.find((d) => d.type === 'tag')?.params,
+        );
+    });
+});


### PR DESCRIPTION
## What

`attribute` and `tag` now support the full shared **`textStyle`** block — **size *and* color** — instead of only `textSize`.

```yaml
- attribute:
    field: age
    textStyle: { size: large, color: "#c0392b" }
- tag:
    toTag: Person
    name: role
    value: role
    textStyle: { size: small, color: "#2980b9" }
```

## Why

The shared `TextStyle` abstraction (`src/layout/style/text-style.ts`) already documented attribute/tag lines as a consumer — its docstring literally says it "styles any label … attribute/tag lines" — but they were never wired to it. They only had the flat `textSize` field from #491. This finishes the wiring so attribute/tag use the same `{ size, color }` block `edgeStyle`/`atomStyle` already use.

`textSize` moves to `textStyle.size` as a **clean break, no deprecate-and-warn** — `textSize` only shipped in #491, so there's no back-compat burden. No example specs in the repo used it.

## Changes

- **layoutspec** — `AttributeDirective`/`TagDirective` carry `textStyle?: TextStyle`, parsed via the shared `parseTextStyle`; removed `normalizeAttrTextSize`.
- **layoutinstance** — the per-attribute channel carries the whole `TextStyle`; `getAttributeTextSize` → `getAttributeTextStyle`; box sizer reads `.size`.
- **interfaces / webcolatranslator** — `attributeSizes` → `attributeTextStyles` (carries `TextStyle`).
- **webcola-cnd-graph** — attribute/tag tspans get `font-size` from `.size` and `fill` from `.color` (null = inherit the themed label, so dark mode still adapts).
- **spec-editor registry** — attribute/tag expose the shared `textStyle` group in the no-code builder; relocated `TEXT_STYLE_FIELDS` above its first consumer.
- **docs** — `YAML_SPECIFICATION.md`, `site/directives.md`, `site/yaml-reference.md`, and the agent-manifest (`1.8.0` → `1.9.0`).
- **version** — `3.0.1` → `3.1.0` (minor: additive optional fields).

## Testing

- New `tests/attribute-tag-textstyle.test.ts` (**7 tests**) filling the gap #491 left with no coverage: parse (size+color, sparse color-only, absent) for `attribute`; parse for `tag`; end-to-end that `LayoutNode.attributeTextStyles` carries the style for both, plus the empty-when-unset case.
- **80/80 pass** across 10 directive/style/spec-editor suites, including the spec-editor round-trip PBT (now exercises the new `textStyle` group on attribute/tag).
- Verified in-browser on real rendered tspans: `age:` line at 16px / `rgb(192,57,43)` (large + `#c0392b`), `role:` line at 9px / `rgb(41,128,185)` (small + `#2980b9`), main labels unchanged.

## Reviewer notes

- Behavior-preserving for size; color is net-new for attribute/tag.
- `textStyle` today is `{ size, color }` — bold/italic would be a separate additive change to the shared block (would light up all label types at once), intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)