### PR TITLE
feat(directives): draw endpoints accept single (unary) groups; same-group ends render a hull self-loop

### DIFF
--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -906,7 +906,8 @@ Resolution notes:
 - The group name must belong to some `group` constraint (checked when the spec is parsed).
 - A name that means both a keyed group and a single group at once (two group constraints sharing the name — one binary, one unary — or two unary ones) is ambiguous and errors at layout time. Rename one of the constraints.
 - Keys may be hidden (`hideAtom`) — group ends attach to the hull and don't need the key node drawn.
-- If an end's atom doesn't key a group of that name **in this instance**, the edge is skipped with a console warning (data-dependent, not a spec error). Same when both ends resolve to the same group, or when the constraint built no groups at all (e.g. its relation is empty in this instance).
+- If an end's atom doesn't key a group of that name **in this instance**, the edge is skipped with a console warning (data-dependent, not a spec error). Same when the constraint built no groups at all (e.g. its relation is empty in this instance).
+- Both ends resolving to the **same group** draw a self-loop on that group's hull, just like a node self-loop.
 
 **Examples:**
 

--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -904,8 +904,9 @@ The left end applies to each tuple's first atom, the right end to its last. `dra
 Resolution notes:
 
 - The group name must belong to some `group` constraint (checked when the spec is parsed).
+- The named group constraint must be **keyed** (binary selector). Naming a group with no keys (unary selector — one group of atoms) is an error at layout time: `draw` attaches by key, so there is nothing to attach to.
 - Keys may be hidden (`hideAtom`) — group ends attach to the hull and don't need the key node drawn.
-- If an end's atom doesn't key a group of that name **in this instance**, the edge is skipped with a console warning (data-dependent, not a spec error). Same when both ends resolve to the same group.
+- If an end's atom doesn't key a group of that name **in this instance**, the edge is skipped with a console warning (data-dependent, not a spec error). Same when both ends resolve to the same group, or when the constraint built no groups at all (e.g. its relation is empty in this instance).
 
 **Examples:**
 

--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -897,14 +897,14 @@ end   ::=  _  |  <group-constraint-name>
 ```
 
 - `_` — this end attaches to the atom itself (the default behavior).
-- A group name — this end attaches to the **hull of that group constraint's group keyed by this end's atom**. A keyed group constraint (binary selector) produces one group per key, named `name[key]`; `draw` names the constraint, and the tuple's atom picks which of its groups.
+- A group name — this end attaches to the **hull of that group constraint's group**. A keyed group constraint (binary selector) builds one group per key, named `name[key]`: `draw` names the constraint, and this end's atom picks which of its groups. A unary group constraint builds a **single group**: naming it attaches the end to that group directly (the atom plays no part).
 
 The left end applies to each tuple's first atom, the right end to its last. `draw` never reorders — to flip an edge, transpose the selector (`~connected`). With `draw`, the selector may also be **unary**: the single atom feeds both ends (e.g. `draw: _ -> regions` connects each key to its own group).
 
 Resolution notes:
 
 - The group name must belong to some `group` constraint (checked when the spec is parsed).
-- The named group constraint must be **keyed** (binary selector). Naming a group with no keys (unary selector — one group of atoms) is an error at layout time: `draw` attaches by key, so there is nothing to attach to.
+- A name that means both a keyed group and a single group at once (two group constraints sharing the name — one binary, one unary — or two unary ones) is ambiguous and errors at layout time. Rename one of the constraints.
 - Keys may be hidden (`hideAtom`) — group ends attach to the hull and don't need the key node drawn.
 - If an end's atom doesn't key a group of that name **in this instance**, the edge is skipped with a console warning (data-dependent, not a spec error). Same when both ends resolve to the same group, or when the constraint built no groups at all (e.g. its relation is empty in this instance).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/site/directives.md
+++ b/site/directives.md
@@ -725,7 +725,7 @@ By default each selected pair gets an arrow between its two **atoms**. `draw` re
 - `draw: _ -> regions` — atom to hull.
 - With `draw`, a **unary** selector is allowed: the single atom feeds both ends, so `draw: _ -> regions` connects each key to its own group.
 
-The group name must match a `group` constraint (checked at parse time). If an atom doesn't key a group of that name in the current instance, that edge is skipped with a console warning. Keys hidden with `hideAtom` are fine — group ends attach to the hull, not the key node.
+The group name must match a `group` constraint (checked at parse time), and that constraint must be **keyed** — a binary selector, one group per key. Naming a group with no keys (unary selector) is an error at layout time, since `draw` attaches by key. If an atom doesn't key a group of that name in the current instance, that edge is skipped with a console warning. Keys hidden with `hideAtom` are fine — group ends attach to the hull, not the key node.
 
 ### Examples
 

--- a/site/directives.md
+++ b/site/directives.md
@@ -725,7 +725,7 @@ By default each selected pair gets an arrow between its two **atoms**. `draw` re
 - `draw: _ -> regions` — atom to hull.
 - With `draw`, a **unary** selector is allowed: the single atom feeds both ends, so `draw: _ -> regions` connects each key to its own group.
 
-The group name must match a `group` constraint (checked at parse time). A keyed group constraint (binary selector) builds one group per key, and the end's atom picks which; a unary group constraint builds a single group, and the end attaches to it directly. A name meaning both at once (two constraints sharing it) is an error. If an atom doesn't key a group of that name in the current instance, that edge is skipped with a console warning. Keys hidden with `hideAtom` are fine — group ends attach to the hull, not the key node.
+The group name must match a `group` constraint (checked at parse time). A keyed group constraint (binary selector) builds one group per key, and the end's atom picks which; a unary group constraint builds a single group, and the end attaches to it directly. A name meaning both at once (two constraints sharing it) is an error. If an atom doesn't key a group of that name in the current instance, that edge is skipped with a console warning. Both ends landing on the same group draw a self-loop on its hull. Keys hidden with `hideAtom` are fine — group ends attach to the hull, not the key node.
 
 ### Examples
 

--- a/site/directives.md
+++ b/site/directives.md
@@ -725,7 +725,7 @@ By default each selected pair gets an arrow between its two **atoms**. `draw` re
 - `draw: _ -> regions` — atom to hull.
 - With `draw`, a **unary** selector is allowed: the single atom feeds both ends, so `draw: _ -> regions` connects each key to its own group.
 
-The group name must match a `group` constraint (checked at parse time), and that constraint must be **keyed** — a binary selector, one group per key. Naming a group with no keys (unary selector) is an error at layout time, since `draw` attaches by key. If an atom doesn't key a group of that name in the current instance, that edge is skipped with a console warning. Keys hidden with `hideAtom` are fine — group ends attach to the hull, not the key node.
+The group name must match a `group` constraint (checked at parse time). A keyed group constraint (binary selector) builds one group per key, and the end's atom picks which; a unary group constraint builds a single group, and the end attaches to it directly. A name meaning both at once (two constraints sharing it) is an error. If an atom doesn't key a group of that name in the current instance, that edge is skipped with a console warning. Keys hidden with `hideAtom` are fine — group ends attach to the hull, not the key node.
 
 ### Examples
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -3176,6 +3176,44 @@ export class LayoutInstance {
         const drawDirectives = this._layoutSpec.directives.inferredEdges.filter(he => he.draw);
         drawDirectives.forEach((he) => {
 
+            const draw = he.draw!;
+
+            // Check the named group ends against the groups that were actually
+            // built, once per directive. Parsing already checked the names exist;
+            // whether a group constraint's groups have keys is only knowable per
+            // instance (it depends on the selector's arity in the data).
+            const namedEnds = [...new Set([draw.source, draw.target])]
+                .filter((end): end is string => end !== null);
+            for (const endName of namedEnds) {
+                const built = groups.filter(grp =>
+                    grp.sourceConstraint !== undefined
+                    && (grp.sourceConstraint as GroupBySelector).name === endName);
+                // Groups exist but none have keys: the constraint uses a unary
+                // selector, so no edge can ever attach. A spec bug — fail loudly
+                // rather than warning per tuple. (Checked for both ends before
+                // any data-dependent skip below, so it always surfaces.)
+                if (built.length > 0 && !built.some(grp => grp.keyed === true)) {
+                    throw new Error(
+                        `inferredEdge '${he.name}': draw endpoint '${endName}' is a group with no keys. `
+                        + `'${endName}' uses a unary selector, which makes a single group of atoms. `
+                        + `draw attaches an edge end to the group keyed by that end's atom, so it needs `
+                        + `a group constraint with a binary selector (one group per key). `
+                        + `Use '_' to keep this end on the atom itself.`
+                    );
+                }
+            }
+            for (const endName of namedEnds) {
+                // No groups at all. Indistinguishable from an empty relation in
+                // this instance (which also builds no groups), so this is a data
+                // fact, not a spec bug: warn once and skip the directive.
+                if (!groups.some(grp =>
+                    grp.sourceConstraint !== undefined
+                    && (grp.sourceConstraint as GroupBySelector).name === endName)) {
+                    console.warn(`[spytial] inferredEdge '${he.name}': skipping — no '${endName}' groups exist in this instance.`);
+                    return;
+                }
+            }
+
             let res;
             try {
                 res = this.evaluator.evaluate(he.selector, { instanceIndex: this.instanceNum });
@@ -3193,7 +3231,6 @@ export class LayoutInstance {
                 selectedTuples = res.selectedAtoms().map((atom: string) => [atom]);
             }
 
-            const draw = he.draw!;
             let edgeIdPrefix = `${inferredEdgePrefix}<:${he.name}`;
 
             selectedTuples.forEach((tuple) => {

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -3217,14 +3217,6 @@ export class LayoutInstance {
                     return;
                 }
             }
-            // Both ends naming the same single group can never draw anything —
-            // every edge would connect the group to itself. Warn once, not per tuple.
-            if (draw.source !== null && draw.source === draw.target
-                && builtFor(draw.source).some(grp => grp.keyed !== true)) {
-                console.warn(`[spytial] inferredEdge '${he.name}': skipping — both ends are the single group '${draw.source}'.`);
-                return;
-            }
-
             let res;
             try {
                 res = this.evaluator.evaluate(he.selector, { instanceIndex: this.instanceNum });
@@ -3256,10 +3248,9 @@ export class LayoutInstance {
                     return; // Skipped; resolveDrawEnd already warned.
                 }
 
-                if (source.groupId && source.groupId === target.groupId) {
-                    console.warn(`[spytial] inferredEdge '${he.name}': skipping edge for (${tuple.join(', ')}) — both ends resolve to the same group '${source.groupId}'.`);
-                    return;
-                }
+                // Both ends resolving to the same group is fine: the anchors
+                // coincide on one member and the renderer draws a self-loop on
+                // the hull, just like a node self-loop.
 
                 let edgeLabel = he.name;
                 if (n > 2) {

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -3180,25 +3180,31 @@ export class LayoutInstance {
 
             // Check the named group ends against the groups that were actually
             // built, once per directive. Parsing already checked the names exist;
-            // whether a group constraint's groups have keys is only knowable per
-            // instance (it depends on the selector's arity in the data).
+            // what kind of groups a constraint builds (one per key, or a single
+            // unkeyed group) is only knowable per instance.
             const namedEnds = [...new Set([draw.source, draw.target])]
                 .filter((end): end is string => end !== null);
+            const builtFor = (endName: string) => groups.filter(grp =>
+                grp.sourceConstraint !== undefined
+                && (grp.sourceConstraint as GroupBySelector).name === endName);
             for (const endName of namedEnds) {
-                const built = groups.filter(grp =>
-                    grp.sourceConstraint !== undefined
-                    && (grp.sourceConstraint as GroupBySelector).name === endName);
-                // Groups exist but none have keys: the constraint uses a unary
-                // selector, so no edge can ever attach. A spec bug — fail loudly
-                // rather than warning per tuple. (Checked for both ends before
-                // any data-dependent skip below, so it always surfaces.)
-                if (built.length > 0 && !built.some(grp => grp.keyed === true)) {
+                const built = builtFor(endName);
+                const single = built.filter(grp => grp.keyed !== true);
+                // A name may mean "one group per key" (binary selector) or "the
+                // single group" (unary selector) — but not both at once, and not
+                // two single groups: with no key in play there is no way to pick.
+                if (single.length > 1) {
                     throw new Error(
-                        `inferredEdge '${he.name}': draw endpoint '${endName}' is a group with no keys. `
-                        + `'${endName}' uses a unary selector, which makes a single group of atoms. `
-                        + `draw attaches an edge end to the group keyed by that end's atom, so it needs `
-                        + `a group constraint with a binary selector (one group per key). `
-                        + `Use '_' to keep this end on the atom itself.`
+                        `inferredEdge '${he.name}': draw endpoint '${endName}' is ambiguous — `
+                        + `${single.length} group constraints named '${endName}' each build a single (unkeyed) group. `
+                        + `Rename one of them.`
+                    );
+                }
+                if (single.length === 1 && built.length > 1) {
+                    throw new Error(
+                        `inferredEdge '${he.name}': draw endpoint '${endName}' is ambiguous — '${endName}' names `
+                        + `both a keyed group constraint (one group per key) and a single-group (unary) constraint. `
+                        + `Rename one of them.`
                     );
                 }
             }
@@ -3206,12 +3212,17 @@ export class LayoutInstance {
                 // No groups at all. Indistinguishable from an empty relation in
                 // this instance (which also builds no groups), so this is a data
                 // fact, not a spec bug: warn once and skip the directive.
-                if (!groups.some(grp =>
-                    grp.sourceConstraint !== undefined
-                    && (grp.sourceConstraint as GroupBySelector).name === endName)) {
+                if (builtFor(endName).length === 0) {
                     console.warn(`[spytial] inferredEdge '${he.name}': skipping — no '${endName}' groups exist in this instance.`);
                     return;
                 }
+            }
+            // Both ends naming the same single group can never draw anything —
+            // every edge would connect the group to itself. Warn once, not per tuple.
+            if (draw.source !== null && draw.source === draw.target
+                && builtFor(draw.source).some(grp => grp.keyed !== true)) {
+                console.warn(`[spytial] inferredEdge '${he.name}': skipping — both ends are the single group '${draw.source}'.`);
+                return;
             }
 
             let res;
@@ -3296,12 +3307,25 @@ export class LayoutInstance {
             return { anchor: atom };
         }
 
-        const matches = groups.filter(grp =>
-            grp.keyed === true
-            && grp.keyNodeId === atom
-            && grp.sourceConstraint !== undefined
+        const named = groups.filter(grp =>
+            grp.sourceConstraint !== undefined
             && (grp.sourceConstraint as GroupBySelector).name === family
         );
+
+        // A unary group constraint builds a single group with no keys: the end
+        // attaches to that group, whatever the atom. (addDrawInferredEdges has
+        // already rejected names that mean both a keyed and a single group.)
+        const single = named.find(grp => grp.keyed !== true);
+        if (single) {
+            const singleAnchor = single.nodeIds.find(id => g.hasNode(id));
+            if (!singleAnchor) {
+                console.warn(`[spytial] inferredEdge '${directiveName}': skipping edge — group '${single.name}' has no members present in the graph to anchor on.`);
+                return null;
+            }
+            return { anchor: singleAnchor, groupId: single.name };
+        }
+
+        const matches = named.filter(grp => grp.keyed === true && grp.keyNodeId === atom);
 
         if (matches.length === 0) {
             console.warn(`[spytial] inferredEdge '${directiveName}': skipping edge — atom '${atom}' does not key any '${family}' group in this instance.`);

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -803,7 +803,7 @@ const inferredEdge: ItemDefinition = {
       key: 'draw',
       kind: 'text',
       label: 'Draw',
-      help: "Endpoint interpretation: '<end> -> <end>', each end '_' (the atom itself) or a group constraint name (attach to that group's hull, keyed by the end's atom). E.g. 'regions -> regions' or '_ -> regions'.",
+      help: "Endpoint interpretation: '<end> -> <end>', each end '_' (the atom itself) or a keyed group constraint name (attach to that group's hull, keyed by the end's atom; the group needs a binary selector). E.g. 'regions -> regions' or '_ -> regions'.",
     },
     // Same shared blocks as edgeStyle. The engine still accepts the legacy flat
     // color/style/weight (deprecated + warned), so old specs keep working.

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -803,7 +803,7 @@ const inferredEdge: ItemDefinition = {
       key: 'draw',
       kind: 'text',
       label: 'Draw',
-      help: "Endpoint interpretation: '<end> -> <end>', each end '_' (the atom itself) or a keyed group constraint name (attach to that group's hull, keyed by the end's atom; the group needs a binary selector). E.g. 'regions -> regions' or '_ -> regions'.",
+      help: "Endpoint interpretation: '<end> -> <end>', each end '_' (the atom itself) or a group constraint name (attach to that group's hull — a keyed group picks by the end's atom; a unary group is a single group and attaches directly). E.g. 'regions -> regions' or '_ -> regions'.",
     },
     // Same shared blocks as edgeStyle. The engine still accepts the legacy flat
     // color/style/weight (deprecated + warned), so old specs keep working.

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -4315,6 +4315,49 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    * @param d - Edge data object.
    * @returns { source, target } with group-attached ends replaced by group objects.
    */
+  /**
+   * True when both ends are stamped with the SAME group: `draw: g -> g` on a
+   * tuple whose two atoms pick the same group, or a single (unary) group named
+   * at both ends. Rendered as a self-loop on the hull — the group analogue of
+   * a node self-loop. (Both anchors sit on the same member node, so the rest
+   * of the pipeline already treats these as self-loops.)
+   */
+  private isGroupSelfLoop(d: any): boolean {
+    return !!(d?.sourceGroupId && d.sourceGroupId === d.targetGroupId);
+  }
+
+  /**
+   * Route for a group self-loop: the node self-loop petal, drawn on the group
+   * hull instead of the node rect. Loops on the same hull distribute around
+   * its sides/rings independently of any node self-loops. Falls back to the
+   * member-node petal when the group (or its bounds) is missing.
+   */
+  private createGroupSelfLoopRoute(edgeData: any, grid: boolean = false): Array<{ x: number; y: number }> {
+    const groups = this.currentLayout?.groups || [];
+    const grp = groups.find((g: any) => g.id === edgeData.sourceGroupId);
+    if (grp) this.ensureGroupBounds(grp, edgeData.source);
+    const bounds = grp?.bounds ?? undefined;
+    const index = bounds ? this.getGroupSelfLoopIndex(edgeData) : undefined;
+    return grid
+      ? this.createGridSelfLoopRoute(edgeData, bounds, index)
+      : this.createSelfLoopRoute(edgeData, bounds, index);
+  }
+
+  /**
+   * 0-based index of this self-loop among all self-loops on its GROUP, so
+   * multiple loops on one hull spread around its sides like node loops do.
+   */
+  private getGroupSelfLoopIndex(edgeData: any): number {
+    let idx = 0;
+    for (const e of ((this.currentLayout?.links as any[]) ?? [])) {
+      if (this.isGroupSelfLoop(e) && e.sourceGroupId === edgeData.sourceGroupId) {
+        if (e.id === edgeData.id) return idx;
+        idx++;
+      }
+    }
+    return 0;
+  }
+
   private resolveGroupEdgeEndpoints(d: any): { source: any; target: any } {
     if (!(d.sourceGroupId || d.targetGroupId)) {
       return { source: d.source, target: d.target };
@@ -4476,6 +4519,13 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     // is not picked up here — markers and .raise() apply only to the main edge.
     this.svgLinkGroups.select('path[data-link-id]')
       .attr('d', (d: EdgeWithMetadata) => {
+        // Same group at both ends: a self-loop petal on the hull. (Resolving
+        // endpoints would hand getStableEdgePath the same rect twice and
+        // collapse the path to a point.)
+        if (this.isGroupSelfLoop(d)) {
+          return this.lineFunction(this.createGroupSelfLoopRoute(d));
+        }
+
         // Resolve group-edge endpoints (group boundary instead of member node center).
         const { source, target } = this.resolveGroupEdgeEndpoints(d);
 
@@ -4743,6 +4793,9 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
             // draw-stamped edges are exempt (coinciding anchors can still have
             // distinct hull endpoints); `_g_` connectors keep their historical
             // self-loop rendering (see createEdgeRoute).
+            if (this.isGroupSelfLoop(d)) {
+                return this.gridLineFunction(this.createGroupSelfLoopRoute(d, true));
+            }
             if (d.source?.id === d.target?.id
                 && (d.id?.startsWith('_g_') || !(d.sourceGroupId || d.targetGroupId))) {
                 const route = this.createGridSelfLoopRoute(d);
@@ -5269,11 +5322,14 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         .attr("d", (edgeData: any) => {
           // Handle self-loops specially - GridRouter can't route these
           if (edgeData.source?.id === edgeData.target?.id) {
+            if (this.isGroupSelfLoop(edgeData)) {
+              return this.gridLineFunction(this.createGroupSelfLoopRoute(edgeData, true));
+            }
             // Orthogonal "out and back" hook to match grid mode's rectilinear style
             const route = this.createGridSelfLoopRoute(edgeData);
             return this.gridLineFunction(route);
           }
-          
+
           const route = routesByEdgeId.get(edgeData.id);
           if (!route) {
             // Create orthogonal fallback path for unroutable edges
@@ -5349,10 +5405,13 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
       .attr("d", (edgeData: any) => {
         // Handle self-loops specially
         if (edgeData.source?.id === edgeData.target?.id) {
+          if (this.isGroupSelfLoop(edgeData)) {
+            return this.gridLineFunction(this.createGroupSelfLoopRoute(edgeData, true));
+          }
           const route = this.createGridSelfLoopRoute(edgeData);
           return this.gridLineFunction(route);
         }
-        
+
         // Create orthogonal fallback path
         const sourceX = edgeData.source?.x ?? edgeData.source?.bounds?.cx() ?? 0;
         const sourceY = edgeData.source?.y ?? edgeData.source?.bounds?.cy() ?? 0;
@@ -6821,6 +6880,10 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     // hulls — differ. `_g_` connectors are NOT exempt: a key-is-its-own-anchor
     // connector kept its historical self-loop rendering through the stamp
     // unification, so desugared connectors stay on this path.
+    if (this.isGroupSelfLoop(edgeData)) {
+      // Both ends are the same group: a self-loop petal on the hull.
+      return this.createGroupSelfLoopRoute(edgeData);
+    }
     if (edgeData.source.id === edgeData.target.id
         && (edgeData.id?.startsWith('_g_')
             || !(edgeData.sourceGroupId || edgeData.targetGroupId))) {
@@ -8055,9 +8118,9 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    * @param edgeData - The edge data object
    * @returns Array of route points for the self-loop
    */
-  private createSelfLoopRoute(edgeData: any): Array<{ x: number; y: number }> {
+  private createSelfLoopRoute(edgeData: any, boundsOverride?: any, indexOverride?: number): Array<{ x: number; y: number }> {
     const source = edgeData.source;
-    const bounds = source.bounds;
+    const bounds = boundsOverride ?? source.bounds;
 
     if (!bounds) {
       // Fallback for missing bounds — minimal upward petal.
@@ -8075,7 +8138,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     const cx = bounds.x + width / 2;
     const cy = bounds.y + height / 2;
 
-    const selfLoopIndex = this.getSelfLoopIndex(edgeData);
+    const selfLoopIndex = indexOverride ?? this.getSelfLoopIndex(edgeData);
     const sideIdx = selfLoopIndex % 4;
     const ring = Math.floor(selfLoopIndex / 4);
     const ringScale = 1 + ring * WebColaCnDGraph.SELF_LOOP_CURVATURE_SCALE;
@@ -8156,9 +8219,9 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
    *   p3 = (cx + spread/2, top)   ← end
    * Drawn with the rectilinear gridLineFunction → three right-angle bends.
    */
-  private createGridSelfLoopRoute(edgeData: any): Array<{ x: number; y: number }> {
+  private createGridSelfLoopRoute(edgeData: any, boundsOverride?: any, indexOverride?: number): Array<{ x: number; y: number }> {
     const source = edgeData.source;
-    const bounds = source.bounds;
+    const bounds = boundsOverride ?? source.bounds;
 
     if (!bounds) {
       return [
@@ -8174,7 +8237,7 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     const cx = bounds.x + width / 2;
     const cy = bounds.y + height / 2;
 
-    const selfLoopIndex = this.getSelfLoopIndex(edgeData);
+    const selfLoopIndex = indexOverride ?? this.getSelfLoopIndex(edgeData);
     const sideIdx = selfLoopIndex % 4;
     const ring = Math.floor(selfLoopIndex / 4);
     const ringScale = 1 + ring * WebColaCnDGraph.SELF_LOOP_CURVATURE_SCALE;
@@ -8230,14 +8293,17 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
     const key = this.getNodePairKey(nodeId, nodeId);
     const selfLoops = this.edgeRoutingCache.edgesBetweenNodes.get(key);
     if (selfLoops) {
-      const idx = selfLoops.findIndex((e: any) => e.id === edgeData.id);
+      // Group self-loops share the node-pair key (both anchors on one member)
+      // but render on the hull — don't let them consume node-petal sides.
+      const nodeLoops = selfLoops.filter((e: any) => !this.isGroupSelfLoop(e));
+      const idx = nodeLoops.findIndex((e: any) => e.id === edgeData.id);
       return idx >= 0 ? idx : 0;
     }
     // Fallback: scan all links
     if (this.currentLayout?.links) {
       let idx = 0;
       for (const edge of this.currentLayout.links as any[]) {
-        if (edge.source.id === nodeId && edge.target.id === nodeId) {
+        if (edge.source.id === nodeId && edge.target.id === nodeId && !this.isGroupSelfLoop(edge)) {
           if (edge.id === edgeData.id) return idx;
           idx++;
         }

--- a/tests/inferred-edge-draw.test.ts
+++ b/tests/inferred-edge-draw.test.ts
@@ -176,7 +176,7 @@ directives:
     expect(edges.some(e => e.id.includes('r3'))).toBe(false);
   });
 
-  it('skips edges whose ends resolve to the same group', () => {
+  it('keeps edges whose ends resolve to the same group: a self-loop on that group', () => {
     const withSelfLoop: IJsonDataInstance = {
       ...regionsData,
       relations: regionsData.relations.map(r =>
@@ -194,9 +194,17 @@ directives:
     const layout = generate(groupedSpec('regions -> regions'), withSelfLoop);
 
     const edges = layout.edges.filter(e => e.id.includes('_inferred_') && e.id.includes('connected'));
-    expect(edges).toHaveLength(1);
-    expect(edges[0].sourceGroupId).toBe('regions[r1]');
-    expect(edges[0].targetGroupId).toBe('regions[r2]');
+    expect(edges).toHaveLength(2);
+
+    const loop = edges.find(e => e.sourceGroupId === e.targetGroupId);
+    expect(loop).toBeDefined();
+    expect(loop?.sourceGroupId).toBe('regions[r1]');
+    // Both anchors coincide on one member — the renderer's self-loop shape.
+    expect(loop?.source.id).toBe(loop?.target.id);
+
+    const plain = edges.find(e => e.sourceGroupId !== e.targetGroupId);
+    expect(plain?.sourceGroupId).toBe('regions[r1]');
+    expect(plain?.targetGroupId).toBe('regions[r2]');
   });
 
   it('survives hidden group keys: group ends anchor on members, not keys', () => {
@@ -302,7 +310,7 @@ directives:
     expect(edges.every(e => e.targetGroupId === 'cities')).toBe(true);
   });
 
-  it('warns once and skips when both ends are the same single group', () => {
+  it('draws a self-loop on the single group when both ends name it', () => {
     const spec = `
 constraints:
   - group:
@@ -314,16 +322,13 @@ directives:
       selector: connected
       draw: cities -> cities
 `;
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const layout = generate(spec);
-      const edges = layout.edges.filter(e => e.id.includes('_inferred_') && e.id.includes('connected'));
-      expect(edges).toHaveLength(0);
-      const skips = warn.mock.calls.filter(c => String(c[0]).includes("both ends are the single group 'cities'"));
-      expect(skips).toHaveLength(1);
-    } finally {
-      warn.mockRestore();
-    }
+    const layout = generate(spec);
+    const edges = layout.edges.filter(e => e.id.includes('_inferred_') && e.id.includes('connected'));
+    expect(edges).toHaveLength(1);
+    expect(edges[0].sourceGroupId).toBe('cities');
+    expect(edges[0].targetGroupId).toBe('cities');
+    // Both anchors coincide on one member — the renderer's self-loop shape.
+    expect(edges[0].source.id).toBe(edges[0].target.id);
   });
 
   it('errors when a name means both a keyed group and a single group', () => {

--- a/tests/inferred-edge-draw.test.ts
+++ b/tests/inferred-edge-draw.test.ts
@@ -246,7 +246,7 @@ directives:
   });
 });
 
-describe('inferredEdge draw — groups without keys', () => {
+describe('inferredEdge draw — single (unary) groups', () => {
   // A relation that exists but has no tuples in this instance: the group
   // constraint over it builds no groups, which must NOT be treated as a spec bug.
   const withEmptyRelation: IJsonDataInstance = {
@@ -257,7 +257,7 @@ describe('inferredEdge draw — groups without keys', () => {
     ]
   };
 
-  it('errors at layout time when a draw end names a group with no keys (unary selector)', () => {
+  it('attaches to the single group when the named constraint is unary', () => {
     const spec = `
 constraints:
   - group:
@@ -269,10 +269,79 @@ directives:
       selector: connected
       draw: _ -> cities
 `;
-    // The name exists, so parsing succeeds — whether the group has keys is
-    // only knowable per instance (it depends on the selector's arity).
-    expect(() => parseLayoutSpec(spec)).not.toThrow();
-    expect(() => generate(spec)).toThrow(/group with no keys/);
+    const layout = generate(spec);
+
+    const edge = layout.edges.find(e => e.id.includes('_inferred_') && e.id.includes('connected'));
+    expect(edge).toBeDefined();
+    expect(edge?.source.id).toBe('r1');
+    // A unary constraint builds one group named after the constraint — no [key].
+    expect(edge?.targetGroupId).toBe('cities');
+    // Anchored on a member of the single group.
+    expect(['c1', 'c2', 'c3']).toContain(edge?.target.id);
+  });
+
+  it('ignores the atom for a single-group end: every tuple attaches to the same group', () => {
+    const spec = `
+constraints:
+  - group:
+      name: cities
+      selector: City
+directives:
+  - inferredEdge:
+      name: connected
+      selector: Region
+      draw: _ -> cities
+`;
+    // Regions are not members of cities — the atom plays no part in a
+    // single-group end, it only anchors the '_' side.
+    const layout = generate(spec);
+
+    const edges = layout.edges.filter(e => e.id.includes('_inferred_') && e.id.includes('connected'));
+    expect(edges).toHaveLength(2);
+    expect(edges.map(e => e.source.id).sort()).toEqual(['r1', 'r2']);
+    expect(edges.every(e => e.targetGroupId === 'cities')).toBe(true);
+  });
+
+  it('warns once and skips when both ends are the same single group', () => {
+    const spec = `
+constraints:
+  - group:
+      name: cities
+      selector: City
+directives:
+  - inferredEdge:
+      name: connected
+      selector: connected
+      draw: cities -> cities
+`;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const layout = generate(spec);
+      const edges = layout.edges.filter(e => e.id.includes('_inferred_') && e.id.includes('connected'));
+      expect(edges).toHaveLength(0);
+      const skips = warn.mock.calls.filter(c => String(c[0]).includes("both ends are the single group 'cities'"));
+      expect(skips).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('errors when a name means both a keyed group and a single group', () => {
+    const spec = `
+constraints:
+  - group:
+      name: cities
+      selector: contains
+  - group:
+      name: cities
+      selector: City
+directives:
+  - inferredEdge:
+      name: connected
+      selector: connected
+      draw: _ -> cities
+`;
+    expect(() => generate(spec)).toThrow(/ambiguous/);
   });
 
   it('warns once and skips (no error) when the named group built no groups in this instance', () => {
@@ -297,26 +366,6 @@ directives:
     } finally {
       warn.mockRestore();
     }
-  });
-
-  it('surfaces the no-keys error even when the other end would skip', () => {
-    const spec = `
-constraints:
-  - group:
-      name: owners
-      selector: owns
-  - group:
-      name: cities
-      selector: City
-directives:
-  - inferredEdge:
-      name: connected
-      selector: connected
-      draw: owners -> cities
-`;
-    // 'owners' built no groups (would skip), but 'cities' having no keys is a
-    // spec bug and must not be masked by the skip.
-    expect(() => generate(spec, withEmptyRelation)).toThrow(/group with no keys/);
   });
 });
 

--- a/tests/inferred-edge-draw.test.ts
+++ b/tests/inferred-edge-draw.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
 import { parseLayoutSpec, parseInferredEdgeDraw } from '../src/layout/layoutspec';
 import { LayoutInstance } from '../src/layout/layoutinstance';
@@ -243,6 +243,80 @@ directives:
     expect(edge?.target.id).toBe('r2');
     expect(edge?.sourceGroupId).toBeUndefined();
     expect(edge?.targetGroupId).toBeUndefined();
+  });
+});
+
+describe('inferredEdge draw — groups without keys', () => {
+  // A relation that exists but has no tuples in this instance: the group
+  // constraint over it builds no groups, which must NOT be treated as a spec bug.
+  const withEmptyRelation: IJsonDataInstance = {
+    ...regionsData,
+    relations: [
+      ...regionsData.relations,
+      { id: 'owns', name: 'owns', types: ['Region', 'City'], tuples: [] }
+    ]
+  };
+
+  it('errors at layout time when a draw end names a group with no keys (unary selector)', () => {
+    const spec = `
+constraints:
+  - group:
+      name: cities
+      selector: City
+directives:
+  - inferredEdge:
+      name: connected
+      selector: connected
+      draw: _ -> cities
+`;
+    // The name exists, so parsing succeeds — whether the group has keys is
+    // only knowable per instance (it depends on the selector's arity).
+    expect(() => parseLayoutSpec(spec)).not.toThrow();
+    expect(() => generate(spec)).toThrow(/group with no keys/);
+  });
+
+  it('warns once and skips (no error) when the named group built no groups in this instance', () => {
+    const spec = `
+constraints:
+  - group:
+      name: owners
+      selector: owns
+directives:
+  - inferredEdge:
+      name: connected
+      selector: connected
+      draw: _ -> owners
+`;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const layout = generate(spec, withEmptyRelation);
+      const edges = layout.edges.filter(e => e.id.includes('_inferred_') && e.id.includes('connected'));
+      expect(edges).toHaveLength(0);
+      const skips = warn.mock.calls.filter(c => String(c[0]).includes("no 'owners' groups exist"));
+      expect(skips).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('surfaces the no-keys error even when the other end would skip', () => {
+    const spec = `
+constraints:
+  - group:
+      name: owners
+      selector: owns
+  - group:
+      name: cities
+      selector: City
+directives:
+  - inferredEdge:
+      name: connected
+      selector: connected
+      draw: owners -> cities
+`;
+    // 'owners' built no groups (would skip), but 'cities' having no keys is a
+    // spec bug and must not be masked by the skip.
+    expect(() => generate(spec, withEmptyRelation)).toThrow(/group with no keys/);
   });
 });
 


### PR DESCRIPTION
## What this does

A `draw` endpoint names a group constraint. Which group does the end attach to?

- A **keyed** group constraint (binary selector) builds one group per key — `regions[West]`, `regions[East]` — and the end's atom picks which one. (This shipped in #499.)
- A **unary** group constraint builds a **single group**, with no keys. Naming it now attaches the end to that group directly — there is nothing for a key to pick, and the atom plays no part.

```yaml
constraints:
  - group: { name: people, selector: Person }   # unary -> one group
directives:
  - inferredEdge:
      name: manages
      selector: manages
      draw: people -> _        # people hull -> atom
```

Previously the unary case parsed fine (the name exists) but silently dropped every edge at layout time, with a per-tuple warning that blamed the data — "atom 'p1' does not key any 'people' group in this instance" — when no instance could ever work.

Fixes #500.

## Same group at both ends: a self-loop on the hull

`draw` never decides which edges exist — the selector does; `draw` only reinterprets what the ends attach to. So when both ends resolve to the same group (a tuple whose two atoms key the same group, or a single group named at both ends), the edge is **kept** and rendered as a self-loop on the group hull — the same petal shape node self-loops use, drawn on the hull's boundary. Multiple loops on one hull distribute around its sides and rings, independently of any node self-loops inside it.

## Diagnostics, each at the right place

| situation | what happens |
|---|---|
| the name doesn't match any group constraint | parse error (unchanged) |
| the name means both a keyed group and a single group (two constraints share it), or two single groups | error at layout time — with no key in play there is no way to pick |
| the constraint built no groups (e.g. its relation is empty in this instance) | one warning, directive skipped — a data fact, never an error |
| the groups have keys but an atom isn't one of them | unchanged per-edge warning, which is accurate |

Why the ambiguity check is at layout time, not parse time: what kind of groups a constraint builds depends on its selector's arity in the instance, and the parser has no instance. Names are checked at parse time; group kinds at layout time.

Why "built no groups" never errors: an empty binary relation also builds no groups — indistinguishable from a unary selector at that point — and a correct spec must keep rendering quietly on empty data. The check therefore reads the built groups, never the selector's arity flag.

## Renderer

Group self-loops reuse the existing node self-loop petal (both routing modes), pointed at the group's bounds, dispatched wherever edge paths are drawn (initial routing, drag updates, grid mode, grid fallback). Everything else is untouched: stamps are group names either way (`regions[r1]` keyed, `people` single), and the renderer already looks groups up by name. Node self-loop side-distribution no longer counts group loops that share the same anchor node.

## Verification

- 7 new/updated tests in `tests/inferred-edge-draw.test.ts`: a single-group end resolves (bare name stamp, member anchor); the atom plays no part; same group at both ends keeps the edge with equal stamps and coinciding anchors (keyed and single variants); keyed+single name collision errors; an empty relation warns once and skips without error.
- Full suite 2002/2002; typecheck error set identical to main (73 pre-existing, zero new).
- Browser-verified, numerically: a keyed self-loop's petal starts and ends exactly on the `regions[r1]` hull edge (x = 309.99687, matching the hull's right edge to the last digit); a single-group self-loop sits exactly on the `people` hull edge; labels at the petal apex; plain node self-loops for the underlying relations still render on their nodes; hull-to-hull and hull-to-atom edges unregressed; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
