### PR TITLE
fix(webcola): resolve link paths via the link-group, not an id-built selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/d3": "^4.13.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -4483,12 +4483,12 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
 
     // Update link labels using path midpoint calculation
     this.svgLinkGroups.select('.linklabel')
-      .attr('x', (d: EdgeWithMetadata) => {
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
+      .attr('x', (d: EdgeWithMetadata, i: number, nodes: any) => {
+        const pathElement = this.getLinkPathElement(nodes[i]);
         return pathElement ? this.calculateNewPosition(pathElement, 'x') : (d.source.x + d.target.x) / 2;
       })
-      .attr('y', (d: EdgeWithMetadata) => {
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
+      .attr('y', (d: EdgeWithMetadata, i: number, nodes: any) => {
+        const pathElement = this.getLinkPathElement(nodes[i]);
         return pathElement ? this.calculateNewPosition(pathElement, 'y') : (d.source.y + d.target.y) / 2;
       })
       .style('font-size', () => {
@@ -4560,8 +4560,8 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       position: 'start' | 'end'
     ): void => {
       sel
-        .attr('transform', (d: EdgeWithMetadata) => {
-          const point = this.getEdgePathPoint(d.id, position);
+        .attr('transform', (d: EdgeWithMetadata, i: number, nodes: any) => {
+          const point = this.getEdgePathPoint(nodes[i], position);
           const fallback = (position === 'end' ? d.target : d.source) as any;
           const x = point ? point.x : (fallback?.x || 0);
           const y = point ? point.y : (fallback?.y || 0);
@@ -4579,14 +4579,33 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
   }
 
   /**
-   * Read the start or end point of a rendered edge path.
+   * Find the main edge path belonging to the same link-group as `el` — the
+   * label, marker, or other sibling that needs the path's geometry.
+   *
+   * Scoped to the group rather than looked up by id across the shadow root:
+   * edge ids are data and routinely contain selector syntax (`_inferred_<:
+   * <:"k4"->n3` is a real one), so splicing an id into a selector made
+   * querySelector throw SyntaxError and took the whole layout down with it.
+   * Matching on the group also keeps this off the per-tick cost of scanning
+   * the entire shadow root once per label.
+   *
+   * `data-link-id` marks the main path, so the optional highlight underlay
+   * sibling is never picked up here.
+   */
+  private getLinkPathElement(el: Element | null | undefined): SVGPathElement | null {
+    const group = el?.closest('.link-group');
+    return (group?.querySelector('path[data-link-id]') ?? null) as SVGPathElement | null;
+  }
+
+  /**
+   * Read the start or end point of the edge path `el` belongs to.
    *
    * Returns null when the path is missing or not rendered:
    * getTotalLength()/getPointAtLength() throw InvalidStateError on detached
    * or hidden paths, so callers fall back to layout coordinates.
    */
-  private getEdgePathPoint(linkId: string, position: 'start' | 'end'): { x: number; y: number } | null {
-    const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${linkId}"]`) as SVGPathElement | null;
+  private getEdgePathPoint(el: Element | null | undefined, position: 'start' | 'end'): { x: number; y: number } | null {
+    const pathElement = this.getLinkPathElement(el);
     if (!pathElement) return null;
     try {
       return pathElement.getPointAtLength(position === 'end' ? pathElement.getTotalLength() : 0);
@@ -4750,8 +4769,8 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     
     // Update link labels to follow edges using path midpoint
     linkGroups.select("text.linklabel")
-        .attr("x", (d: any) => {
-            const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
+        .attr("x", (d: any, i: number, nodes: any) => {
+            const pathElement = this.getLinkPathElement(nodes[i]);
             if (pathElement) {
                 const pathLength = pathElement.getTotalLength();
                 const midpoint = pathElement.getPointAtLength(pathLength / 2);
@@ -4762,8 +4781,8 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
             const targetX = d.target?.x ?? d.target?.bounds?.cx() ?? 0;
             return (sourceX + targetX) / 2;
         })
-        .attr("y", (d: any) => {
-            const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
+        .attr("y", (d: any, i: number, nodes: any) => {
+            const pathElement = this.getLinkPathElement(nodes[i]);
             if (pathElement) {
                 const pathLength = pathElement.getTotalLength();
                 const midpoint = pathElement.getPointAtLength(pathLength / 2);
@@ -5344,9 +5363,9 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     linkGroups
       .filter((d: any) => !this.isAlignmentEdge(d))
       .select("text.linklabel")
-      .attr("x", (edgeData: any) => {
+      .attr("x", (edgeData: any, i: number, nodes: any) => {
         // Use the actual rendered path element to find the true midpoint
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${edgeData.id}"]`) as SVGPathElement;
+        const pathElement = this.getLinkPathElement(nodes[i]);
         if (pathElement) {
           try {
             const pathLength = pathElement.getTotalLength();
@@ -5360,9 +5379,9 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         // Use node.x/y as primary source (same as default mode)
         return midpoint?.x ?? (edgeData.source?.x ?? edgeData.source?.bounds?.cx() ?? 0);
       })
-      .attr("y", (edgeData: any) => {
+      .attr("y", (edgeData: any, i: number, nodes: any) => {
         // Use the actual rendered path element to find the true midpoint
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${edgeData.id}"]`) as SVGPathElement;
+        const pathElement = this.getLinkPathElement(nodes[i]);
         if (pathElement) {
           try {
             const pathLength = pathElement.getTotalLength();
@@ -9115,16 +9134,16 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    */
   private updateLinkLabelsAfterRouting(): void {
     this.container.selectAll('.link-group .linklabel')
-      .attr('x', (d: any) => {
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
+      .attr('x', (d: any, i: number, nodes: any) => {
+        const pathElement = this.getLinkPathElement(nodes[i]);
         if (!pathElement) return 0;
 
         const pathLength = pathElement.getTotalLength();
         const midpoint = pathElement.getPointAtLength(pathLength / 2);
         return midpoint.x;
       })
-      .attr('y', (d: any) => {
-        const pathElement = this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`) as SVGPathElement;
+      .attr('y', (d: any, i: number, nodes: any) => {
+        const pathElement = this.getLinkPathElement(nodes[i]);
         if (!pathElement) return 0;
 
         const pathLength = pathElement.getTotalLength();

--- a/tests/webcola-link-selector.test.ts
+++ b/tests/webcola-link-selector.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
+
+/**
+ * Regression tests for resolving a link label's edge path.
+ *
+ * Edge ids come from the source data, so they carry whatever characters the
+ * data has — `_inferred_<: <:"k4"->n3` is a real id off an Alloy subtyping
+ * relation. Interpolated into `path[data-link-id="..."]`, its quotes closed the
+ * selector's string early and querySelector threw SyntaxError. The throw
+ * escaped the WebCola 'end' handler, so link labels never got positioned and
+ * the loading overlay wedged at "Finalizing...". The lookup now scopes to the
+ * label's own link-group and never puts an id in a selector, so no id can
+ * break it.
+ */
+
+const proto = WebColaCnDGraph.prototype as any;
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Build a shadow root of link-groups shaped like the real render: an optional
+ * highlight underlay, the main path carrying data-link-id, and a label.
+ */
+function renderLinkGroups(specs: Array<{ id: string; highlighted?: boolean }>) {
+  const host = document.createElement('div');
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  const labels = new Map<string, SVGTextElement>();
+  const paths = new Map<string, SVGPathElement>();
+
+  for (const { id, highlighted } of specs) {
+    const group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'link-group');
+
+    if (highlighted) {
+      const underlay = document.createElementNS(SVG_NS, 'path');
+      underlay.setAttribute('class', 'highlight-underlay');
+      group.appendChild(underlay);
+    }
+
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'link');
+    path.setAttribute('data-link-id', id);
+    group.appendChild(path);
+
+    const label = document.createElementNS(SVG_NS, 'text');
+    label.setAttribute('class', 'linklabel');
+    group.appendChild(label);
+
+    shadowRoot.appendChild(group);
+    labels.set(id, label);
+    paths.set(id, path);
+  }
+  return { labels, paths };
+}
+
+const lookup = (el: unknown) => proto.getLinkPathElement.call({}, el);
+
+// Both ids are real, and differ only inside the quoted segment.
+const K4 = '_inferred_<: <:"k4"->n3';
+const K1 = '_inferred_<: <:"k1"->n3';
+
+describe('WebColaCnDGraph.getLinkPathElement', () => {
+  it('resolves the path for a label whose id contains quotes and angle brackets', () => {
+    const { labels, paths } = renderLinkGroups([{ id: K1 }, { id: K4 }]);
+    expect(lookup(labels.get(K4))).toBe(paths.get(K4));
+  });
+
+  it('resolves each label to its own path, never a neighbour', () => {
+    const { labels, paths } = renderLinkGroups([{ id: K1 }, { id: K4 }]);
+    expect(lookup(labels.get(K1))).toBe(paths.get(K1));
+    expect(lookup(labels.get(K4))).toBe(paths.get(K4));
+  });
+
+  it.each([
+    ['bracket', 'a]b[c'],
+    ['backslash', 'back\\slash'],
+    ['quote and backslash', 'quote"and\\slash'],
+    ['newline', 'new\nline'],
+    ['leading digit', '9leading'],
+    ['space', 'has space'],
+    ['emoji', 'emoji🚀'],
+    ['empty', ''],
+  ])('resolves a label whose id contains a %s', (_label, id) => {
+    const { labels, paths } = renderLinkGroups([{ id }, { id: 'decoy' }]);
+    expect(lookup(labels.get(id))).toBe(paths.get(id));
+  });
+
+  it('picks the main path, not the highlight underlay drawn beneath it', () => {
+    const { labels, paths } = renderLinkGroups([{ id: K4, highlighted: true }]);
+    const found = lookup(labels.get(K4));
+    expect(found).toBe(paths.get(K4));
+    expect(found?.getAttribute('class')).toBe('link');
+  });
+
+  it.each([null, undefined])('returns null for a missing element (%s)', (el) => {
+    expect(lookup(el)).toBeNull();
+  });
+
+  it('returns null for an element outside any link-group', () => {
+    const orphan = document.createElementNS(SVG_NS, 'text');
+    expect(lookup(orphan)).toBeNull();
+  });
+});

--- a/tests/webcola-teardown.test.ts
+++ b/tests/webcola-teardown.test.ts
@@ -13,12 +13,16 @@ import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
 
 const proto = WebColaCnDGraph.prototype as any;
 
-/** Chainable d3-selection stub that records resolved attr values. */
-function markerSelection(datum: any) {
+/**
+ * Chainable d3-selection stub that records resolved attr values. Accessors are
+ * invoked with d3's (d, i, nodes) contract so code that reaches for its own
+ * element finds one.
+ */
+function markerSelection(datum: any, element: any = {}) {
   const applied: Record<string, any> = {};
   const sel: any = {
     attr(name: string, value: any) {
-      applied[name] = typeof value === 'function' ? value(datum) : value;
+      applied[name] = typeof value === 'function' ? value(datum, 0, [element]) : value;
       return sel;
     },
     style() { return sel; },
@@ -57,7 +61,7 @@ describe('WebColaCnDGraph teardown (#474)', () => {
           select: (selector: string) =>
             selector === '.target-marker' ? target.sel : source.sel,
         },
-        shadowRoot: { querySelector: () => throwingPath },
+        getLinkPathElement: () => throwingPath,
         getEdgePathPoint: proto.getEdgePathPoint,
       };
 
@@ -70,27 +74,28 @@ describe('WebColaCnDGraph teardown (#474)', () => {
   });
 
   describe('getEdgePathPoint', () => {
+    // The path lookup is stubbed per-test, so the element is just a handle to pass through.
+    const marker = {} as any;
+
     it('returns the path point when the path is rendered', () => {
       const fakeThis: any = {
-        shadowRoot: {
-          querySelector: () => ({
-            getTotalLength: () => 10,
-            getPointAtLength: (length: number) => ({ x: length, y: 5 }),
-          }),
-        },
+        getLinkPathElement: () => ({
+          getTotalLength: () => 10,
+          getPointAtLength: (length: number) => ({ x: length, y: 5 }),
+        }),
       };
 
-      expect(proto.getEdgePathPoint.call(fakeThis, 'e1', 'end')).toEqual({ x: 10, y: 5 });
-      expect(proto.getEdgePathPoint.call(fakeThis, 'e1', 'start')).toEqual({ x: 0, y: 5 });
+      expect(proto.getEdgePathPoint.call(fakeThis, marker, 'end')).toEqual({ x: 10, y: 5 });
+      expect(proto.getEdgePathPoint.call(fakeThis, marker, 'start')).toEqual({ x: 0, y: 5 });
     });
 
     it('returns null when the path is missing or not rendered', () => {
-      const missing: any = { shadowRoot: { querySelector: () => null } };
-      expect(proto.getEdgePathPoint.call(missing, 'e1', 'end')).toBeNull();
+      const missing: any = { getLinkPathElement: () => null };
+      expect(proto.getEdgePathPoint.call(missing, marker, 'end')).toBeNull();
 
-      const detached: any = { shadowRoot: { querySelector: () => throwingPath } };
-      expect(proto.getEdgePathPoint.call(detached, 'e1', 'end')).toBeNull();
-      expect(proto.getEdgePathPoint.call(detached, 'e1', 'start')).toBeNull();
+      const detached: any = { getLinkPathElement: () => throwingPath };
+      expect(proto.getEdgePathPoint.call(detached, marker, 'end')).toBeNull();
+      expect(proto.getEdgePathPoint.call(detached, marker, 'start')).toBeNull();
     });
   });
 


### PR DESCRIPTION
Link labels rendered at the wrong place and the loading overlay wedged at "Finalizing…" forever. Both symptoms had one cause.

## The bug

Edge ids come from the source data, and Alloy subtyping relations produce ids containing literal double quotes — `_inferred_<: <:"k4"->n3` is a real one from the reported sample. Nine call sites spliced that id straight into a selector:

```js
this.shadowRoot?.querySelector(`path[data-link-id="${d.id}"]`)
```

The embedded `"` closes the attribute value early, so `querySelector` throws:

```
SyntaxError: Failed to execute 'querySelector' on 'DocumentFragment':
'path[data-link-id="_inferred_<: <:"k4"->n3"]' is not a valid selector.
```

Two things made a narrow bug look catastrophic:

1. **The throw is inside a d3 `.attr()` accessor**, and d3 aborts the entire selection pass on the first throw — so a single bad id strands *every* link label, not just its own.
2. **The exception escaped WebCola's `end` handler** before it reached the closing `hideLoading()`, so the overlay never came down. Hence "stuck on finalizing".

## The fix

Rather than escape the id, remove it from the selector entirely. A label (or marker) and its path are always children of the same `.link-group`, so the lookup scopes to the group and matches on attribute *presence*:

```ts
private getLinkPathElement(el: Element | null | undefined): SVGPathElement | null {
  const group = el?.closest('.link-group');
  return (group?.querySelector('path[data-link-id]') ?? null) as SVGPathElement | null;
}
```

This is the idiom the file already used in two places. No id reaches a selector, so no id can break one. It also replaces a full shadow-root scan per label per tick with a scoped lookup — on a path that runs every frame.

All nine sites now route through this helper. `getEdgePathPoint` takes an element instead of an id; the d3 accessors use the `(d, i, nodes)` signature to get their own element.

### Why not escape?

Tried first, rejected — every scheme had a hole:

| scheme | hole |
|---|---|
| `CSS.escape` | not implemented in jsdom at all (`window.CSS` is undefined), so it'd need an untested fallback branch |
| quoted-string escaping | silently mismatches ids containing `]` — an nwsapi parser bug, so tests would quietly lie |
| hex-escape everything | breaks on surrogate pairs (emoji) |

The structural fix has none of these, and is testable in jsdom without quirks.

## Verification

Built the bundle and ran the reported sample in a real browser. The preview tab reports `visibilityState: "hidden"`, which parks `requestAnimationFrame` so WebCola can't tick on its own — the solver's tick loop was pumped manually to work around that harness limitation.

| | old bundle | fixed |
|---|---|---|
| tick | `SyntaxError` (the exact reported error) | no throw |
| converged | `false` | `true` |
| events fired | none | `relations-available`, `layout-complete` |
| labels positioned | **11/19** | **19/19** |
| `#loading` `visible` class | **`true`** (wedged) | `false` (hidden) |

The 11/19 is the tell: eleven clean ids positioned before the twelfth threw and killed the pass.

- Typecheck: 77 errors, identical to baseline (pre-existing).
- Tests: 137 files / 1937 tests pass.

## Notes for the reviewer

- **New test** `tests/webcola-link-selector.test.ts` covers the real id plus brackets, backslashes, newlines, emoji, and the highlight-underlay sibling (asserting it picks the main path, not the underlay).
- **`tests/webcola-teardown.test.ts` updated** for the new signatures. Its fake-`this` stubs now mock the direct collaborator (`getLinkPathElement`) instead of reaching through `shadowRoot`, and `markerSelection` now invokes accessors with d3's real `(d, i, nodes)` contract.
- **Lint goes 52 → 54 `no-undef`**, both from `Element` in the two new type annotations. That's the same false positive the config already emits 52 times for this file (it lacks browser globals and flags types like `Element`/`URL`/`Blob`). It can't pass either way — worth fixing separately.
- **The repro artifacts are deliberately not committed.** `sample/failing-sample.html` and `sample/failing-sample_files/` (3.8MB, containing a vendored stale build of this library) were untracked before this work and would rot immediately. Happy to add a trimmed fixture if you'd prefer one in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)