### PR TITLE
feat(spec-editor): unknown-key warnings, consumable taxonomy, and a CodeMirror code editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "3.2.3",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,21 @@
 {
   "name": "spytial-core",
-  "version": "3.1.1",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "3.1.1",
+      "version": "3.2.3",
       "license": "MIT",
       "dependencies": {
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-yaml": "^6.1.3",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.6",
+        "@lezer/highlight": "^1.2.3",
         "@types/d3": "^4.13.12",
         "@types/graphlib-dot": "^0.6.4",
         "@types/react": "^19.1.8",
@@ -28,7 +35,8 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "simple-graph-query": "^2.8.2",
-        "webcola": "^3.4.0"
+        "webcola": "^3.4.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -612,6 +620,91 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1717,6 +1810,47 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4438,6 +4572,12 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
     },
     "node_modules/cross-fetch": {
       "version": "4.1.0",
@@ -9197,6 +9337,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/stylus": {
       "version": "0.62.0",
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.62.0.tgz",
@@ -10681,6 +10827,12 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -10951,11 +11103,10 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "optional": true,
-      "peer": true,
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,13 @@
     "z3-solver": "^4.16.0"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-yaml": "^6.1.3",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/lint": "^6.9.7",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.6",
+    "@lezer/highlight": "^1.2.3",
     "@types/d3": "^4.13.12",
     "@types/graphlib-dot": "^0.6.4",
     "@types/react": "^19.1.8",
@@ -148,6 +155,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "simple-graph-query": "^2.8.2",
-    "webcola": "^3.4.0"
+    "webcola": "^3.4.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/src/components/NoCodeView/shims.ts
+++ b/src/components/NoCodeView/shims.ts
@@ -28,7 +28,6 @@ import {
   serializeStateToYaml,
   newId,
   isKnownType,
-  isKnownYamlKey,
   getKnownYamlKeys,
 } from '../../spec-editor';
 import type { SpecItem, SpecDocumentState } from '../../spec-editor';
@@ -155,12 +154,21 @@ export interface SpytialValidationResult {
 
 /**
  * Recognized constraint/directive keys are derived from the registry
- * (`isKnownYamlKey` / `getKnownYamlKeys`) rather than hand-listed here, so this
- * check can't drift out of sync as the registry grows — the reason a
- * hand-maintained list previously false-warned on `atomStyle`/`edgeStyle`. The
- * check is kind-agnostic (a known key is accepted in either section, matching
- * the engine, which simply ignores a directive placed among constraints).
+ * (`getKnownYamlKeys`) rather than hand-listed here, so this check can't drift
+ * as the registry grows — the reason a stale list previously false-warned on
+ * the current `atomStyle`/`edgeStyle` directives. The check stays section-aware:
+ * a known key in the wrong section (e.g. `edgeStyle` under `constraints`) is
+ * still flagged, because `parseLayoutSpec` drops it there.
  */
+
+/** Keys valid in the `constraints:` section. */
+const CONSTRAINT_SECTION_KEYS = getKnownYamlKeys('constraint');
+/**
+ * Keys valid in the `directives:` section. `size`/`hideAtom` are registered as
+ * constraints but the engine also reads them among directives, so they are
+ * valid in both sections.
+ */
+const DIRECTIVE_SECTION_KEYS = [...getKnownYamlKeys('directive'), 'size', 'hideAtom'];
 
 /** Known top-level keys in a Spytial spec. */
 const KNOWN_TOP_LEVEL_KEYS = ['constraints', 'directives'];
@@ -217,9 +225,9 @@ export function validateSpytialSpec(yamlString: string): SpytialValidationResult
       obj.constraints.forEach((constraint, i) => {
         if (constraint && typeof constraint === 'object') {
           const constraintType = Object.keys(constraint as object)[0];
-          if (constraintType && !isKnownYamlKey(constraintType)) {
+          if (constraintType && !CONSTRAINT_SECTION_KEYS.includes(constraintType)) {
             result.warnings.push(
-              `Unrecognized constraint type at index ${i}: "${constraintType}". Known types: ${getKnownYamlKeys().join(', ')}`,
+              `Unrecognized constraint type at index ${i}: "${constraintType}". Known types: ${CONSTRAINT_SECTION_KEYS.join(', ')}`,
             );
           }
         }
@@ -230,9 +238,9 @@ export function validateSpytialSpec(yamlString: string): SpytialValidationResult
       obj.directives.forEach((directive, i) => {
         if (directive && typeof directive === 'object') {
           const directiveType = Object.keys(directive as object)[0];
-          if (directiveType && !isKnownYamlKey(directiveType)) {
+          if (directiveType && !DIRECTIVE_SECTION_KEYS.includes(directiveType)) {
             result.warnings.push(
-              `Unrecognized directive type at index ${i}: "${directiveType}". Known types: ${getKnownYamlKeys().join(', ')}`,
+              `Unrecognized directive type at index ${i}: "${directiveType}". Known types: ${DIRECTIVE_SECTION_KEYS.join(', ')}`,
             );
           }
         }

--- a/src/components/NoCodeView/shims.ts
+++ b/src/components/NoCodeView/shims.ts
@@ -28,6 +28,8 @@ import {
   serializeStateToYaml,
   newId,
   isKnownType,
+  isKnownYamlKey,
+  getKnownYamlKeys,
 } from '../../spec-editor';
 import type { SpecItem, SpecDocumentState } from '../../spec-editor';
 import type { ConstraintData, DirectiveData } from './interfaces';
@@ -151,29 +153,14 @@ export interface SpytialValidationResult {
   warnings: string[];
 }
 
-/** Known constraint top-level keys (derived from `parseConstraints`). */
-const KNOWN_CONSTRAINT_TYPES = [
-  'orientation',
-  'cyclic',
-  'group',
-  'align',
-  'size',
-  'hideAtom',
-];
-
-/** Known directive top-level keys (derived from `parseDirectives`). */
-const KNOWN_DIRECTIVE_TYPES = [
-  'atomColor',
-  'edgeColor',
-  'size',
-  'icon',
-  'attribute',
-  'hideField',
-  'inferredEdge',
-  'hideAtom',
-  'flag',
-  'tag',
-];
+/**
+ * Recognized constraint/directive keys are derived from the registry
+ * (`isKnownYamlKey` / `getKnownYamlKeys`) rather than hand-listed here, so this
+ * check can't drift out of sync as the registry grows — the reason a
+ * hand-maintained list previously false-warned on `atomStyle`/`edgeStyle`. The
+ * check is kind-agnostic (a known key is accepted in either section, matching
+ * the engine, which simply ignores a directive placed among constraints).
+ */
 
 /** Known top-level keys in a Spytial spec. */
 const KNOWN_TOP_LEVEL_KEYS = ['constraints', 'directives'];
@@ -230,9 +217,9 @@ export function validateSpytialSpec(yamlString: string): SpytialValidationResult
       obj.constraints.forEach((constraint, i) => {
         if (constraint && typeof constraint === 'object') {
           const constraintType = Object.keys(constraint as object)[0];
-          if (constraintType && !KNOWN_CONSTRAINT_TYPES.includes(constraintType)) {
+          if (constraintType && !isKnownYamlKey(constraintType)) {
             result.warnings.push(
-              `Unrecognized constraint type at index ${i}: "${constraintType}". Known types: ${KNOWN_CONSTRAINT_TYPES.join(', ')}`,
+              `Unrecognized constraint type at index ${i}: "${constraintType}". Known types: ${getKnownYamlKeys().join(', ')}`,
             );
           }
         }
@@ -243,9 +230,9 @@ export function validateSpytialSpec(yamlString: string): SpytialValidationResult
       obj.directives.forEach((directive, i) => {
         if (directive && typeof directive === 'object') {
           const directiveType = Object.keys(directive as object)[0];
-          if (directiveType && !KNOWN_DIRECTIVE_TYPES.includes(directiveType)) {
+          if (directiveType && !isKnownYamlKey(directiveType)) {
             result.warnings.push(
-              `Unrecognized directive type at index ${i}: "${directiveType}". Known types: ${KNOWN_DIRECTIVE_TYPES.join(', ')}`,
+              `Unrecognized directive type at index ${i}: "${directiveType}". Known types: ${getKnownYamlKeys().join(', ')}`,
             );
           }
         }

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -463,11 +463,35 @@ function assertValidSizeParams(size: Record<string, unknown>, context: string): 
 }
 
 
+/**
+ * A non-fatal issue found while parsing a spec. Warnings never block parsing —
+ * the returned {@link LayoutSpec} is always usable — they are advisory feedback
+ * a consumer can surface or ignore. Returned on {@link LayoutSpec.warnings} so
+ * callers get them by reading the parse result (no callback, no throw), and the
+ * same messages are still written to `console.warn` for back-compat.
+ *
+ * `code` is a machine-readable category (e.g. `'deprecated'`) so consumers can
+ * filter without string-matching; it aligns with the spec-editor `Diagnostic`
+ * `code` vocabulary.
+ */
+export interface ParseWarning {
+    code: 'deprecated' | (string & {});
+    message: string;
+}
+
 export interface LayoutSpec {
 
     constraints: ConstraintsBlock
 
     directives : DirectivesBlock
+
+    /**
+     * Advisory, non-fatal warnings raised while parsing (e.g. use of a
+     * deprecated directive form). Optional and additive — existing consumers
+     * that only read `constraints`/`directives` are unaffected. Populated by
+     * {@link parseLayoutSpec}; empty when the spec is built directly.
+     */
+    warnings?: ParseWarning[]
 }
 
 function DEFAULT_LAYOUT() : LayoutSpec 
@@ -499,7 +523,8 @@ function DEFAULT_LAYOUT() : LayoutSpec
             hiddenAtoms: [],
             hideDisconnected: false,
             hideDisconnectedBuiltIns: false
-        }
+        },
+        warnings: []
     };
 }
 
@@ -542,6 +567,9 @@ export function parseLayoutSpec(s: string): LayoutSpec {
 
 
     let layoutSpec: LayoutSpec = DEFAULT_LAYOUT();
+    // Same array reference as `layoutSpec.warnings` (seeded by DEFAULT_LAYOUT);
+    // parsing pushes advisory warnings here and they ride out on the result.
+    const warnings = layoutSpec.warnings!;
 
     // Now we go through the constraints and directives and extract them
     // Note: size and hideAtom can appear in either constraints or directives
@@ -578,7 +606,7 @@ export function parseLayoutSpec(s: string): LayoutSpec {
 
     if (directives && Array.isArray(directives)) {
         try {
-            let directivesParsed = parseDirectives(directives);
+            let directivesParsed = parseDirectives(directives, warnings);
             layoutSpec.directives = directivesParsed;
             
             // Merge size and hideAtom from constraints into directives
@@ -919,9 +947,16 @@ function parseConstraints(constraints: unknown[]):   ConstraintsBlock
  * @returns List of CnD directives
  * @throws Error if there are inconsistencies in the directives.
  */
-function parseDirectives(directives: unknown[]): DirectivesBlock {
+function parseDirectives(directives: unknown[], warnings: ParseWarning[] = []): DirectivesBlock {
     // Type assertion since we expect specific structure from YAML
     const typedDirectives = directives as Record<string, any>[];
+
+    // Emit a deprecation both to the console (back-compat: several tests assert
+    // this) and to the consumable `warnings` accumulator (rides out on the spec).
+    const deprecate = (message: string): void => {
+        console.warn(message);
+        warnings.push({ code: 'deprecated', message });
+    };
 
     // CURRENTLY NO SUGAR HERE!
 
@@ -943,7 +978,7 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
     // and atom styling flows via `atomStyles`.
     const rawAtomColors = typedDirectives.filter(d => d.atomColor);
     if (rawAtomColors.length > 0) {
-        console.warn(
+        deprecate(
             "[spytial] 'atomColor' is deprecated and will be removed in a future major; " +
             "use 'atomStyle' with a 'borderStyle' block (value→borderStyle.color), " +
             "or a 'fillStyle' block for a real interior fill."
@@ -973,7 +1008,7 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
     // (findEdgeDirective) then no-ops, and edge styling flows via `edgeStyles`.
     const rawEdgeColors = typedDirectives.filter(d => d.edgeColor);
     if (rawEdgeColors.length > 0) {
-        console.warn(
+        deprecate(
             "[spytial] 'edgeColor' is deprecated and will be removed in a future major; " +
             "use 'edgeStyle' with a 'lineStyle' block " +
             "(value→lineStyle.color, style→lineStyle.pattern, weight→lineStyle.weight, highlight→lineStyle.highlight)."
@@ -1025,7 +1060,7 @@ function parseDirectives(directives: unknown[]): DirectivesBlock {
         };
     });
     if (usedLegacyInferredInline) {
-        console.warn(
+        deprecate(
             "[spytial] inferredEdge's inline 'color'/'style'/'weight'/'highlight' are deprecated; " +
             "use a 'lineStyle' block (color, pattern, weight, highlight) instead."
         );

--- a/src/spec-editor/core/code-positioning.ts
+++ b/src/spec-editor/core/code-positioning.ts
@@ -90,6 +90,39 @@ function findKeyRange(node: unknown, key: string): [number, number] | null {
 }
 
 /**
+ * Find the range of a key reached by a dotted `path` (`['fillStyle', 'width']`),
+ * descending into each segment's value. A single-segment path is an unqualified
+ * key → {@link findKeyRange}'s recursive search. A parent-qualified path lets a
+ * nested unknown key resolve to the exact token *in its own block*, not a
+ * same-named key in a sibling block (e.g. `fillStyle.width` vs `borderStyle.width`).
+ */
+function findKeyByPath(node: unknown, path: string[]): [number, number] | null {
+  if (path.length === 0) return null;
+  if (path.length === 1) return findKeyRange(node, path[0]);
+  const [head, ...rest] = path;
+  if (isMap(node)) {
+    for (const pair of node.items) {
+      if (isScalar(pair.key) && String(pair.key.value) === head) {
+        const found = findKeyByPath(pair.value, rest);
+        if (found) return found;
+      }
+    }
+    // `head` isn't at this level — an item wraps its body under a type key, so
+    // descend one level with the full path.
+    for (const pair of node.items) {
+      const found = findKeyByPath(pair.value, path);
+      if (found) return found;
+    }
+  } else if (isSeq(node)) {
+    for (const item of node.items) {
+      const found = findKeyByPath(item, path);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
  * Resolve a `[from, to]` range for one diagnostic, or null if it can't be
  * located. Order of preference: the specific field key, then the item's type
  * key, then a line/column already on the diagnostic.
@@ -109,7 +142,7 @@ function resolveRange(
         const itemNode = seq.items[loc.index];
         if (itemNode !== undefined) {
           if (d.fieldKey) {
-            const fieldRange = findKeyRange(itemNode, d.fieldKey);
+            const fieldRange = findKeyByPath(itemNode, d.fieldKey.split('.'));
             if (fieldRange) return fieldRange;
           }
           const typeRange = itemTypeKeyRange(itemNode);

--- a/src/spec-editor/core/code-positioning.ts
+++ b/src/spec-editor/core/code-positioning.ts
@@ -1,0 +1,200 @@
+/**
+ * Position resolution for code-view diagnostics.
+ *
+ * Structural diagnostics ({@link Diagnostic}) are anchored to a `SpecItem`
+ * (`itemId`) and optionally a field (`fieldKey`) — not to a text location. To
+ * draw an editor squiggle under the offending token, the code view needs a
+ * character range. This module re-parses the code-view YAML with a
+ * position-aware parser (`yaml`, a.k.a. eemeli/yaml, whose nodes expose a source
+ * `range`) and walks `(itemId → section+index, fieldKey)` to the matching key
+ * node, recording its `[from, to]` offsets.
+ *
+ * The authoritative model still parses through `parseYamlToState` (js-yaml);
+ * this is a *second*, read-only parse used only to locate tokens for the editor.
+ * The two agree on structure/order for any YAML that parses, which is the only
+ * case where structural diagnostics exist.
+ *
+ * Framework-agnostic — no React, no CodeMirror. The returned offsets are what a
+ * CodeMirror lint source (or any editor) needs.
+ */
+
+import { parseDocument, isMap, isScalar, isSeq } from 'yaml';
+import type { Diagnostic, SpecDocumentState } from './types';
+import { parseYamlToState, SpecParseError } from './yaml-codec';
+import { validateState } from './diagnostics';
+import type { DomainSchema } from '../domain/domain-schema';
+
+/**
+ * A diagnostic annotated with a character range into the code-view text, when
+ * one could be resolved. `from`/`to` are absent for diagnostics that couldn't be
+ * located (an editor squiggles the ones with a range and may still list the
+ * rest).
+ */
+export interface PositionedDiagnostic extends Diagnostic {
+  /** inclusive start offset into the YAML text. */
+  from?: number;
+  /** exclusive end offset into the YAML text. */
+  to?: number;
+}
+
+type Section = 'constraints' | 'directives';
+type Loc = { section: Section; index: number };
+
+/** offsets[i] = char offset at which (0-based) line i starts. */
+function lineStartOffsets(text: string): number[] {
+  const offsets = [0];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\n') offsets.push(i + 1);
+  }
+  return offsets;
+}
+
+/** Convert a 1-based line/column (our `Diagnostic` convention) to an offset. */
+function lineColToOffset(line: number, column: number, starts: number[], len: number): number {
+  const li = Math.min(Math.max(line - 1, 0), starts.length - 1);
+  return Math.min(starts[li] + Math.max(column - 1, 0), len);
+}
+
+/** Range of the first key of a single-entry item map, e.g. the `icon` in `{icon: …}`. */
+function itemTypeKeyRange(itemNode: unknown): [number, number] | null {
+  if (isMap(itemNode) && itemNode.items.length > 0) {
+    const key = itemNode.items[0].key;
+    if (isScalar(key) && key.range) return [key.range[0], key.range[1]];
+  }
+  return null;
+}
+
+/**
+ * Find the range of the key `key` within `node`, preferring a direct child over
+ * a nested one (so `color` resolves to the item's own `color` before any
+ * `lineStyle.color`). Returns the key scalar's `[from, to]`.
+ */
+function findKeyRange(node: unknown, key: string): [number, number] | null {
+  if (isMap(node)) {
+    for (const pair of node.items) {
+      if (isScalar(pair.key) && String(pair.key.value) === key && pair.key.range) {
+        return [pair.key.range[0], pair.key.range[1]];
+      }
+    }
+    for (const pair of node.items) {
+      const nested = findKeyRange(pair.value, key);
+      if (nested) return nested;
+    }
+  } else if (isSeq(node)) {
+    for (const item of node.items) {
+      const nested = findKeyRange(item, key);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a `[from, to]` range for one diagnostic, or null if it can't be
+ * located. Order of preference: the specific field key, then the item's type
+ * key, then a line/column already on the diagnostic.
+ */
+function resolveRange(
+  d: Diagnostic,
+  locById: Map<string, Loc>,
+  doc: ReturnType<typeof parseDocument> | null,
+  starts: number[],
+  len: number,
+): [number, number] | null {
+  if (d.itemId && doc) {
+    const loc = locById.get(d.itemId);
+    if (loc) {
+      const seq = doc.get(loc.section);
+      if (isSeq(seq)) {
+        const itemNode = seq.items[loc.index];
+        if (itemNode !== undefined) {
+          if (d.fieldKey) {
+            const fieldRange = findKeyRange(itemNode, d.fieldKey);
+            if (fieldRange) return fieldRange;
+          }
+          const typeRange = itemTypeKeyRange(itemNode);
+          if (typeRange) return typeRange;
+        }
+      }
+    }
+  }
+
+  if (d.line !== undefined) {
+    const from = lineColToOffset(d.line, d.column ?? 1, starts, len);
+    // A short, visible marker: to end of the token/line start region.
+    return [from, Math.min(from + 1, len)];
+  }
+
+  return null;
+}
+
+/**
+ * Annotate diagnostics with `[from, to]` character ranges against `yamlText`.
+ * Every input diagnostic is returned in order; those that resolve to a token
+ * gain `from`/`to`, the rest are passed through unchanged (an editor squiggles
+ * the located ones and can still list the others).
+ */
+export function positionDiagnostics(
+  yamlText: string,
+  state: SpecDocumentState,
+  diagnostics: readonly Diagnostic[],
+): PositionedDiagnostic[] {
+  const locById = new Map<string, Loc>();
+  state.constraints.forEach((it, i) => locById.set(it.id, { section: 'constraints', index: i }));
+  state.directives.forEach((it, i) => locById.set(it.id, { section: 'directives', index: i }));
+
+  let doc: ReturnType<typeof parseDocument> | null = null;
+  try {
+    doc = parseDocument(yamlText);
+  } catch {
+    doc = null;
+  }
+
+  const starts = lineStartOffsets(yamlText);
+  const len = yamlText.length;
+
+  return diagnostics.map((d) => {
+    const range = resolveRange(d, locById, doc, starts, len);
+    if (!range) return { ...d };
+    // Clamp defensively so an editor never gets an out-of-bounds range.
+    const from = Math.max(0, Math.min(range[0], len));
+    const to = Math.max(from, Math.min(range[1], len));
+    return { ...d, from, to };
+  });
+}
+
+/**
+ * Lint a YAML string for the code editor: parse it, validate the result, and
+ * resolve each diagnostic to a character range — all from the SAME text, so the
+ * diagnostics' item ids always match the state used to position them.
+ *
+ * This is deliberately self-contained rather than reusing the editor's debounced
+ * model: the code view must reflect the diagnostics of the text as typed, and
+ * item ids are regenerated on every parse (so a diagnostic computed against one
+ * parse can't be positioned against a later one). On a syntax error it returns a
+ * single positioned error; otherwise the structural (+ domain) warnings/errors.
+ */
+export function lintYaml(yamlText: string, domain?: DomainSchema): PositionedDiagnostic[] {
+  if (yamlText.trim() === '') return [];
+
+  let state: SpecDocumentState;
+  try {
+    state = parseYamlToState(yamlText);
+  } catch (error) {
+    const err = error as SpecParseError;
+    const diag: Diagnostic = {
+      severity: 'error',
+      code: 'yaml-syntax',
+      source: 'yaml',
+      message: `YAML syntax error: ${err.message}`,
+      ...(err.line !== undefined ? { line: err.line } : {}),
+      ...(err.column !== undefined ? { column: err.column } : {}),
+    };
+    return positionDiagnostics(yamlText, { constraints: [], directives: [] }, [diag]);
+  }
+
+  const diagnostics = validateState(state, domain).filter(
+    (d) => d.severity === 'error' || d.severity === 'warning',
+  );
+  return positionDiagnostics(yamlText, state, diagnostics);
+}

--- a/src/spec-editor/core/diagnostics.ts
+++ b/src/spec-editor/core/diagnostics.ts
@@ -122,6 +122,7 @@ function unknownKeyDiagnostic(
   suggestable: readonly string[],
   context: string,
   itemId: string,
+  fieldKey: string = key,
 ): Diagnostic {
   const suggestion = closestKey(key, suggestable);
   const hint = suggestion
@@ -134,7 +135,7 @@ function unknownKeyDiagnostic(
     code: 'unknown-key',
     message: `Unknown field "${key}" in ${context}.${hint}`,
     itemId,
-    fieldKey: key,
+    fieldKey,
     source: 'structure',
   };
 }
@@ -155,7 +156,13 @@ function checkUnknownKeys(item: SpecItem, def: ItemDefinition): Diagnostic[] {
   }
   for (const k of EXTRA_ACCEPTED_KEYS_BY_TYPE[item.type] ?? []) allowed.add(k);
 
-  for (const key of Object.keys(item.params)) {
+  // Prefer the raw parsed body when present: a custom `fromYamlNode` (group /
+  // flag) copies only recognized keys into `params`, so a typo like `naem` would
+  // otherwise be dropped before it reaches this check. `sourceBody` preserves the
+  // original keys for exactly this; it falls back to `params` for builder-built
+  // items (which only ever hold known fields).
+  const topLevel = isRecord(item.sourceBody) ? item.sourceBody : item.params;
+  for (const key of Object.keys(topLevel)) {
     if (allowed.has(key)) continue;
     out.push(unknownKeyDiagnostic(key, fieldKeys, def.label, item.id));
   }
@@ -168,7 +175,13 @@ function checkUnknownKeys(item: SpecItem, def: ItemDefinition): Diagnostic[] {
     const allowedChildren = new Set(childKeys);
     for (const key of Object.keys(block)) {
       if (allowedChildren.has(key)) continue;
-      out.push(unknownKeyDiagnostic(key, childKeys, field.label, item.id));
+      // Route with a parent-qualified key (`fillStyle.width`) so the diagnostic
+      // can't collide with a same-named field in a sibling block (e.g.
+      // `borderStyle.width`) — the renderer filters nested diagnostics by an
+      // exact `fieldKey`. The message still names the child key and its block.
+      out.push(
+        unknownKeyDiagnostic(key, childKeys, field.label, item.id, `${field.key}.${key}`),
+      );
     }
   }
 

--- a/src/spec-editor/core/diagnostics.ts
+++ b/src/spec-editor/core/diagnostics.ts
@@ -61,8 +61,6 @@ const CONSTRAINT_STRUCTURAL_KEYS: readonly string[] = ['hold'];
  * fields, so the unknown-key check must not report them as typos:
  *  - `inferredEdge` still parses the deprecated flat `color`/`style`/`weight`/
  *    `highlight` (its own deprecation warning covers them).
- *  - `attribute` / `hideField` accept `filter` (a `FieldDirective` tuple filter,
- *    read by `parseDirectives`) — supported by the engine, just not yet a field.
  *  - `edgeColor` is the deprecated flat form; `edgeColorToEdgeStyleRule` reads
  *    these extras beyond the fields the registry lists.
  *
@@ -72,8 +70,6 @@ const CONSTRAINT_STRUCTURAL_KEYS: readonly string[] = ['hold'];
  */
 const EXTRA_ACCEPTED_KEYS_BY_TYPE: Readonly<Record<string, readonly string[]>> = {
   inferredEdge: ['color', 'style', 'weight', 'highlight'],
-  attribute: ['filter'],
-  hideField: ['filter'],
   edgeColor: ['highlight', 'showLabel', 'hidden', 'filter'],
 };
 
@@ -135,6 +131,7 @@ function unknownKeyDiagnostic(
       : '';
   return {
     severity: 'warning',
+    code: 'unknown-key',
     message: `Unknown field "${key}" in ${context}.${hint}`,
     itemId,
     fieldKey: key,
@@ -186,6 +183,7 @@ export function validateItem(item: SpecItem): Diagnostic[] {
   if (item.raw !== undefined && getDefinition(item.type) === undefined) {
     out.push({
       severity: 'warning',
+      code: 'unknown-type',
       message: `Unknown ${item.kind} type "${item.type}". It is preserved as-is but the builder cannot edit it.`,
       itemId: item.id,
       source: 'structure',
@@ -197,11 +195,27 @@ export function validateItem(item: SpecItem): Diagnostic[] {
   if (!def) {
     out.push({
       severity: 'warning',
+      code: 'unknown-type',
       message: `Unknown ${item.kind} type "${item.type}".`,
       itemId: item.id,
       source: 'structure',
     });
     return out;
+  }
+
+  // Deprecated type: still parses and renders, but nudge toward its replacement.
+  // A distinct `code` so consumers can treat it apart from typo-style warnings.
+  if (def.deprecated) {
+    const replacement = def.deprecatedInFavorOf
+      ? ` Use "${def.deprecatedInFavorOf}" instead.`
+      : '';
+    out.push({
+      severity: 'warning',
+      code: 'deprecated',
+      message: `"${def.label}" is deprecated.${replacement}`,
+      itemId: item.id,
+      source: 'structure',
+    });
   }
 
   for (const field of def.fields) {
@@ -210,6 +224,7 @@ export function validateItem(item: SpecItem): Diagnostic[] {
     if (field.required && isEmpty(value)) {
       out.push({
         severity: 'error',
+        code: 'missing-required',
         message: `Missing required field "${field.label}".`,
         itemId: item.id,
         fieldKey: field.key,
@@ -229,6 +244,7 @@ export function validateItem(item: SpecItem): Diagnostic[] {
         if (!allowed.has(v)) {
           out.push({
             severity: 'error',
+            code: 'invalid-value',
             message: `Invalid value "${v}" for "${field.label}". Allowed: ${field.options.join(', ')}.`,
             itemId: item.id,
             fieldKey: field.key,

--- a/src/spec-editor/core/diagnostics.ts
+++ b/src/spec-editor/core/diagnostics.ts
@@ -18,7 +18,7 @@
  */
 
 import { getDefinition } from './registry';
-import type { Diagnostic, SpecDocumentState, SpecItem } from './types';
+import type { Diagnostic, ItemDefinition, SpecDocumentState, SpecItem } from './types';
 import type { DomainSchema } from '../domain/domain-schema';
 import { validateAgainstDomain } from '../domain/domain-validation';
 
@@ -33,6 +33,149 @@ function isEmpty(value: unknown): boolean {
     return value.length === 0;
   }
   return false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+// ---- unknown-key detection ----------------------------------------------
+//
+// The registry (`def.fields`, with nested `children`) is the source of truth
+// for which keys a type accepts. A key in `item.params` that no field backs is
+// almost always a typo (`showLabel` for `showLabels`, `colour` for `color`) or
+// stray junk — the engine parser silently ignores it, so without this the
+// mistake renders as a quiet no-op. We surface it as a *warning* (the diagram
+// still renders) with a "did you mean" when a real field is a near-miss.
+
+/**
+ * Keys the engine accepts on a *constraint* that are deliberately not builder
+ * fields, so they must not be flagged: `hold: never` negates any constraint
+ * (read by `parseConstraints`), but exposing it as a field would clutter every
+ * constraint form.
+ */
+const CONSTRAINT_STRUCTURAL_KEYS: readonly string[] = ['hold'];
+
+/**
+ * Per-type keys the engine accepts but the registry does not expose as builder
+ * fields, so the unknown-key check must not report them as typos:
+ *  - `inferredEdge` still parses the deprecated flat `color`/`style`/`weight`/
+ *    `highlight` (its own deprecation warning covers them).
+ *  - `attribute` / `hideField` accept `filter` (a `FieldDirective` tuple filter,
+ *    read by `parseDirectives`) — supported by the engine, just not yet a field.
+ *  - `edgeColor` is the deprecated flat form; `edgeColorToEdgeStyleRule` reads
+ *    these extras beyond the fields the registry lists.
+ *
+ * NOTE: this mirrors the engine parser (`layoutspec.ts` + the style-spec
+ * parsers). If a directive gains an inner key there, add it here (or as a real
+ * registry field) or valid specs will draw a spurious warning.
+ */
+const EXTRA_ACCEPTED_KEYS_BY_TYPE: Readonly<Record<string, readonly string[]>> = {
+  inferredEdge: ['color', 'style', 'weight', 'highlight'],
+  attribute: ['filter'],
+  hideField: ['filter'],
+  edgeColor: ['highlight', 'showLabel', 'hidden', 'filter'],
+};
+
+/** Levenshtein edit distance (case-insensitive at the call site). */
+function editDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const prev = new Array<number>(n + 1);
+  const curr = new Array<number>(n + 1);
+  for (let j = 0; j <= n; j++) prev[j] = j;
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    for (let j = 0; j <= n; j++) prev[j] = curr[j];
+  }
+  return prev[n];
+}
+
+/**
+ * The known key closest to `key`, or undefined when nothing is a near-miss.
+ * "Near" is an edit distance of at most 2 that is also strictly less than the
+ * typo's length, so short foreign keys don't get an absurd suggestion.
+ */
+function closestKey(key: string, known: readonly string[]): string | undefined {
+  let best: string | undefined;
+  let bestDist = Infinity;
+  const lower = key.toLowerCase();
+  for (const candidate of known) {
+    const d = editDistance(lower, candidate.toLowerCase());
+    if (d < bestDist) {
+      bestDist = d;
+      best = candidate;
+    }
+  }
+  return best !== undefined && bestDist <= 2 && bestDist < key.length ? best : undefined;
+}
+
+/**
+ * Build the "unknown field" diagnostic for `key`, appending a `did you mean`
+ * when a field is a near-miss, else the list of valid keys.
+ * `suggestable` is the set of builder-field keys (what we advertise); it may be
+ * narrower than the set that suppresses the warning (which also allows `hold`
+ * and deprecated inline keys).
+ */
+function unknownKeyDiagnostic(
+  key: string,
+  suggestable: readonly string[],
+  context: string,
+  itemId: string,
+): Diagnostic {
+  const suggestion = closestKey(key, suggestable);
+  const hint = suggestion
+    ? ` Did you mean "${suggestion}"?`
+    : suggestable.length > 0
+      ? ` Known fields: ${suggestable.join(', ')}.`
+      : '';
+  return {
+    severity: 'warning',
+    message: `Unknown field "${key}" in ${context}.${hint}`,
+    itemId,
+    fieldKey: key,
+    source: 'structure',
+  };
+}
+
+/**
+ * Flag params keys not backed by a field on `def` — at the top level and one
+ * level down inside each declared `group` block (lineStyle / textStyle / …).
+ * Only `group` fields are recursed into; other block-shaped values (e.g. a
+ * group's `addEdge` written in its block form) are left alone by design.
+ */
+function checkUnknownKeys(item: SpecItem, def: ItemDefinition): Diagnostic[] {
+  const out: Diagnostic[] = [];
+
+  const fieldKeys = def.fields.map((f) => f.key);
+  const allowed = new Set<string>(fieldKeys);
+  if (item.kind === 'constraint') {
+    for (const k of CONSTRAINT_STRUCTURAL_KEYS) allowed.add(k);
+  }
+  for (const k of EXTRA_ACCEPTED_KEYS_BY_TYPE[item.type] ?? []) allowed.add(k);
+
+  for (const key of Object.keys(item.params)) {
+    if (allowed.has(key)) continue;
+    out.push(unknownKeyDiagnostic(key, fieldKeys, def.label, item.id));
+  }
+
+  for (const field of def.fields) {
+    if (field.kind !== 'group' || !field.children) continue;
+    const block = item.params[field.key];
+    if (!isRecord(block)) continue;
+    const childKeys = field.children.map((c) => c.key);
+    const allowedChildren = new Set(childKeys);
+    for (const key of Object.keys(block)) {
+      if (allowedChildren.has(key)) continue;
+      out.push(unknownKeyDiagnostic(key, childKeys, field.label, item.id));
+    }
+  }
+
+  return out;
 }
 
 /** Validate a single item structurally against its registry definition. */
@@ -95,6 +238,8 @@ export function validateItem(item: SpecItem): Diagnostic[] {
       }
     }
   }
+
+  out.push(...checkUnknownKeys(item, def));
 
   if (def.validate) {
     for (const d of def.validate(item.params)) {

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -24,7 +24,7 @@
  *     - attribute:    { field, selector?, filter?, textStyle?:{size,color} }
  *     - hideField:    { field, selector?, filter? }
  *     - icon:         { path, selector?, showLabels? }
- *     - atomStyle:    { selector?, shape?, fillStyle?:{color}, borderStyle?:{color,width}, textStyle?:{size,color} }
+ *     - atomStyle:    { selector?, fillStyle?:{color}, borderStyle?:{color,width}, textStyle?:{size,color} }
  *     - atomColor:    { value, selector? }  (deprecated → atomStyle)
  *     - edgeStyle:    { field, selector?, filter?, lineStyle?:{color,pattern,weight,highlight}, textStyle?:{size,color}, showLabel?, hidden? }
  *     - edgeColor:    { value, field, selector?, filter?, style?, weight?, showLabel?, hidden?, highlight? }  (deprecated → edgeStyle)
@@ -95,14 +95,6 @@ export const ORIENTATION_DIRECTIONS = [
 export const CYCLIC_DIRECTIONS = ['clockwise', 'counterclockwise'] as const;
 export const ALIGN_DIRECTIONS = ['horizontal', 'vertical'] as const;
 export const EDGE_STYLES = ['solid', 'dashed', 'dotted'] as const;
-
-/**
- * Node outline shapes for `atomStyle.shape`, drawn inscribed in the node's
- * box. (Mirrors NODE_SHAPES in layout/style/node-shape.ts.) No field `default`
- * is set — an unset value is omitted from YAML and the engine draws the
- * rectangle, so specs stay clean.
- */
-export const NODE_SHAPE_OPTIONS = ['rectangle', 'ellipse', 'circle', 'diamond', 'hexagon', 'pill'] as const;
 
 /**
  * Text-size tiers for a label line, relative to the node label. `large` renders
@@ -741,10 +733,9 @@ const atomStyle: ItemDefinition = {
   kind: 'directive',
   type: 'atomStyle',
   label: 'Atom style',
-  description: 'Style matching atoms — shape, fill, border, and label.',
+  description: 'Style matching atoms — fill, border, and label.',
   fields: [
     { key: 'selector', kind: 'selector', label: 'Selector', selectorArity: 'unary' },
-    { key: 'shape', kind: 'enum', options: NODE_SHAPE_OPTIONS, label: 'Shape' },
     { key: 'fillStyle', kind: 'group', label: 'Fill style', children: FILL_STYLE_FIELDS },
     { key: 'borderStyle', kind: 'group', label: 'Border style', children: BORDER_STYLE_FIELDS },
     { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
@@ -957,13 +948,24 @@ export function isKnownYamlKey(yamlKey: string): boolean {
 }
 
 /**
- * Every YAML key some definition emits under (constraints + directives),
- * deduplicated. The registry-derived source of truth for "which top-level
- * constraint/directive keys are recognized" — use this instead of hand-listing
- * types, which drifts as the registry grows.
+ * YAML keys some definition emits under, deduplicated. With no `kind`, every
+ * key (constraints + directives); with a `kind`, only keys some definition of
+ * that kind emits under. The registry-derived source of truth for "which
+ * top-level keys are recognized" — use this instead of hand-listing types,
+ * which drifts as the registry grows.
+ *
+ * Note: `size`/`hideAtom` are registered as constraints, so they appear only
+ * under `'constraint'` here even though the engine also reads them among
+ * directives — callers that validate the directives section must allow them.
  */
-export function getKnownYamlKeys(): string[] {
-  return [...CANDIDATES_BY_YAML_KEY.keys()];
+export function getKnownYamlKeys(kind?: ItemKind): string[] {
+  const keys: string[] = [];
+  for (const [key, defs] of CANDIDATES_BY_YAML_KEY) {
+    if (!kind || defs.some((d) => d.kind === kind)) {
+      keys.push(key);
+    }
+  }
+  return keys;
 }
 
 /** Look up an item definition by registry type key. */

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -24,7 +24,7 @@
  *     - attribute:    { field, selector?, filter?, textStyle?:{size,color} }
  *     - hideField:    { field, selector?, filter? }
  *     - icon:         { path, selector?, showLabels? }
- *     - atomStyle:    { selector?, fillStyle?:{color}, borderStyle?:{color,width}, textStyle?:{size,color} }
+ *     - atomStyle:    { selector?, shape?, fillStyle?:{color}, borderStyle?:{color,width}, textStyle?:{size,color} }
  *     - atomColor:    { value, selector? }  (deprecated → atomStyle)
  *     - edgeStyle:    { field, selector?, filter?, lineStyle?:{color,pattern,weight,highlight}, textStyle?:{size,color}, showLabel?, hidden? }
  *     - edgeColor:    { value, field, selector?, filter?, style?, weight?, showLabel?, hidden?, highlight? }  (deprecated → edgeStyle)
@@ -95,6 +95,14 @@ export const ORIENTATION_DIRECTIONS = [
 export const CYCLIC_DIRECTIONS = ['clockwise', 'counterclockwise'] as const;
 export const ALIGN_DIRECTIONS = ['horizontal', 'vertical'] as const;
 export const EDGE_STYLES = ['solid', 'dashed', 'dotted'] as const;
+
+/**
+ * Node outline shapes for `atomStyle.shape`, drawn inscribed in the node's
+ * box. (Mirrors NODE_SHAPES in layout/style/node-shape.ts.) No field `default`
+ * is set — an unset value is omitted from YAML and the engine draws the
+ * rectangle, so specs stay clean.
+ */
+export const NODE_SHAPE_OPTIONS = ['rectangle', 'ellipse', 'circle', 'diamond', 'hexagon', 'pill'] as const;
 
 /**
  * Text-size tiers for a label line, relative to the node label. `large` renders
@@ -360,6 +368,7 @@ const groupfield: ItemDefinition = {
   label: 'Group (by field)',
   description: 'Group elements based on a field. Deprecated — prefer Group (by selector).',
   deprecated: true,
+  deprecatedInFavorOf: 'groupselector',
   fields: [
     {
       key: 'field',
@@ -564,6 +573,13 @@ const attribute: ItemDefinition = {
       label: 'Selector',
       selectorArity: 'unary',
     },
+    {
+      key: 'filter',
+      kind: 'selector',
+      label: 'Filter',
+      selectorArity: 'binary',
+      help: 'Optional n-ary selector — apply only to matching (source, target) tuples.',
+    },
     // Shared text-style block (size + color), same shape edgeStyle/atomStyle use.
     { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
   ],
@@ -592,6 +608,13 @@ const hideField: ItemDefinition = {
       kind: 'selector',
       label: 'Selector',
       selectorArity: 'unary',
+    },
+    {
+      key: 'filter',
+      kind: 'selector',
+      label: 'Filter',
+      selectorArity: 'binary',
+      help: 'Optional n-ary selector — hide only matching (source, target) tuples.',
     },
   ],
   summary(params) {
@@ -642,6 +665,7 @@ const atomColor: ItemDefinition = {
   label: 'Atom color',
   description: 'Deprecated — use Atom style (atomStyle). Still parsed/rendered for back-compat (value → border color).',
   deprecated: true,
+  deprecatedInFavorOf: 'atomStyle',
   fields: [
     {
       key: 'value',
@@ -717,9 +741,10 @@ const atomStyle: ItemDefinition = {
   kind: 'directive',
   type: 'atomStyle',
   label: 'Atom style',
-  description: 'Style matching atoms — fill, border, and label.',
+  description: 'Style matching atoms — shape, fill, border, and label.',
   fields: [
     { key: 'selector', kind: 'selector', label: 'Selector', selectorArity: 'unary' },
+    { key: 'shape', kind: 'enum', options: NODE_SHAPE_OPTIONS, label: 'Shape' },
     { key: 'fillStyle', kind: 'group', label: 'Fill style', children: FILL_STYLE_FIELDS },
     { key: 'borderStyle', kind: 'group', label: 'Border style', children: BORDER_STYLE_FIELDS },
     { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
@@ -740,6 +765,7 @@ const edgeColor: ItemDefinition = {
   label: 'Edge color',
   description: 'Deprecated — use Edge style (edgeStyle). Still parsed/rendered for back-compat.',
   deprecated: true,
+  deprecatedInFavorOf: 'edgeStyle',
   fields: [
     {
       key: 'field',
@@ -928,6 +954,16 @@ export function getDefinitionsForYamlKey(yamlKey: string): readonly ItemDefiniti
 /** True iff some registry definition emits under this YAML key. */
 export function isKnownYamlKey(yamlKey: string): boolean {
   return CANDIDATES_BY_YAML_KEY.has(yamlKey);
+}
+
+/**
+ * Every YAML key some definition emits under (constraints + directives),
+ * deduplicated. The registry-derived source of truth for "which top-level
+ * constraint/directive keys are recognized" — use this instead of hand-listing
+ * types, which drifts as the registry grows.
+ */
+export function getKnownYamlKeys(): string[] {
+  return [...CANDIDATES_BY_YAML_KEY.keys()];
 }
 
 /** Look up an item definition by registry type key. */

--- a/src/spec-editor/core/types.ts
+++ b/src/spec-editor/core/types.ts
@@ -61,6 +61,18 @@ export interface FieldSpec {
 export interface Diagnostic {
   severity: 'error' | 'warning' | 'info';
   message: string;
+  /**
+   * Machine-readable category, so consumers can filter/handle by kind rather
+   * than string-matching the message — e.g. surface `'deprecated'` differently
+   * from `'unknown-key'`. Optional and open-ended; absent on older diagnostics.
+   */
+  code?:
+    | 'unknown-key'
+    | 'unknown-type'
+    | 'deprecated'
+    | 'missing-required'
+    | 'invalid-value'
+    | (string & {});
   /** ties to a builder row */
   itemId?: string;
   /** ties to a specific field */
@@ -81,6 +93,11 @@ export interface ItemDefinition {
   description?: string;
   /** parse + render, but hide from add menu (e.g. 'groupfield') */
   deprecated?: boolean;
+  /**
+   * When `deprecated`, the label of the type that supersedes it (e.g. 'atomStyle'
+   * for 'atomColor'). Surfaced in the deprecation diagnostic so the fix is named.
+   */
+  deprecatedInFavorOf?: string;
   fields: FieldSpec[];
   /** one-line summary for the collapsed row, e.g. "left, above · parent" */
   summary(params: Record<string, unknown>): string;

--- a/src/spec-editor/core/types.ts
+++ b/src/spec-editor/core/types.ts
@@ -21,6 +21,14 @@ export interface SpecItem {
   comment?: string;
   /** present iff type unknown to registry; re-emitted verbatim */
   raw?: unknown;
+  /**
+   * The raw inner YAML body this item parsed from, when a custom `fromYamlNode`
+   * (group / flag) ingested it. Curated ingestion copies only recognized keys
+   * into `params`, so this preserves the rest — enabling the unknown-key check
+   * to still flag typos on those types. Not serialized; absent for
+   * builder-built items (which only ever hold known fields).
+   */
+  sourceBody?: Record<string, unknown>;
 }
 
 // ---- field model ----

--- a/src/spec-editor/core/yaml-codec.ts
+++ b/src/spec-editor/core/yaml-codec.ts
@@ -284,7 +284,15 @@ function nodeToItem(node: unknown, kind: SpecItem['kind']): SpecItem | null {
     }
     const params = def.fromYamlNode(node);
     if (params !== null) {
-      return { id: newId(), kind, type: def.type, params };
+      const item: SpecItem = { id: newId(), kind, type: def.type, params };
+      // Preserve the raw inner body: fromYamlNode copies only recognized keys
+      // into `params`, so keep the original around for the unknown-key check to
+      // flag typos it would otherwise have dropped.
+      const body = (node as Record<string, unknown>)[yamlKey];
+      if (isRecord(body)) {
+        item.sourceBody = body;
+      }
+      return item;
     }
   }
 

--- a/src/spec-editor/index.ts
+++ b/src/spec-editor/index.ts
@@ -50,6 +50,10 @@ export {
 // ---- diagnostics ----
 export { validateItem, validateState } from './core/diagnostics';
 
+// ---- code-view diagnostic positioning (eemeli/yaml) ----
+export { positionDiagnostics, lintYaml } from './core/code-positioning';
+export type { PositionedDiagnostic } from './core/code-positioning';
+
 // ---- id helper (used by integrators that build SpecItems by hand) ----
 export { newId } from './core/id';
 

--- a/src/spec-editor/index.ts
+++ b/src/spec-editor/index.ts
@@ -34,6 +34,7 @@ export {
   getDefinitions,
   getAllDefinitions,
   getDefinitionsForYamlKey,
+  getKnownYamlKeys,
   isKnownType,
   isKnownYamlKey,
   defaultParamsFor,

--- a/src/spec-editor/ui/CodeView.tsx
+++ b/src/spec-editor/ui/CodeView.tsx
@@ -1,35 +1,42 @@
 /**
  * {@link CodeView} — the raw-YAML editing surface of the spec editor.
  *
- * A controlled monospace `<textarea>` whose value is owned by {@link SpecEditor}.
- * Typing fires `onChange(text)` immediately (the text is controlled), and a
- * debounced parse is attempted by the parent via `onParse`. CodeView itself is
- * presentation-only: it does not own a {@link SpecDocument}. The parent passes
- * down the current parse `diagnostics` (line/column anchored, severity colored)
- * and a flag indicating whether the text currently differs from the model
- * ("unapplied edits"). A parse error never clobbers the model — the parent keeps
- * the last good state and surfaces the diagnostic here.
+ * A CodeMirror 6 editor (not a textarea): CodeMirror owns the text rendering, so
+ * syntax highlighting is real (no transparent-text mirror to keep in sync) and
+ * diagnostics are drawn as IDE-style squiggly underlines you can hover to read.
+ * The value is controlled by {@link SpecEditor}: typing fires `onChange(text)`
+ * immediately, and the parent attempts a debounced parse. A parse error never
+ * clobbers the model — the parent keeps the last good state and passes the
+ * diagnostics down here as {@link PositionedDiagnostic}s (already resolved to
+ * character ranges by `positionDiagnostics`), which we hand to `@codemirror/lint`.
  *
- * The YAML is syntax-highlighted with the same mirror-overlay technique the
- * SelectorField uses: a highlighted `<pre>` sits behind a transparent-text
- * textarea with identical metrics, scroll-synced on both axes (the text never
- * wraps, so horizontal sync matters here). Tokenization is the lossless
- * line tokenizer in `highlight-yaml.ts` (comments, strings, numbers, keys,
- * and the spec's known constraint/directive keywords). Optional line numbers
- * render in a gutter that shares the same scroll sync.
+ * Highlighting uses `@codemirror/lang-yaml` themed through the same
+ * `--spytial-ed-syn-*` CSS variables the rest of the editor uses, so it tracks
+ * light/dark automatically. A persistent diagnostics list is kept below the
+ * editor for accessibility and for any diagnostic that couldn't be positioned.
  */
 
-import React, { useCallback, useEffect, useId, useMemo, useRef } from 'react';
+import React, { useEffect, useId, useMemo, useRef } from 'react';
+import { EditorState, Compartment } from '@codemirror/state';
+import { EditorView, keymap, lineNumbers } from '@codemirror/view';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { yaml } from '@codemirror/lang-yaml';
+import { lintGutter, setDiagnostics, type Diagnostic as CmDiagnostic } from '@codemirror/lint';
+import { tags as t } from '@lezer/highlight';
 import type { Diagnostic } from '../core/types';
-import { tokenizeYaml, yamlTokenClassName } from './highlight-yaml';
+import type { PositionedDiagnostic } from '../core/code-positioning';
 
 export interface CodeViewProps {
   /** controlled YAML text */
   value: string;
   /** fired with the next text on every edit */
   onChange(value: string): void;
-  /** parse diagnostics for the current text (line/column, severity colored). */
-  diagnostics?: readonly Diagnostic[];
+  /**
+   * Diagnostics for the current text, pre-resolved to character ranges. Those
+   * with a range become editor squiggles; all appear in the list below.
+   */
+  diagnostics?: readonly PositionedDiagnostic[];
   /**
    * True when the text differs from the applied model (a parse error is keeping
    * the model on its last good state). Drives the "unapplied edits" notice.
@@ -37,10 +44,7 @@ export interface CodeViewProps {
   hasUnappliedEdits?: boolean;
   /** render a line-number gutter (default true). */
   showLineNumbers?: boolean;
-  /**
-   * Render the YAML highlight mirror (default true). Escape hatch for hosts
-   * where the overlay misaligns: when false the textarea shows its own text.
-   */
+  /** syntax-highlight the YAML (default true). */
   syntaxHighlighting?: boolean;
   disabled?: boolean;
   'aria-label'?: string;
@@ -54,60 +58,180 @@ const SEVERITY_ORDER: Record<Diagnostic['severity'], number> = {
   info: 2,
 };
 
+/**
+ * YAML token colors, mapped onto the editor's `--spytial-ed-syn-*` variables so
+ * the highlight tracks the active (light/dark) theme. Keys carry the "keyword"
+ * color, matching the old hand-rolled tokenizer's palette.
+ */
+const yamlHighlightStyle = HighlightStyle.define([
+  { tag: t.comment, color: 'var(--spytial-ed-syn-comment, #8a8170)', fontStyle: 'italic' },
+  { tag: [t.string, t.special(t.string)], color: 'var(--spytial-ed-syn-string, #7a5901)' },
+  { tag: [t.number, t.bool, t.null], color: 'var(--spytial-ed-syn-number, #7a5901)' },
+  {
+    tag: [t.propertyName, t.definition(t.propertyName), t.keyword, t.atom],
+    color: 'var(--spytial-ed-syn-keyword, #6d28a8)',
+  },
+  { tag: [t.punctuation, t.separator], color: 'var(--spytial-ed-text-muted, #6e6553)' },
+]);
+
+/** Editor chrome themed through the shared spec-editor CSS variables. */
+const editorTheme = EditorView.theme({
+  '&': {
+    fontSize: '0.85em',
+    color: 'var(--spytial-ed-text, #221d14)',
+    backgroundColor: 'var(--spytial-ed-surface, #faf8f2)',
+    border: '1px solid var(--spytial-ed-border, #d9d2c0)',
+    borderRadius: 'var(--spytial-ed-radius, 2px)',
+    minHeight: '12rem',
+  },
+  '&.cm-focused': { outline: '2px solid var(--spytial-ed-accent, #b5431a)', outlineOffset: '-1px' },
+  '.cm-scroller': {
+    fontFamily: 'var(--spytial-ed-mono-font-family, ui-monospace, monospace)',
+    lineHeight: '1.5',
+    overflow: 'auto',
+  },
+  '.cm-content': { padding: '0.5em 0', caretColor: 'var(--spytial-ed-accent, #b5431a)' },
+  '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--spytial-ed-accent, #b5431a)' },
+  '.cm-gutters': {
+    backgroundColor: 'var(--spytial-ed-surface-raised, #f1ecdf)',
+    color: 'var(--spytial-ed-text-muted, #6e6553)',
+    border: 'none',
+    borderInlineEnd: '1px solid var(--spytial-ed-border, #d9d2c0)',
+  },
+  '.cm-lineNumbers .cm-gutterElement': { padding: '0 0.5em 0 0.6em' },
+  '&.cm-editor .cm-selectionBackground, & .cm-selectionBackground, & .cm-content ::selection': {
+    backgroundColor: 'color-mix(in srgb, var(--spytial-ed-accent, #b5431a) 22%, transparent)',
+  },
+  '.cm-tooltip': {
+    border: '1px solid var(--spytial-ed-border, #d9d2c0)',
+    backgroundColor: 'var(--spytial-ed-surface-raised, #f1ecdf)',
+    color: 'var(--spytial-ed-text, #221d14)',
+    borderRadius: 'var(--spytial-ed-radius, 2px)',
+    fontSize: '0.85em',
+  },
+});
+
+/** Map our severity onto CodeMirror's (identical vocabulary for these three). */
+function cmSeverity(s: Diagnostic['severity']): CmDiagnostic['severity'] {
+  return s; // 'error' | 'warning' | 'info' all exist in CodeMirror's union
+}
+
+/** Positioned diagnostics → CodeMirror lint diagnostics (only the ranged ones). */
+function toCmDiagnostics(
+  diagnostics: readonly PositionedDiagnostic[] | undefined,
+  docLength: number,
+): CmDiagnostic[] {
+  if (!diagnostics) return [];
+  const out: CmDiagnostic[] = [];
+  for (const d of diagnostics) {
+    if (d.from === undefined || d.to === undefined) continue;
+    const from = Math.max(0, Math.min(d.from, docLength));
+    const to = Math.max(from, Math.min(d.to, docLength));
+    out.push({
+      from,
+      to,
+      severity: cmSeverity(d.severity),
+      message: d.message,
+      // `code` (e.g. 'deprecated') surfaces as the source label in the tooltip.
+      source: d.code,
+    });
+  }
+  // CodeMirror expects diagnostics sorted by `from`.
+  out.sort((a, b) => a.from - b.from);
+  return out;
+}
+
 export const CodeView: React.FC<CodeViewProps> = ({
   value,
   onChange,
   diagnostics,
   hasUnappliedEdits = false,
   showLineNumbers = true,
-  syntaxHighlighting = true,
+  syntaxHighlighting: highlight = true,
   disabled = false,
   'aria-label': ariaLabel = 'Layout specification YAML',
   className,
 }) => {
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const gutterRef = useRef<HTMLDivElement | null>(null);
-  const mirrorRef = useRef<HTMLPreElement | null>(null);
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  // Always-current callback, so the persistent editor never calls a stale one.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  // Reconfigurable editable/read-only state (driven by `disabled`).
+  const editableRef = useRef(new Compartment());
   const baseId = useId();
   const diagId = `${baseId}-diag`;
 
-  const lineCount = useMemo(() => {
-    // At least one line so the gutter is never empty.
-    const lines = value.split('\n').length;
-    return Math.max(1, lines);
-  }, [value]);
+  // Create the editor once; subsequent prop changes are pushed via the effects
+  // below (the EditorView persists across React renders).
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
 
-  const highlightedLines = useMemo(
-    () => (syntaxHighlighting ? tokenizeYaml(value) : []),
-    [value, syntaxHighlighting],
-  );
+    const extensions = [
+      history(),
+      keymap.of([...defaultKeymap, ...historyKeymap]),
+      ...(showLineNumbers ? [lineNumbers()] : []),
+      ...(highlight ? [yaml(), syntaxHighlighting(yamlHighlightStyle)] : []),
+      lintGutter(),
+      editorTheme,
+      editableRef.current.of([
+        EditorView.editable.of(!disabled),
+        EditorState.readOnly.of(disabled),
+      ]),
+      EditorView.contentAttributes.of({ 'aria-label': ariaLabel, 'aria-describedby': diagId }),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          onChangeRef.current(update.state.doc.toString());
+        }
+      }),
+    ];
 
-  // Keep the gutter and the highlight mirror scrolled in lockstep with the
-  // textarea — both axes: with `wrap="off"` the text scrolls horizontally too.
-  const syncScroll = useCallback(() => {
-    const ta = textareaRef.current;
-    if (!ta) return;
-    const gutter = gutterRef.current;
-    if (gutter) gutter.scrollTop = ta.scrollTop;
-    const mirror = mirrorRef.current;
-    if (mirror) {
-      mirror.scrollTop = ta.scrollTop;
-      mirror.scrollLeft = ta.scrollLeft;
-    }
+    const view = new EditorView({
+      state: EditorState.create({ doc: value, extensions }),
+      parent: host,
+    });
+    viewRef.current = view;
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // Mount once. `value`/`diagnostics`/`disabled` are synced by the effects
+    // below; the other inputs are construction-time options.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Re-sync after every value change as well (typing can scroll the textarea
-  // without firing a scroll event in all engines).
+  // Push external value changes into the editor (guarding the typing feedback
+  // loop: when the user types, onChange updates `value`, which arrives here
+  // already equal to the doc, so no transaction is dispatched).
   useEffect(() => {
-    syncScroll();
-  }, [value, syncScroll]);
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current !== value) {
+      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+    }
+  }, [value]);
 
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      onChange(e.target.value);
-    },
-    [onChange],
-  );
+  // Push diagnostics into the lint layer (squiggles + hover tooltips).
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch(setDiagnostics(view.state, toCmDiagnostics(diagnostics, view.state.doc.length)));
+  }, [diagnostics]);
+
+  // Reconfigure editable / read-only when `disabled` changes.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: editableRef.current.reconfigure([
+        EditorView.editable.of(!disabled),
+        EditorState.readOnly.of(disabled),
+      ]),
+    });
+  }, [disabled]);
 
   const sorted = useMemo(() => {
     if (!diagnostics || diagnostics.length === 0) return [];
@@ -118,9 +242,6 @@ export const CodeView: React.FC<CodeViewProps> = ({
     });
   }, [diagnostics]);
 
-  const hasError = sorted.some((d) => d.severity === 'error');
-  const describedBy = sorted.length > 0 ? diagId : undefined;
-
   return (
     <div className={`spytial-ed-code${className ? ` ${className}` : ''}`}>
       {hasUnappliedEdits ? (
@@ -129,69 +250,10 @@ export const CodeView: React.FC<CodeViewProps> = ({
         </div>
       ) : null}
 
-      <div className="spytial-ed-code-editor">
-        {showLineNumbers ? (
-          <div
-            ref={gutterRef}
-            className="spytial-ed-code-gutter"
-            aria-hidden="true"
-          >
-            {Array.from({ length: lineCount }, (_, i) => (
-              <div key={i} className="spytial-ed-code-gutter-line">
-                {i + 1}
-              </div>
-            ))}
-          </div>
-        ) : null}
-
-        <div className="spytial-ed-code-input-wrap">
-          {/* Highlight mirror, behind the textarea (presentation only;
-              omitted entirely when highlighting is disabled). */}
-          {syntaxHighlighting ? (
-            <pre
-              ref={mirrorRef}
-              className="spytial-ed-code-mirror"
-              aria-hidden="true"
-            >
-              {highlightedLines.map((tokens, lineIdx) => (
-                <React.Fragment key={lineIdx}>
-                  {lineIdx > 0 ? '\n' : null}
-                  {tokens.map((t, i) => {
-                    const cls = yamlTokenClassName(t.kind);
-                    return cls ? (
-                      <span key={i} className={cls}>
-                        {t.text}
-                      </span>
-                    ) : (
-                      t.text
-                    );
-                  })}
-                </React.Fragment>
-              ))}
-              {/* trailing newline keeps the last line's height in the mirror */}
-              {'\n'}
-            </pre>
-          ) : null}
-
-          <textarea
-            ref={textareaRef}
-            className={`spytial-ed-code-textarea${
-              syntaxHighlighting ? '' : ' spytial-ed-code-textarea--plain'
-            }`}
-            value={value}
-            onChange={handleChange}
-            onScroll={syncScroll}
-            disabled={disabled}
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            wrap="off"
-            aria-label={ariaLabel}
-            aria-describedby={describedBy}
-            aria-invalid={hasError || undefined}
-          />
-        </div>
-      </div>
+      <div
+        ref={hostRef}
+        className={`spytial-ed-code-cm${disabled ? ' spytial-ed-code-cm--disabled' : ''}`}
+      />
 
       {sorted.length > 0 ? (
         <ul className="spytial-ed-code-diagnostics" id={diagId}>

--- a/src/spec-editor/ui/SpecEditor.tsx
+++ b/src/spec-editor/ui/SpecEditor.tsx
@@ -57,6 +57,7 @@ import {
 } from './theme';
 import { BuilderView } from './BuilderView';
 import { CodeView } from './CodeView';
+import { lintYaml } from '../core/code-positioning';
 import type { SelectorFieldExtras } from './FieldRenderer';
 
 export interface SpecEditorProps {
@@ -552,17 +553,11 @@ export const SpecEditor: React.FC<SpecEditorProps> = ({
     .filter(Boolean)
     .join(' ');
 
-  const codeDiagnostics = useMemo(() => {
-    const ds: Diagnostic[] = [];
-    if (parseError) ds.push(parseError);
-    // Surface non-yaml structural/domain diagnostics too (without locations).
-    for (const d of structuralDomain) {
-      if (d.severity === 'error' || d.severity === 'warning') {
-        ds.push(d);
-      }
-    }
-    return ds;
-  }, [parseError, structuralDomain]);
+  // Lint the code-view text itself — parse + validate + position all from the
+  // same `value`, so diagnostics' item ids match the state used to place them.
+  // (Deliberately independent of the debounced model, whose ids drift on each
+  // re-parse and whose text may lag during unapplied edits.)
+  const codeDiagnostics = useMemo(() => lintYaml(value, domain), [value, domain]);
 
   const resolvedTheme = resolveSpecEditorTheme(theme);
 

--- a/src/spec-editor/ui/spec-editor.css
+++ b/src/spec-editor/ui/spec-editor.css
@@ -1280,6 +1280,21 @@
   padding: 0.4em 0.6em;
 }
 
+/* CodeMirror host: the editor renders its own themed chrome (via EditorView.theme
+   in CodeView.tsx, driven by the same --spytial-ed-* vars); this container only
+   sizes and caps it. The .spytial-ed-code-editor / -gutter / -textarea / -mirror
+   rules below are retained for the legacy textarea CodeView still exported from
+   the barrel. */
+.spytial-ed-code-cm {
+  display: block;
+}
+.spytial-ed-code-cm .cm-editor {
+  max-height: 32rem;
+}
+.spytial-ed-code-cm--disabled {
+  opacity: 0.65;
+}
+
 .spytial-ed-code-editor {
   display: flex;
   border: 1px solid var(--spytial-ed-border, #d9d2c0);

--- a/tests/cnd-layout-interface-integration.test.tsx
+++ b/tests/cnd-layout-interface-integration.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom'
-import { render, within, screen, act, waitFor, fireEvent, cleanup } from '@testing-library/react'
+import { render, within, screen, act, waitFor, cleanup } from '@testing-library/react'
+import { EditorView } from '@codemirror/view'
 import {
   mountCndLayoutInterface,
   CndLayoutStateManager,
@@ -78,20 +79,27 @@ directives:
     )
   }
 
-  function getTextarea(): HTMLTextAreaElement {
+  function getCmView(): EditorView {
     const testContainer = screen.getByTestId(
       'test-cnd-layout-interface',
     ) as HTMLElement
-    return within(testContainer).getByRole('textbox') as HTMLTextAreaElement
+    const el = testContainer.querySelector('.cm-editor') as HTMLElement | null
+    const view = el ? EditorView.findFromDOM(el) : null
+    if (!view) throw new Error('CodeMirror editor not found')
+    return view
   }
 
   async function typeYaml(yaml: string) {
-    // Type the YAML into the Code View (the textarea is controlled, so the host
-    // state must echo it back — fireEvent.change drives the controlled input).
-    const textarea = getTextarea()
+    // Drive the CodeMirror code view (no <textarea>): dispatch a document
+    // replacement, which fires the same onChange path as typing. Wrap it in
+    // act() so the resulting onChange → setState → effect chain (which syncs the
+    // host's state manager) flushes before the caller reads the spec back.
+    await act(async () => {
+      const view = getCmView()
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: yaml } })
+    })
     await waitFor(() => {
-      fireEvent.change(textarea, { target: { value: yaml } })
-      expect(textarea.value).toBe(yaml)
+      expect(getCmView().state.doc.toString()).toBe(yaml)
     })
   }
 

--- a/tests/components/CndLayoutInterface.test.tsx
+++ b/tests/components/CndLayoutInterface.test.tsx
@@ -2,9 +2,32 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
+import { EditorView } from '@codemirror/view'
 import { CndLayoutInterface } from '../../src/components/CndLayoutInterface'
 import type { ConstraintData, DirectiveData } from '../../src/components/NoCodeView/interfaces'
 import { useState } from 'react'
+
+/*
+ * The Code view is a CodeMirror 6 editor (no `<textarea>`). These helpers drive
+ * it through its EditorView API: `cmText()` reads the doc, `setCmText()` fires
+ * the same onChange path as typing, `cmIsReadOnly()` reflects the disabled state.
+ */
+function cmView(): EditorView {
+  const el = document.querySelector('.cm-editor') as HTMLElement | null
+  const view = el ? EditorView.findFromDOM(el) : null
+  if (!view) throw new Error('CodeMirror editor not found')
+  return view
+}
+function cmText(): string {
+  return cmView().state.doc.toString()
+}
+function setCmText(text: string): void {
+  const view = cmView()
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } })
+}
+function cmIsReadOnly(): boolean {
+  return document.querySelector('.cm-content')?.getAttribute('contenteditable') === 'false'
+}
 
 /*
  * These tests exercise the back-compat `CndLayoutInterface` wrapper, which is
@@ -99,31 +122,27 @@ describe('CndLayoutInterface Component', () => {
       expect(getBuilderTab()).toHaveAttribute('aria-selected', 'true')
     })
 
-    it('should display textarea empty by default', () => {
+    it('should display the editor empty by default', () => {
       render(<CndLayoutInterface {...defaultProps} />)
 
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-      expect(textarea.value).toBe('')
+      expect(cmText()).toBe('')
     })
 
-    it('should display yamlValue in textarea, if given', () => {
+    it('should display yamlValue in the editor, if given', () => {
       const testYaml = 'constraints:\n  - orientation: {}'
       render(<CndLayoutInterface {...defaultProps} yamlValue={testYaml} />)
 
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-      expect(textarea.value).toBe(testYaml)
+      expect(cmText()).toBe(testYaml)
     })
   })
 
   describe('User Interactions', () => {
-    it('should call onChange when textarea value changes', async () => {
-      const user = userEvent.setup()
+    it('should call onChange when the code text changes', () => {
       const mockOnChange = defaultProps.onChange
 
       render(<CndLayoutInterface {...defaultProps} />)
 
-      const textarea = screen.getByRole('textbox')
-      await user.type(textarea, 'test content')
+      setCmText('test content')
 
       expect(mockOnChange).toHaveBeenCalled()
     })
@@ -192,10 +211,7 @@ describe('CndLayoutInterface Component', () => {
       // Switch back to code and type invalid YAML; a parse diagnostic appears
       // (the "unapplied edits" badge) without clobbering the model.
       await user.click(getCodeTab())
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-      fireEvent.change(textarea, {
-        target: { value: 'constraints:\n  - orientation: {directions: [below]' },
-      })
+      setCmText('constraints:\n  - orientation: {directions: [below]')
       await waitFor(
         () => {
           expect(
@@ -206,16 +222,14 @@ describe('CndLayoutInterface Component', () => {
       )
     })
 
-    it('should not call onChange when disabled', async () => {
-      const user = userEvent.setup()
+    it('should not call onChange when disabled', () => {
       const mockOnChange = defaultProps.onChange
 
       render(<CndLayoutInterface {...defaultProps} disabled={true} />)
 
-      const textarea = screen.getByRole('textbox')
-      expect(textarea).toBeDisabled()
-
-      await user.type(textarea, 'test')
+      // A disabled editor is read-only and takes no user input, so onChange
+      // never fires.
+      expect(cmIsReadOnly()).toBe(true)
       expect(mockOnChange).not.toHaveBeenCalled()
     })
   })
@@ -255,8 +269,7 @@ describe('CndLayoutInterface Component', () => {
 
       render(<CndLayoutInterface {...defaultProps} yamlValue={largeYaml} />)
 
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-      expect(textarea.value).toBe(largeYaml)
+      expect(cmText()).toBe(largeYaml)
     })
 
     it('should render the builder with empty constraints and directives arrays', () => {
@@ -328,9 +341,8 @@ describe('CndLayoutInterface Component', () => {
 
       render(<TestWrapper />)
 
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-      fireEvent.change(textarea, { target: { value: testYaml } })
-      expect(textarea.value).toBe(testYaml)
+      setCmText(testYaml)
+      expect(cmText()).toBe(testYaml)
 
       // Switch to the builder; the parsed orientation constraint appears.
       await user.click(getBuilderTab())
@@ -341,8 +353,7 @@ describe('CndLayoutInterface Component', () => {
 
       // Switch back to the code view; the YAML is preserved.
       await user.click(getCodeTab())
-      const roundTripped = screen.getByRole('textbox') as HTMLTextAreaElement
-      expect(roundTripped.value).toContain('orientation')
+      expect(cmText()).toContain('orientation')
     })
 
     // REWRITTEN (was "Code View should update when No Code View changes"). The
@@ -364,8 +375,7 @@ describe('CndLayoutInterface Component', () => {
 
       // Switch to Code view; the YAML mentions the attribute directive.
       await user.click(getCodeTab())
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-      expect(textarea.value).toContain('attribute')
+      expect(cmText()).toContain('attribute')
 
       // Back to the builder; remove the directive via its overflow menu.
       await user.click(getBuilderTab())
@@ -383,8 +393,7 @@ describe('CndLayoutInterface Component', () => {
 
       // The regenerated YAML no longer mentions the attribute directive.
       await user.click(getCodeTab())
-      const newTextarea = screen.getByRole('textbox') as HTMLTextAreaElement
-      expect(newTextarea.value).not.toContain('attribute')
+      expect(cmText()).not.toContain('attribute')
     })
   })
 })

--- a/tests/components/CodeView.test.tsx
+++ b/tests/components/CodeView.test.tsx
@@ -1,17 +1,23 @@
 import { describe, vi, expect, it } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { EditorView } from '@codemirror/view'
 
 /*
- * The legacy `NoCodeView/CodeView` React component was removed in the
- * spec-editor redesign and replaced by the schema-driven `src/spec-editor/ui/
- * CodeView`. This file is rewritten to test the NEW CodeView, preserving the
- * original rendering + keyboard-focus intent (a controlled YAML textarea) while
- * dropping the old prop surface (constraints/directives/handleTextareaChange).
+ * CodeView is a CodeMirror 6 editor (it replaced the textarea + highlight-mirror
+ * overlay). CodeMirror owns the text rendering, so these tests drive it through
+ * its EditorView API rather than a `<textarea>` value.
  */
 
 import { CodeView } from '../../src/spec-editor/ui/CodeView'
+
+/** The EditorView backing the rendered CodeView. */
+function cmView(container: HTMLElement): EditorView {
+  const el = container.querySelector('.cm-editor') as HTMLElement | null
+  const view = el ? EditorView.findFromDOM(el) : null
+  if (!view) throw new Error('CodeMirror editor not found')
+  return view
+}
 
 describe('CodeView Component Tests', () => {
   const defaultProps = {
@@ -20,71 +26,55 @@ describe('CodeView Component Tests', () => {
   }
 
   describe('Rendering', () => {
-    it('should render a textarea for YAML input', () => {
-      render(<CodeView {...defaultProps} />)
-      const textarea = screen.getByRole('textbox')
-      expect(textarea).toBeInTheDocument()
-      expect(textarea).toHaveValue('')
+    it('renders a CodeMirror editor', () => {
+      const { container } = render(<CodeView {...defaultProps} />)
+      expect(container.querySelector('.cm-editor')).toBeInTheDocument()
+      expect(cmView(container).state.doc.toString()).toBe('')
     })
 
-    it('should render with an initial YAML value', () => {
+    it('shows the initial YAML value', () => {
       const initialYaml = 'constraints:\n  - orientation: {}'
-      render(<CodeView {...defaultProps} value={initialYaml} />)
-      const textarea = screen.getByRole('textbox')
-      expect(textarea).toHaveValue(initialYaml)
+      const { container } = render(<CodeView {...defaultProps} value={initialYaml} />)
+      expect(cmView(container).state.doc.toString()).toBe(initialYaml)
     })
 
-    it('renders a highlight mirror whose text matches the value exactly', () => {
-      // The metrics contract behind the overlay: the mirror must contain the
-      // textarea's text verbatim (plus the trailing newline that preserves the
-      // last line's height), with spec keywords classed for highlighting.
-      const yaml = 'constraints:\n  - orientation: {selector: left}'
-      render(<CodeView {...defaultProps} value={yaml} />)
-      const mirror = document.querySelector('.spytial-ed-code-mirror')!
-      expect(mirror).toBeInTheDocument()
-      expect(mirror.textContent).toBe(`${yaml}\n`)
-      expect(
-        mirror.querySelector('.spytial-ed-syn-keyword')?.textContent,
-      ).toBe('constraints')
+    it('renders a line-number gutter by default', () => {
+      const { container } = render(<CodeView {...defaultProps} value={'a\nb\nc'} />)
+      expect(container.querySelector('.cm-lineNumbers')).toBeInTheDocument()
     })
 
-    it('syntaxHighlighting={false} kills the mirror and shows plain text', () => {
-      // The escape hatch for hosts where the overlay misaligns.
-      render(
-        <CodeView {...defaultProps} value="constraints: []" syntaxHighlighting={false} />,
+    it('omits the line-number gutter when showLineNumbers={false}', () => {
+      const { container } = render(
+        <CodeView {...defaultProps} value={'a\nb'} showLineNumbers={false} />,
       )
-      expect(document.querySelector('.spytial-ed-code-mirror')).toBeNull()
-      expect(screen.getByRole('textbox').className).toContain(
-        'spytial-ed-code-textarea--plain',
-      )
+      expect(container.querySelector('.cm-lineNumbers')).toBeNull()
     })
   })
 
   describe('Interactions', () => {
     it('should fire onChange with the edited text', () => {
       const onChange = vi.fn()
-      render(<CodeView {...defaultProps} onChange={onChange} />)
-      const textarea = screen.getByRole('textbox')
-      fireEvent.change(textarea, { target: { value: 'directives:\n  - flag: foo' } })
+      const { container } = render(<CodeView {...defaultProps} onChange={onChange} />)
+      cmView(container).dispatch({
+        changes: { from: 0, insert: 'directives:\n  - flag: foo' },
+      })
       expect(onChange).toHaveBeenCalledWith('directives:\n  - flag: foo')
     })
 
     it('should not be editable when disabled', () => {
-      render(<CodeView {...defaultProps} disabled />)
-      expect(screen.getByRole('textbox')).toBeDisabled()
+      const { container } = render(<CodeView {...defaultProps} disabled />)
+      const content = container.querySelector('.cm-content')
+      expect(content?.getAttribute('contenteditable')).toBe('false')
     })
   })
 
   describe('Accessibility', () => {
-    it('should support keyboard navigation', async () => {
-      const user = userEvent.setup()
-      render(<CodeView {...defaultProps} />)
-
-      const textarea = screen.getByRole('textbox')
-
-      // Should be able to focus the textarea with the keyboard.
-      await user.tab()
-      expect(textarea).toHaveFocus()
+    it('exposes a focusable, labelled text input', () => {
+      const { container } = render(<CodeView {...defaultProps} />)
+      const content = container.querySelector('.cm-content') as HTMLElement
+      expect(content.getAttribute('aria-label')).toBe('Layout specification YAML')
+      content.focus()
+      expect(document.activeElement).toBe(content)
     })
 
     it('should surface parse diagnostics with the unapplied-edits notice', () => {
@@ -94,7 +84,15 @@ describe('CodeView Component Tests', () => {
           value="constraints: ["
           hasUnappliedEdits
           diagnostics={[
-            { severity: 'error', message: 'bad yaml', source: 'yaml', line: 1, column: 14 },
+            {
+              severity: 'error',
+              message: 'bad yaml',
+              source: 'yaml',
+              line: 1,
+              column: 14,
+              from: 13,
+              to: 14,
+            },
           ]}
         />,
       )

--- a/tests/evaluator-cache.test.ts
+++ b/tests/evaluator-cache.test.ts
@@ -39,9 +39,10 @@ constraints:
       directions:
         - right
 directives:
-  - atomColor:
+  - atomStyle:
       selector: A->B
-      value: "#FF0000"
+      fillStyle:
+        color: "#FF0000"
   - size:
       selector: A->B
       height: 100
@@ -119,9 +120,10 @@ constraints:
   it('caches results for multiple directives using the same selector', () => {
     const layoutSpecWithMultipleDirectives = `
 directives:
-  - atomColor:
+  - atomStyle:
       selector: Type1
-      value: "#FF0000"
+      fillStyle:
+        color: "#FF0000"
   - size:
       selector: Type1
       height: 100
@@ -162,9 +164,10 @@ constraints:
       directions:
         - right
 directives:
-  - atomColor:
+  - atomStyle:
       selector: A->B
-      value: "#FF0000"
+      fillStyle:
+        color: "#FF0000"
 `;
 
     const instance = new JSONDataInstance(jsonData);

--- a/tests/field-selectors-integration.test.ts
+++ b/tests/field-selectors-integration.test.ts
@@ -68,14 +68,16 @@ describe('Field-based directives with selectors - Integration', () => {
   it('should apply edge colors only to specified atoms via selector', () => {
     const layoutSpecStr = `
 directives:
-  - edgeColor:
+  - edgeStyle:
       field: 'name'
-      value: 'red'
       selector: 'Person'
-  - edgeColor:
+      lineStyle:
+        color: 'red'
+  - edgeStyle:
       field: 'name'
-      value: 'blue'
       selector: 'Car'
+      lineStyle:
+        color: 'blue'
 `;
 
     const layoutSpec = parseLayoutSpec(layoutSpecStr);

--- a/tests/layout-instance.test.ts
+++ b/tests/layout-instance.test.ts
@@ -214,10 +214,11 @@ constraints:
       name: nodes
       addEdge: fromgroup
 directives:
-  - edgeColor:
+  - edgeStyle:
       field: nodes
-      value: '#FF0000'
       filter: 'A -> B'
+      lineStyle:
+        color: '#FF0000'
 `);
       const instance = new JSONDataInstance(groupEdgeData);
       const evaluator = createEvaluator(instance);

--- a/tests/nocode-improvements.test.tsx
+++ b/tests/nocode-improvements.test.tsx
@@ -141,6 +141,22 @@ directives:
             const result = validateSpytialSpec(validDirectives);
             expect(result.warnings.filter(w => w.includes('Unrecognized directive'))).toHaveLength(0);
         });
+
+        it('recognizes the current atomStyle/edgeStyle directives (registry-derived, no drift)', () => {
+            // Regression: a hand-maintained known-types list omitted these and
+            // false-warned on the recommended style directives.
+            const currentStyleDirectives = `
+directives:
+  - atomStyle:
+      selector: Node
+      fillStyle: { color: "#ff0000" }
+  - edgeStyle:
+      field: edges
+      lineStyle: { color: "#00ff00" }
+`;
+            const result = validateSpytialSpec(currentStyleDirectives);
+            expect(result.warnings.filter(w => w.includes('Unrecognized directive'))).toHaveLength(0);
+        });
     });
 });
 

--- a/tests/nocode-improvements.test.tsx
+++ b/tests/nocode-improvements.test.tsx
@@ -157,6 +157,29 @@ directives:
             const result = validateSpytialSpec(currentStyleDirectives);
             expect(result.warnings.filter(w => w.includes('Unrecognized directive'))).toHaveLength(0);
         });
+
+        it('flags a known directive key placed under constraints (section-aware)', () => {
+            // edgeStyle is a directive; under `constraints` the engine drops it,
+            // so the misplaced no-op block should still be surfaced.
+            const result = validateSpytialSpec('constraints:\n  - edgeStyle:\n      field: link\n');
+            expect(result.warnings.some(
+                w => w.includes('Unrecognized constraint type') && w.includes('edgeStyle'),
+            )).toBe(true);
+        });
+
+        it('flags a known constraint key placed under directives (section-aware)', () => {
+            const result = validateSpytialSpec('directives:\n  - orientation:\n      selector: a\n      directions: [left]\n');
+            expect(result.warnings.some(
+                w => w.includes('Unrecognized directive type') && w.includes('orientation'),
+            )).toBe(true);
+        });
+
+        it('allows size/hideAtom in the directives section (dual-placed)', () => {
+            const result = validateSpytialSpec(
+                'directives:\n  - size: { width: 100, height: 60, selector: X }\n  - hideAtom: { selector: X }\n',
+            );
+            expect(result.warnings.filter(w => w.includes('Unrecognized directive'))).toHaveLength(0);
+        });
     });
 });
 

--- a/tests/parse-warnings.test.ts
+++ b/tests/parse-warnings.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+
+/**
+ * `parseLayoutSpec` returns advisory warnings on the parsed `LayoutSpec` so a
+ * direct library consumer can read them off the result — opt-in (ignore the
+ * field and nothing changes) and non-breaking (parsing never throws for a
+ * warning, and the same messages still go to `console.warn`).
+ */
+describe('parseLayoutSpec — returned warnings (consumable, non-breaking)', () => {
+  it('surfaces atomColor deprecation on spec.warnings AND still parses the directive', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spec = parseLayoutSpec("directives:\n  - atomColor: { selector: Node, value: '#ff0000' }");
+    warn.mockRestore();
+
+    const deprecations = (spec.warnings ?? []).filter((w) => w.code === 'deprecated');
+    expect(deprecations.length).toBeGreaterThan(0);
+    expect(deprecations.some((w) => w.message.includes('atomColor'))).toBe(true);
+    // The spec is fully usable — atomColor desugared into an atomStyle rule.
+    expect(spec.directives.atomStyles.length).toBeGreaterThan(0);
+  });
+
+  it('surfaces edgeColor deprecation on spec.warnings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spec = parseLayoutSpec("directives:\n  - edgeColor: { field: left, value: '#111111' }");
+    warn.mockRestore();
+
+    expect(
+      (spec.warnings ?? []).some((w) => w.code === 'deprecated' && w.message.includes('edgeColor')),
+    ).toBe(true);
+  });
+
+  it('keeps warnings empty (defined, not undefined) for a clean spec', () => {
+    const spec = parseLayoutSpec(
+      'constraints:\n  - orientation: { selector: parent, directions: [left] }',
+    );
+    expect(spec.warnings).toEqual([]);
+    expect(spec.constraints.orientation.relative.length).toBe(1);
+  });
+
+  it('returns empty warnings for the default (empty) spec', () => {
+    expect(parseLayoutSpec('').warnings).toEqual([]);
+  });
+});

--- a/tests/selector-arity-validation.test.ts
+++ b/tests/selector-arity-validation.test.ts
@@ -11,7 +11,7 @@ import { SelectorArityError } from '../src/evaluators/interfaces';
  *
  * - Binary-position constraints (orientation, align, cyclic) should error when
  *   given a unary selector (e.g. "Person" instead of "Person->Person").
- * - Unary-position constraints/directives (hideAtom, size, atomColor, icon) should
+ * - Unary-position constraints/directives (hideAtom, size, atomStyle, icon) should
  *   error when given a binary selector.
  */
 
@@ -181,12 +181,13 @@ directives:
             expect(arityError!.errorMessage).toContain('unary');
         });
 
-        it('atomColor directive reports error for binary selector', () => {
+        it('atomStyle directive reports error for binary selector', () => {
             const spec = parseLayoutSpec(`
 directives:
-  - atomColor:
+  - atomStyle:
       selector: next
-      value: red
+      fillStyle:
+        color: red
 `);
             const instance = new JSONDataInstance(mixedData);
             const evaluator = createEvaluator(instance);
@@ -194,7 +195,6 @@ directives:
             const { selectorErrors } = layoutInstance.generateLayout(instance);
 
             expect(selectorErrors.length).toBeGreaterThan(0);
-            // atomColor desugars to atomStyle, so the arity check runs under that context now.
             const arityError = selectorErrors.find(e => e.selector === 'next' && e.context === 'atomStyle selector');
             expect(arityError).toBeDefined();
             expect(arityError!.errorMessage).toContain('unary');

--- a/tests/size-hideatom-dual-syntax.test.ts
+++ b/tests/size-hideatom-dual-syntax.test.ts
@@ -206,9 +206,10 @@ constraints:
   - hideAtom:
       selector: Type2
 directives:
-  - atomColor:
+  - atomStyle:
       selector: Type1
-      value: "#FF0000"
+      fillStyle:
+        color: "#FF0000"
 `;
 
       const layoutSpec = parseLayoutSpec(layoutSpecYaml);
@@ -220,10 +221,10 @@ directives:
       // Check directives (including size and hideAtom from constraints)
       expect(layoutSpec.directives.sizes).toHaveLength(1);
       expect(layoutSpec.directives.hiddenAtoms).toHaveLength(1);
-      // atomColor now desugars into a border-preserving atomStyle rule (atomColors emptied).
+      // atomStyle sets the fill color directly (no legacy atomColor desugar).
       expect(layoutSpec.directives.atomColors).toHaveLength(0);
       expect(layoutSpec.directives.atomStyles).toHaveLength(1);
-      expect(layoutSpec.directives.atomStyles[0].style.borderStyle?.color).toBe('#FF0000');
+      expect(layoutSpec.directives.atomStyles[0].style.fillStyle?.color).toBe('#FF0000');
     });
   });
 

--- a/tests/spec-editor-code-positioning.test.ts
+++ b/tests/spec-editor-code-positioning.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseYamlToState,
+  validateState,
+  positionDiagnostics,
+  lintYaml,
+} from '../src/spec-editor';
+
+/** The substring an editor would squiggle for a positioned diagnostic. */
+function span(yaml: string, d: { from?: number; to?: number }): string {
+  if (d.from === undefined || d.to === undefined) return '';
+  return yaml.slice(d.from, d.to);
+}
+
+describe('code-positioning — resolve diagnostic ranges from YAML', () => {
+  it('anchors an unknown field key to that exact token', () => {
+    const yaml = 'directives:\n  - icon:\n      path: a.svg\n      showLabel: true\n';
+    const state = parseYamlToState(yaml);
+    const positioned = positionDiagnostics(yaml, state, validateState(state));
+    const unknown = positioned.find((d) => d.code === 'unknown-key');
+    expect(unknown).toBeDefined();
+    expect(span(yaml, unknown!)).toBe('showLabel');
+  });
+
+  it('anchors a nested-block typo to the nested key', () => {
+    const yaml =
+      'directives:\n  - edgeStyle:\n      field: next\n      lineStyle:\n        colour: red\n';
+    const state = parseYamlToState(yaml);
+    const positioned = positionDiagnostics(yaml, state, validateState(state));
+    const unknown = positioned.find((d) => d.code === 'unknown-key');
+    expect(unknown).toBeDefined();
+    expect(span(yaml, unknown!)).toBe('colour');
+  });
+
+  it('anchors a deprecation (no fieldKey) to the item type key', () => {
+    const yaml = "directives:\n  - atomColor:\n      selector: Node\n      value: '#f00'\n";
+    const state = parseYamlToState(yaml);
+    const positioned = positionDiagnostics(yaml, state, validateState(state));
+    const dep = positioned.find((d) => d.code === 'deprecated');
+    expect(dep).toBeDefined();
+    expect(span(yaml, dep!)).toBe('atomColor');
+  });
+
+  it('falls back to the item type key when the required field is absent', () => {
+    // `directions` is required and missing → its key isn't in the text, so the
+    // squiggle lands on the item type (`orientation`) instead of nowhere.
+    const yaml = 'constraints:\n  - orientation:\n      selector: parent\n';
+    const state = parseYamlToState(yaml);
+    const positioned = positionDiagnostics(yaml, state, validateState(state));
+    const missing = positioned.find((d) => d.code === 'missing-required');
+    expect(missing).toBeDefined();
+    expect(span(yaml, missing!)).toBe('orientation');
+  });
+
+  it('resolves the second item independently of the first (index-correct)', () => {
+    const yaml =
+      'directives:\n  - icon:\n      path: a.svg\n  - icon:\n      path: b.svg\n      showLabel: true\n';
+    const state = parseYamlToState(yaml);
+    const positioned = positionDiagnostics(yaml, state, validateState(state));
+    const unknown = positioned.find((d) => d.code === 'unknown-key');
+    expect(unknown).toBeDefined();
+    // There is exactly one `showLabel`, on the second icon — the range must land there.
+    expect(span(yaml, unknown!)).toBe('showLabel');
+    expect(unknown!.from).toBe(yaml.indexOf('showLabel'));
+  });
+
+  it('lintYaml self-contains parse+validate+position (ranges always resolve)', () => {
+    const yaml =
+      '{directives: [{atomColor: {selector: Node, value: "#ff0000"}}, {icon: {path: a.svg, showLabel: true}}]}';
+    const linted = lintYaml(yaml);
+    const dep = linted.find((d) => d.code === 'deprecated');
+    const unknown = linted.find((d) => d.code === 'unknown-key');
+    // Both resolve to exact tokens — no drift, because state + diagnostics come
+    // from the same parse of `yaml`.
+    expect(span(yaml, dep!)).toBe('atomColor');
+    expect(span(yaml, unknown!)).toBe('showLabel');
+  });
+
+  it('lintYaml reports a syntax error with a location', () => {
+    const linted = lintYaml('constraints:\n  - orientation: {directions: [below]');
+    expect(linted.length).toBeGreaterThan(0);
+    expect(linted[0].severity).toBe('error');
+    expect(linted[0].from).toBeGreaterThanOrEqual(0);
+  });
+
+  it('lintYaml returns nothing for empty text', () => {
+    expect(lintYaml('')).toEqual([]);
+    expect(lintYaml('   \n  ')).toEqual([]);
+  });
+
+  it('every positioned range is within bounds and matches its diagnostic', () => {
+    const yaml = 'directives:\n  - icon:\n      path: a.svg\n      wibble: 1\n';
+    const state = parseYamlToState(yaml);
+    const positioned = positionDiagnostics(yaml, state, validateState(state));
+    for (const d of positioned) {
+      if (d.from === undefined || d.to === undefined) continue;
+      expect(d.from).toBeGreaterThanOrEqual(0);
+      expect(d.to).toBeLessThanOrEqual(yaml.length);
+      expect(d.to).toBeGreaterThanOrEqual(d.from);
+    }
+  });
+});

--- a/tests/spec-editor-codec.test.ts
+++ b/tests/spec-editor-codec.test.ts
@@ -308,8 +308,8 @@ describe('yaml-codec — determinism', () => {
     doc.updateItem(o.id, { params: { selector: 'parent', directions: ['left', 'below'] } });
     const s = doc.addItem('constraint', 'size');
     doc.updateItem(s.id, { params: { selector: 'Node', width: 120, height: 40 } });
-    const a = doc.addItem('directive', 'atomColor');
-    doc.updateItem(a.id, { params: { value: '#ff0000', selector: 'Root' } });
+    const a = doc.addItem('directive', 'atomStyle');
+    doc.updateItem(a.id, { params: { selector: 'Root', fillStyle: { color: '#ff0000' } } });
 
     const first = doc.toYaml();
     const second = SpecDocument.fromYaml(first).toYaml();

--- a/tests/spec-editor-integration.test.tsx
+++ b/tests/spec-editor-integration.test.tsx
@@ -28,6 +28,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
+import { EditorView } from '@codemirror/view'
 
 import { SpecEditor } from '../src/spec-editor/ui/SpecEditor'
 import { parseYamlToState } from '../src/spec-editor'
@@ -81,6 +82,25 @@ function getBuilderTab(root: HTMLElement = document.body): HTMLElement {
 }
 function getCodeTab(root: HTMLElement = document.body): HTMLElement {
   return within(root).getByRole('tab', { name: 'Code' })
+}
+
+/**
+ * Drive the CodeMirror code view. There is no `<textarea>` to set `.value` on;
+ * we dispatch a document replacement into the EditorView, which fires the same
+ * `onChange` path typing would.
+ */
+function findCmView(): EditorView {
+  const el = document.querySelector('.cm-editor') as HTMLElement | null
+  const view = el ? EditorView.findFromDOM(el) : null
+  if (!view) throw new Error('CodeMirror editor not found in DOM')
+  return view
+}
+function setCmText(text: string): void {
+  const view = findCmView()
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } })
+}
+function cmText(): string {
+  return findCmView().state.doc.toString()
 }
 
 /**
@@ -163,10 +183,9 @@ describe('SpecEditor — code-view edits sync to the model (debounced)', () => {
     // typing (userEvent.type deadlocks under fake timers).
     render(<Host onChangeSpy={onChange} defaultView="code" />)
 
-    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
     const yaml = 'constraints:\n  - orientation: {}\n'
     act(() => {
-      fireEvent.change(textarea, { target: { value: yaml } })
+      setCmText(yaml)
     })
 
     // onChange fires immediately (text is controlled); model not yet synced.
@@ -227,10 +246,9 @@ describe('SpecEditor — a model mutation cancels a pending code-view parse (Fin
     act(() => {
       fireEvent.click(getCodeTab())
     })
-    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
     const T = 'constraints:\n  - orientation: {selector: fromCode}\n'
     act(() => {
-      fireEvent.change(textarea, { target: { value: T } })
+      setCmText(T)
     })
     // onChange echoes the code text immediately (controlled), parse not yet run.
     expect(onChange).toHaveBeenLastCalledWith(T)
@@ -277,13 +295,9 @@ describe('SpecEditor — invalid YAML preserves the model and shows a diagnostic
         />,
       )
 
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-
       // Type syntactically invalid YAML.
       act(() => {
-        fireEvent.change(textarea, {
-          target: { value: 'constraints:\n  - orientation: {directions: [below]' },
-        })
+        setCmText('constraints:\n  - orientation: {directions: [below]')
         vi.advanceTimersByTime(350)
       })
 
@@ -303,9 +317,8 @@ describe('SpecEditor — invalid YAML preserves the model and shows a diagnostic
       act(() => {
         fireEvent.click(getCodeTab())
       })
-      const ta2 = screen.getByRole('textbox') as HTMLTextAreaElement
       act(() => {
-        fireEvent.change(ta2, { target: { value: 'directives:\n  - flag: foo\n' } })
+        setCmText('directives:\n  - flag: foo\n')
         vi.advanceTimersByTime(350)
       })
 
@@ -574,14 +587,13 @@ describe('CndLayoutInterface — back-compat with the legacy prop surface', () =
     render(<LegacyHost />)
 
     // Renders in the code view by default (isNoCodeView=false).
-    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-    expect(textarea).toBeInTheDocument()
+    expect(document.querySelector('.cm-editor')).toBeInTheDocument()
 
-    // Code-view edits flow through onChange and update the textarea.
-    fireEvent.change(textarea, {
-      target: { value: 'directives:\n  - attribute:\n      field: key\n' },
+    // Code-view edits flow through onChange and update the editor.
+    act(() => {
+      setCmText('directives:\n  - attribute:\n      field: key\n')
     })
-    expect(textarea.value).toContain('attribute')
+    expect(cmText()).toContain('attribute')
 
     // The deprecated setDirectives callback is kept loosely in sync.
     await waitFor(() => {

--- a/tests/spec-editor-registry-diagnostics.test.ts
+++ b/tests/spec-editor-registry-diagnostics.test.ts
@@ -5,6 +5,8 @@ import {
   getDefinitions,
   defaultParamsFor,
   validateItem,
+  validateState,
+  parseYamlToState,
   type SpecItem,
 } from '../src/spec-editor';
 import { newId } from '../src/spec-editor';
@@ -175,6 +177,28 @@ describe('diagnostics — unknown keys (typo detection)', () => {
     expect(warn!.severity).toBe('warning');
     expect(warn!.message).toContain('Line style');
     expect(warn!.message).toContain('Did you mean "color"');
+  });
+
+  it('routes a nested unknown key with a parent-qualified fieldKey (no sibling collision)', () => {
+    // `width` is valid in borderStyle but not fillStyle; the diagnostic must not
+    // attach to borderStyle.width, so its fieldKey is parent-qualified.
+    const diags = validateItem(item('atomStyle', { fillStyle: { width: 2 } }, 'directive'));
+    const warn = diags.find((d) => d.message.includes('width'));
+    expect(warn).toBeDefined();
+    expect(warn!.code).toBe('unknown-key');
+    expect(warn!.fieldKey).toBe('fillStyle.width');
+  });
+
+  it('flags a typo on a group (custom fromYamlNode) via the raw source body', () => {
+    // groupselector ingests through fromYamlNode, which copies only known keys
+    // into params — so without the raw body preserved, `naem` would vanish.
+    const state = parseYamlToState(
+      'constraints:\n  - group:\n      selector: p\n      name: c\n      naem: cluster\n',
+    );
+    const diags = validateState(state);
+    const warn = diags.find((d) => d.code === 'unknown-key' && d.message.includes('naem'));
+    expect(warn).toBeDefined();
+    expect(warn!.message).toContain('Did you mean "name"');
   });
 
   it('lists valid fields when the unknown key has no near-miss', () => {

--- a/tests/spec-editor-registry-diagnostics.test.ts
+++ b/tests/spec-editor-registry-diagnostics.test.ts
@@ -218,7 +218,7 @@ describe('diagnostics — unknown keys (typo detection)', () => {
     expect(diags.filter((d) => /Unknown field/.test(d.message))).toHaveLength(0);
   });
 
-  it('does not flag `filter` on attribute/hideField (engine-accepted, not yet a field)', () => {
+  it('does not flag `filter` on attribute/hideField (a real field)', () => {
     const attr = validateItem(
       item('attribute', { field: 'age', filter: 'x.isAdult' }, 'directive'),
     );
@@ -238,5 +238,32 @@ describe('diagnostics — unknown keys (typo detection)', () => {
       ),
     );
     expect(diags).toHaveLength(0);
+  });
+});
+
+describe('diagnostics — warning taxonomy (code discriminator)', () => {
+  it('tags unknown-key warnings with code "unknown-key"', () => {
+    const diags = validateItem(item('icon', { path: 'a.svg', showLabel: true }, 'directive'));
+    const warn = diags.find((d) => d.message.includes('showLabel'));
+    expect(warn!.code).toBe('unknown-key');
+  });
+
+  it('emits a distinct "deprecated" diagnostic naming the replacement', () => {
+    const diags = validateItem(
+      item('atomColor', { value: '#f00', selector: 'Node' }, 'directive'),
+    );
+    const dep = diags.find((d) => d.code === 'deprecated');
+    expect(dep).toBeDefined();
+    expect(dep!.severity).toBe('warning');
+    expect(dep!.message).toContain('atomStyle');
+    // the deprecation notice is separate from any typo/unknown-key warning
+    expect(dep!.code).not.toBe('unknown-key');
+  });
+
+  it('does not deprecation-warn a current (non-deprecated) type', () => {
+    const diags = validateItem(
+      item('atomStyle', { selector: 'Node', fillStyle: { color: '#f00' } }, 'directive'),
+    );
+    expect(diags.some((d) => d.code === 'deprecated')).toBe(false);
   });
 });

--- a/tests/spec-editor-registry-diagnostics.test.ts
+++ b/tests/spec-editor-registry-diagnostics.test.ts
@@ -154,3 +154,89 @@ describe('diagnostics — structural validation', () => {
     expect(doc.validate()).toHaveLength(0);
   });
 });
+
+describe('diagnostics — unknown keys (typo detection)', () => {
+  it('warns on an unknown top-level key with a did-you-mean', () => {
+    // `showLabel` is a near-miss for the icon field `showLabels`.
+    const diags = validateItem(item('icon', { path: 'a.svg', showLabel: true }, 'directive'));
+    const warn = diags.find((d) => d.message.includes('showLabel'));
+    expect(warn).toBeDefined();
+    expect(warn!.severity).toBe('warning');
+    expect(warn!.source).toBe('structure');
+    expect(warn!.message).toContain('Did you mean "showLabels"');
+  });
+
+  it('warns on an unknown key inside a nested style block', () => {
+    const diags = validateItem(
+      item('edgeStyle', { field: 'next', lineStyle: { colour: 'red' } }, 'directive'),
+    );
+    const warn = diags.find((d) => d.message.includes('colour'));
+    expect(warn).toBeDefined();
+    expect(warn!.severity).toBe('warning');
+    expect(warn!.message).toContain('Line style');
+    expect(warn!.message).toContain('Did you mean "color"');
+  });
+
+  it('lists valid fields when the unknown key has no near-miss', () => {
+    const diags = validateItem(item('atomStyle', { wibble: 1 }, 'directive'));
+    const warn = diags.find((d) => d.message.includes('wibble'));
+    expect(warn).toBeDefined();
+    expect(warn!.severity).toBe('warning');
+    expect(warn!.message).not.toContain('Did you mean');
+    expect(warn!.message).toContain('Known fields:');
+  });
+
+  it('a typo of a required field is reported both ways', () => {
+    // `directon` for `directions`: the field is still missing (error) AND the
+    // stray key is flagged with the fix (warning) — the warning is the clue.
+    const diags = validateItem(
+      item('orientation', { selector: 'p', directon: ['left'] }, 'constraint'),
+    );
+    expect(diags.some((d) => d.severity === 'error' && /Directions/.test(d.message))).toBe(true);
+    const warn = diags.find((d) => d.message.includes('directon'));
+    expect(warn!.severity).toBe('warning');
+    expect(warn!.message).toContain('Did you mean "directions"');
+  });
+
+  it('does not flag `hold` on a constraint (negation marker, not a field)', () => {
+    const diags = validateItem(
+      item('orientation', { selector: 'p', directions: ['left'], hold: 'never' }, 'constraint'),
+    );
+    expect(diags).toHaveLength(0);
+  });
+
+  it('does not flag inferredEdge deprecated inline line keys', () => {
+    // color/style/weight/highlight are still parsed (deprecation-warned
+    // elsewhere), so they are not "unknown".
+    const diags = validateItem(
+      item(
+        'inferredEdge',
+        { name: 'e', selector: 'r', color: '#f00', style: 'dashed', weight: 2 },
+        'directive',
+      ),
+    );
+    expect(diags.filter((d) => /Unknown field/.test(d.message))).toHaveLength(0);
+  });
+
+  it('does not flag `filter` on attribute/hideField (engine-accepted, not yet a field)', () => {
+    const attr = validateItem(
+      item('attribute', { field: 'age', filter: 'x.isAdult' }, 'directive'),
+    );
+    expect(attr.filter((d) => /Unknown field/.test(d.message))).toHaveLength(0);
+    const hide = validateItem(
+      item('hideField', { field: 'age', filter: 'x.isAdult' }, 'directive'),
+    );
+    expect(hide.filter((d) => /Unknown field/.test(d.message))).toHaveLength(0);
+  });
+
+  it('leaves valid items (including nested blocks) clean', () => {
+    const diags = validateItem(
+      item(
+        'edgeStyle',
+        { field: 'next', lineStyle: { color: 'red', pattern: 'dashed' }, showLabel: true },
+        'directive',
+      ),
+    );
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/tests/yaml-generation-size-hideatom.test.ts
+++ b/tests/yaml-generation-size-hideatom.test.ts
@@ -164,10 +164,10 @@ describe('YAML Generation for Size and HideAtom', () => {
     const directives: DirectiveData[] = [
       {
         id: '1',
-        type: 'atomColor',
+        type: 'atomStyle',
         params: {
           selector: 'Type1',
-          value: '#FF0000'
+          fillStyle: { color: '#FF0000' }
         }
       },
       {
@@ -185,17 +185,17 @@ describe('YAML Generation for Size and HideAtom', () => {
     expect(yaml).toContain('orientation:');
     expect(yaml).toContain('size:');
     expect(yaml).toContain('directives:');
-    expect(yaml).toContain('atomColor:');
+    expect(yaml).toContain('atomStyle:');
     expect(yaml).toContain('hideAtom:');
     
     // Verify it can be parsed back correctly
     const parsed = parseLayoutSpec(yaml);
     expect(parsed.constraints.orientation.relative).toHaveLength(1);
     expect(parsed.directives.sizes).toHaveLength(1);
-    // atomColor now desugars into a border-preserving atomStyle rule (atomColors emptied).
+    // atomStyle sets the fill color directly (no legacy atomColor desugar).
     expect(parsed.directives.atomColors).toHaveLength(0);
     expect(parsed.directives.atomStyles).toHaveLength(1);
-    expect(parsed.directives.atomStyles[0].style.borderStyle?.color).toBe('#FF0000');
+    expect(parsed.directives.atomStyles[0].style.fillStyle?.color).toBe('#FF0000');
     expect(parsed.directives.hiddenAtoms).toHaveLength(1);
   });
 

--- a/webcola-demo/alloy-demo.html
+++ b/webcola-demo/alloy-demo.html
@@ -104,6 +104,31 @@
         .status.info { background: #e3f2fd; color: #1976d2; }
         .status.success { background: #e8f5e8; color: #2e7d32; }
         .status.error { background: #ffebee; color: #c62828; }
+        .status.warning { background: #fff8e1; color: #8a6d00; }
+
+        /* Advisory (non-fatal) parse warnings surfaced from spec.warnings.
+           Amber, distinct from the red error styling, and shown alongside a
+           rendered diagram — warnings never block. */
+        #spec-warnings { margin: 10px 0; display: none; }
+        #spec-warnings .swarn-head {
+            font-weight: bold; color: #8a6d00;
+            display: flex; align-items: center; gap: 6px; margin-bottom: 6px;
+        }
+        #spec-warnings ul { list-style: none; margin: 0; padding: 0; }
+        #spec-warnings li {
+            background: #fff8e1; border: 1px solid #ffe082; border-left: 4px solid #ffb300;
+            border-radius: 4px; padding: 8px 10px; margin-bottom: 6px;
+            font-size: 13px; color: #5f4b00; display: flex; gap: 8px; align-items: baseline;
+        }
+        #spec-warnings .swarn-code {
+            flex: 0 0 auto; font-family: 'Courier New', monospace; font-size: 11px;
+            text-transform: uppercase; letter-spacing: .02em;
+            background: #ffb300; color: #3b2f00; padding: 1px 6px; border-radius: 10px;
+        }
+        #spec-warnings .swarn-msg { flex: 1 1 auto; }
+        #spec-warnings .swarn-foot {
+            font-size: 12px; color: #8a6d00; font-style: italic; margin-top: 2px;
+        }
 
         /** TODO: Add support for smaller screen sizes */
         /**
@@ -165,6 +190,10 @@
             </div>
             <div id="status" class="status info">Ready to load Alloy graph...</div>
             <div id="error-messages"></div>
+            <!-- Advisory, non-fatal warnings read off parseLayoutSpec's result
+                 (spec.warnings). Populated by renderSpecWarnings after a
+                 successful parse; the graph renders regardless. -->
+            <div id="spec-warnings" role="status" aria-live="polite"></div>
             <div id="relation-highlighter-mount"></div>
             <div id="graph-container-wrapper">
                 <!-- Use the webcola-cnd-graph custom element -->
@@ -346,6 +375,46 @@
             statusElement.className = `status ${type}`;
         }
 
+        function escapeWarningText(s) {
+            return String(s).replace(/[&<>"']/g, (c) => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+            }[c]));
+        }
+
+        /**
+         * Demo consumer for parse warnings.
+         *
+         * `parseLayoutSpec` returns advisory, non-fatal warnings on the spec it
+         * already returns (`spec.warnings: ParseWarning[]`). Reading them is
+         * opt-in — ignore the field and nothing changes — and non-breaking: the
+         * diagram is drawn regardless. Here we surface each one, badged by its
+         * machine-readable `code` (e.g. `deprecated`) so a consumer can style or
+         * filter by category instead of scraping the message text.
+         *
+         * @param {Array<{code?: string, message?: string}>} warnings
+         */
+        function renderSpecWarnings(warnings) {
+            const panel = document.getElementById('spec-warnings');
+            if (!panel) return;
+            const list = Array.isArray(warnings) ? warnings : [];
+            if (list.length === 0) {
+                panel.style.display = 'none';
+                panel.innerHTML = '';
+                return;
+            }
+            const items = list.map((w) => {
+                const code = w && w.code ? String(w.code) : 'warning';
+                const msg = w && w.message ? String(w.message) : String(w);
+                return `<li><span class="swarn-code">${escapeWarningText(code)}</span>` +
+                       `<span class="swarn-msg">${escapeWarningText(msg)}</span></li>`;
+            }).join('');
+            panel.innerHTML =
+                `<div class="swarn-head">⚠ Spec warnings (${list.length})</div>` +
+                `<ul>${items}</ul>` +
+                `<div class="swarn-foot">Advisory only — the diagram still rendered.</div>`;
+            panel.style.display = 'block';
+        }
+
         function getSelectedEvaluatorType() {
             return document.getElementById('evaluator-select')?.value || 'sgq';
         }
@@ -489,8 +558,12 @@
                     if (window.clearAllErrors) {
                         window.clearAllErrors();
                     }
+                    // Consume the advisory warnings the parser returned (opt-in;
+                    // does not affect whether the layout below renders).
+                    renderSpecWarnings(cachedLayoutSpec.warnings);
                 } catch (error) {
                     console.error('Layout spec parse error:', error);
+                    renderSpecWarnings([]);
                     if (window.showParseError) {
                         window.showParseError(error.message, 'Layout Specification');
                     } else {
@@ -821,6 +894,7 @@
             cachedEvaluatorType = getSelectedEvaluatorType();
             cachedEvaluatorInstanceIndex = null;
             updateSequenceExplorer();
+            renderSpecWarnings([]);
             updateStatus('All state reset.', 'info');
         }
 


### PR DESCRIPTION
Consolidated PR — absorbs the former #504 (merged in). Three related pieces of the spec-editor's diagnostics/authoring experience.

## 1. Unknown-key reporting

The engine parser matches YAML by known keys and silently drops the rest, so a misspelled inner key (`showLabel` for `showLabels`, `colour` for `color`, `directon` for `directions`) rendered as a quiet no-op. The registry-driven `validateItem` now flags any key no field backs — top level and one level into each style block — as a **warning** with a Levenshtein "did you mean". Shows in the builder and the code editor.

- Cross-checked engine-accepted-but-not-a-field keys to avoid false positives (`hold`, deprecated inline forms).
- `filter` is now a real field on `attribute`/`hideField` (was engine-supported + documented, missing only from the registry).

## 2. Consumable, non-breaking warning taxonomy

- Optional **`code`** discriminator on `Diagnostic` (`unknown-key`/`unknown-type`/`deprecated`/`missing-required`/`invalid-value`) so consumers filter by category, not message text.
- **Deprecation** is a first-class `code: 'deprecated'` diagnostic naming the replacement.
- `parseLayoutSpec` returns advisory `warnings: ParseWarning[]` on the spec it already returns — opt-in, additive, never throws. Demonstrated in the Alloy demo (`webcola-demo/alloy-demo.html`).
- Legacy `validateSpytialSpec` de-drifted: derives recognized types from the registry (fixed a stale false-warning on `atomStyle`/`edgeStyle`), section-aware.

## 3. IDE-style code editor on CodeMirror 6 (was #504)

Replaces the code view's `<textarea>` + transparent-text highlight-mirror **overlay** with a real **CodeMirror 6** editor:

- `@codemirror/lang-yaml` highlighting (themed via the existing `--spytial-ed-syn-*` vars, tracks light/dark);
- `@codemirror/lint` — **squiggly underlines + hover tooltips** from the diagnostics, no overlay;
- `code-positioning.ts` resolves each diagnostic to a character range via a position-aware parse (`eemeli/yaml`), so a squiggle lands on the exact token; `lintYaml()` parses + validates + positions from the same text (self-contained, reflects what's typed).

Verified live: yellow gutter triangle, squiggles under a deprecated `atomColor` and a misspelled `showLabel`, hover tooltip showing the message + `deprecated` label.

## Codex review fixes (this PR)

- **`fromYamlNode` blind spot** — the codec now preserves the raw inner body on `SpecItem.sourceBody`, so the unknown-key check flags group typos (`naem`) that curated ingestion had dropped.
- **Nested routing collision** — nested unknown keys carry a parent-qualified `fieldKey` (`fillStyle.width`), so they can't mis-attach to a same-named field in a sibling block; the positioner navigates the dotted path to keep squiggles on the exact token.

## Tests

Full suite green — **2010 passing** (oracle/z3 excluded per baseline). Existing CodeView/CndLayoutInterface/integration suites updated to drive CodeMirror via its `EditorView` API; new positioning + taxonomy + de-drift + parser-warning tests.

New deps: `@codemirror/{state,view,language,lint,lang-yaml,commands}`, `@lezer/highlight`, `yaml` (eemeli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)