### PR TITLE
fix(style): make textStyle `large` render perceptibly larger than the node label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/layout/text-extent.ts
+++ b/src/layout/text-extent.ts
@@ -37,8 +37,12 @@ export type AttrTextSize = 'small' | 'normal' | 'large';
 
 /** "small" tier — below the normal secondary size. */
 export const SECONDARY_FONT_SIZE_SMALL = 9;
-/** "large" tier — above {@link MAIN_LABEL_FONT_SIZE} so the line reads as bigger than the node's own label. */
-export const SECONDARY_FONT_SIZE_LARGE = 16;
+/**
+ * "large" tier — must read as bigger than the node's own label at a glance. The
+ * main label is bold, which reads ~1-2px larger than its nominal size, so the
+ * gap has to clear that before it's perceptible: 20px against a bold 14px label.
+ */
+export const SECONDARY_FONT_SIZE_LARGE = 20;
 
 /** Resolve an attribute/tag text-size tier to its pixel font size. Missing/unknown → the normal secondary size. */
 export function resolveAttrFontSize(size?: AttrTextSize): number {

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -4565,14 +4565,19 @@ export class WebColaCnDGraph extends  HTMLElement { //(typeof HTMLElement !== 'u
         const pathElement = this.getLinkPathElement(nodes[i]);
         return pathElement ? this.calculateNewPosition(pathElement, 'y') : (d.source.y + d.target.y) / 2;
       })
-      .style('font-size', () => {
-        // Zoom-aware font sizing: scale up slightly when zoomed out
+      .style('font-size', (d: EdgeWithMetadata) => {
+        // Zoom-aware font sizing: scale up slightly when zoomed out. Base off the
+        // edge's own textStyle tier when it set one — this runs on every tick and
+        // would otherwise clobber the size setupLinkLabels applied, collapsing
+        // every tier back to the 12px default.
+        const baseFontSize = d?.textStyle?.size ? resolveAttrFontSize(d.textStyle.size) : 12;
         const zoomScale = this.getCurrentZoomScale();
-        const baseFontSize = 12;
         // When zoomed out (scale < 1), increase font size slightly to maintain readability
         // When zoomed in (scale > 1), keep base size
         const adjustedSize = zoomScale < 1 ? baseFontSize / Math.sqrt(zoomScale) : baseFontSize;
-        return `${Math.min(adjustedSize, 16)}px`; // Cap at 16px
+        // Cap the zoom-out boost at a third above the base rather than a fixed
+        // ceiling, so a `large` tier isn't shrunk back below its authored size.
+        return `${Math.min(adjustedSize, baseFontSize * 4 / 3)}px`;
       })
       .raise();
 

--- a/tests/edge-style-render.test.ts
+++ b/tests/edge-style-render.test.ts
@@ -84,7 +84,7 @@ describe('webcola-cnd-graph — edge label textStyle → font-size / fill', () =
     it('maps a textStyle size tier to a px font size', () => {
         expect(fontSize({ textStyle: { size: 'small' } })).toBe('9px');
         expect(fontSize({ textStyle: { size: 'normal' } })).toBe('11px');
-        expect(fontSize({ textStyle: { size: 'large' } })).toBe('16px');
+        expect(fontSize({ textStyle: { size: 'large' } })).toBe('20px');
     });
 
     it('returns null font-size when no size tier is set (→ CSS default)', () => {


### PR DESCRIPTION
## What

`textStyle: { size: large }` did not render larger than the node label, despite being documented as "bigger than the label". Two independent causes:

**1. The tier constant was too small.** `SECONDARY_FONT_SIZE_LARGE` was 16px against a main label of 14px **bold**. Bold text reads roughly 1–2px larger than its nominal size, so a 2px nominal gap was cancelled out by the weight difference and `large` looked the same as the label. Raised to 20px.

**2. Edge labels ignored the tier entirely.** `setupLinkLabels` correctly applied the styled font size at render time, but the zoom-aware sizing in the tick handler re-set `font-size` from a hardcoded 12px base on *every layout tick*, capped at 16px. Any authored tier was overwritten within milliseconds, so `large` was never larger on an edge label. It now bases the zoom calculation on the edge's own tier when one is set, and caps the zoom-out boost at 4/3 of that base rather than a fixed 16px ceiling that would have re-shrunk a `large` label.

## Why

Reported directly: `large` was not perceptibly larger than the label. The second cause was found while verifying the first — the constant change alone would have fixed node attribute lines but left edge labels still collapsing to 12px.

## Notes for reviewers

- **The test change is the contract, not a workaround.** `edge-style-render.test.ts:87` pinned the tier's resolved pixel size (`16px` → `20px`). That assertion exists to pin this value, so updating it is the intended signal of the change.
- **Box sizing tracked the change for free.** `estimateLabelBox` already keys off the same constant, so node boxes grow to fit the larger text with no further change.
- **Docs needed no update.** They describe the tier relatively ("`large` renders bigger than the label") with no pixel values, so they are now accurate rather than aspirational.
- **20px is a judgment call** — chosen as noticeable at a glance without dominating the node. It is a single constant if a different weight is preferred.

## Verification

Drove the demo (`webcola-demo/claude-demo.html`) with an attribute and an edge label both set to `large`. Computed styles confirm the attribute line at 20px/400 against the label's 14px/700, and the edge label holding 20px through layout ticks (previously 12px). Node box auto-grew to fit.

Full suite: **1963 tests across 139 files pass** (Z3/oracle suites excluded per project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)