### PR TITLE
feat(spec-editor): inbound spec push, teardown, and top-level section round-trip (#505 items 3a+4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/browser/spytial-core-complete.global.d.ts",

--- a/src/spec-editor/core/spec-document.ts
+++ b/src/spec-editor/core/spec-document.ts
@@ -90,6 +90,14 @@ function cloneState(state: SpecDocumentState): SpecDocumentState {
     constraints: state.constraints.map(cloneItem),
     directives: state.directives.map(cloneItem),
     ...(state.headerComment !== undefined ? { headerComment: state.headerComment } : {}),
+    ...(state.otherSections !== undefined
+      ? {
+          otherSections: state.otherSections.map((section) => ({
+            key: section.key,
+            value: cloneValue(section.value),
+          })),
+        }
+      : {}),
   };
 }
 
@@ -104,6 +112,10 @@ function freezeState(state: SpecDocumentState): Readonly<SpecDocumentState> {
   });
   Object.freeze(state.constraints);
   Object.freeze(state.directives);
+  if (state.otherSections !== undefined) {
+    state.otherSections.forEach((section) => Object.freeze(section));
+    Object.freeze(state.otherSections);
+  }
   return Object.freeze(state);
 }
 

--- a/src/spec-editor/core/types.ts
+++ b/src/spec-editor/core/types.ts
@@ -119,9 +119,24 @@ export interface ItemDefinition {
 
 // ---- document state ----
 
+/** One preserved top-level YAML section the editor does not interpret. */
+export interface OtherSection {
+  /** top-level YAML key, e.g. 'projections' or 'temporal' */
+  key: string;
+  /** the section's parsed value, re-emitted verbatim on serialize */
+  value: unknown;
+}
+
 export interface SpecDocumentState {
   constraints: SpecItem[];
   directives: SpecItem[];
   /** comments/blank-line structure not attached to an item, preserved on serialize */
   headerComment?: string;
+  /**
+   * Top-level sections other than `constraints:`/`directives:` (e.g. a host's
+   * `projections:`/`temporal:` blocks), preserved in document order and
+   * re-emitted after the known sections. The editor never edits these — it
+   * just doesn't delete content it doesn't understand.
+   */
+  otherSections?: OtherSection[];
 }

--- a/src/spec-editor/core/yaml-codec.ts
+++ b/src/spec-editor/core/yaml-codec.ts
@@ -363,6 +363,16 @@ export function parseYamlToState(yamlStr: string): SpecDocumentState {
   if (headerComment) {
     state.headerComment = headerComment;
   }
+
+  // Preserve top-level sections the editor doesn't interpret (a host's
+  // `projections:`/`temporal:` blocks, …) in document order, so a round trip
+  // through the editor never deletes them.
+  const otherSections = Object.entries(root)
+    .filter(([key]) => key !== 'constraints' && key !== 'directives')
+    .map(([key, value]) => ({ key, value }));
+  if (otherSections.length > 0) {
+    state.otherSections = otherSections;
+  }
   return state;
 }
 
@@ -507,6 +517,18 @@ export function serializeStateToYaml(state: SpecDocumentState): string {
       }
       lines.push(...emitItemLines(item));
     }
+  }
+
+  // Preserved uninterpreted sections come last, each dumped whole. Emission is
+  // semantic, not byte-for-byte — same contract as unknown item nodes.
+  for (const section of state.otherSections ?? []) {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    const dumped = jsyaml
+      .dump({ [section.key]: section.value }, { lineWidth: -1, sortKeys: false })
+      .trimEnd();
+    lines.push(...dumped.split('\n'));
   }
 
   return lines.length > 0 ? `${lines.join('\n')}\n` : '';

--- a/src/spec-editor/index.ts
+++ b/src/spec-editor/index.ts
@@ -17,6 +17,7 @@ export type {
   Diagnostic,
   ItemDefinition,
   SpecDocumentState,
+  OtherSection,
 } from './core/types';
 
 // ---- document ----

--- a/tests/cnd-layout-interface-integration.test.tsx
+++ b/tests/cnd-layout-interface-integration.test.tsx
@@ -4,8 +4,10 @@ import { render, within, screen, act, waitFor, cleanup } from '@testing-library/
 import { EditorView } from '@codemirror/view'
 import {
   mountCndLayoutInterface,
+  unmountCndLayoutInterface,
   CndLayoutStateManager,
   InstanceStateManager,
+  DataAPI,
 } from '../webcola-demo/react-component-integration'
 import userEvent, { UserEvent } from '@testing-library/user-event'
 import { createRoot, Root } from 'react-dom/client'
@@ -258,6 +260,64 @@ directives:
       expect(currentSpec).toContain('orientation')
       expect(currentSpec).toContain('attribute')
       expect(currentSpec).toContain('flag')
+    })
+
+    it('DataAPI.updateSpec replaces the mounted editor contents in place', async () => {
+      // Push a spec from outside React, the way a host's "suggest layout"
+      // feature would via window.updateSpecFromReact — no remount involved.
+      await act(async () => {
+        DataAPI.updateSpec(testYaml)
+      })
+
+      // The code view (CodeMirror) reflects the pushed spec…
+      await waitFor(() => {
+        expect(getCmView().state.doc.toString().trim()).toBe(testYaml.trim())
+      })
+      // …and readers get the pushed spec back.
+      expect(DataAPI.getCurrentCndSpec()?.trim()).toBe(testYaml.trim())
+    })
+
+    it('a pushed spec reaches the builder view and legacy readers live', async () => {
+      const user = userEvent.setup()
+      await switchToBuilderView(user)
+
+      await act(async () => {
+        DataAPI.updateSpec(testYaml)
+      })
+
+      // The builder re-renders in place with the pushed items.
+      const testContainer = screen.getByTestId(
+        'test-cnd-layout-interface',
+      ) as HTMLElement
+      const constraintsList = within(testContainer).getByRole('list', {
+        name: 'Constraints List',
+      })
+      await waitFor(() => {
+        expect(within(constraintsList).getAllByText('Orientation')).toHaveLength(2)
+      })
+
+      // The deprecated constraint/directive arrays were re-synced too, so
+      // getCurrentCndSpec (which generates from them in No-Code view) does not
+      // serve a stale spec.
+      const currentSpec = DataAPI.getCurrentCndSpec()
+      expect(currentSpec).toContain('orientation')
+      expect(currentSpec).toContain('flag')
+    })
+
+    it('unmountCndLayoutInterface tears down the mounted root', async () => {
+      expect(container.childElementCount).toBeGreaterThan(0)
+
+      let unmounted = false
+      act(() => {
+        unmounted = unmountCndLayoutInterface('test-cnd-layout-interface')
+      })
+      expect(unmounted).toBe(true)
+      expect(container.childElementCount).toBe(0)
+
+      // A second call reports nothing to unmount, and pushing a spec after
+      // teardown is safe (the wrapper unsubscribed on unmount).
+      expect(unmountCndLayoutInterface('test-cnd-layout-interface')).toBe(false)
+      expect(() => DataAPI.updateSpec(testYaml)).not.toThrow()
     })
 
     it('should reflect builder edits when retrieving the spec after a change', async () => {

--- a/tests/spec-editor-codec.test.ts
+++ b/tests/spec-editor-codec.test.ts
@@ -25,6 +25,7 @@ function normalizeState(state: Readonly<SpecDocumentState>): unknown {
     constraints: state.constraints.map(normalizeItem),
     directives: state.directives.map(normalizeItem),
     headerComment: state.headerComment ?? null,
+    otherSections: state.otherSections ?? null,
   };
 }
 
@@ -298,6 +299,70 @@ describe('yaml-codec — unknown type preservation', () => {
     const state = parseYamlToState(yaml);
     expect(state.directives[0].type).toBe('wibble');
     expect(state.directives[0].raw).toEqual({ wibble: { x: 9 } });
+  });
+});
+
+describe('yaml-codec — unknown top-level section preservation', () => {
+  const FULL_CND = `projections:
+  - sig: State
+    orderBy: next
+
+constraints:
+  - orientation:
+      selector: left
+      directions:
+        - left
+
+temporal:
+  policy: stability
+`;
+
+  it('preserves projections/temporal blocks across a round trip', () => {
+    const state = parseYamlToState(FULL_CND);
+    expect(state.otherSections).toEqual([
+      { key: 'projections', value: [{ sig: 'State', orderBy: 'next' }] },
+      { key: 'temporal', value: { policy: 'stability' } },
+    ]);
+
+    const out = serializeStateToYaml(state);
+    const reparsed = parseYamlToState(out);
+    expect(normalizeState(reparsed)).toEqual(normalizeState(state));
+    // The constraint section still round-trips alongside.
+    expect(reparsed.constraints).toHaveLength(1);
+  });
+
+  it('emits preserved sections even when there are no constraints/directives', () => {
+    const state = parseYamlToState('temporal:\n  policy: stability\n');
+    const out = serializeStateToYaml(state);
+    expect(parseYamlToState(out).otherSections).toEqual([
+      { key: 'temporal', value: { policy: 'stability' } },
+    ]);
+  });
+
+  it('keeps preserved sections through document mutations and undo', () => {
+    const doc = SpecDocument.fromYaml(FULL_CND);
+    const added = doc.addItem('directive', 'flag');
+    doc.updateItem(added.id, { params: { flag: 'hideDisconnectedBuiltIns' } });
+    expect(doc.toYaml()).toContain('projections:');
+    expect(doc.toYaml()).toContain('temporal:');
+
+    doc.undo();
+    doc.undo();
+    expect(doc.toYaml()).toContain('projections:');
+    expect(doc.getState().otherSections).toHaveLength(2);
+  });
+
+  it('replaceFromYaml swaps preserved sections with the new document', () => {
+    const doc = SpecDocument.fromYaml(FULL_CND);
+    doc.replaceFromYaml('directives:\n  - flag: hideDisconnectedBuiltIns\n');
+    expect(doc.getState().otherSections).toBeUndefined();
+    expect(doc.toYaml()).not.toContain('projections:');
+  });
+
+  it('is deterministic across repeated round trips', () => {
+    const first = serializeStateToYaml(parseYamlToState(FULL_CND));
+    const second = serializeStateToYaml(parseYamlToState(first));
+    expect(second).toBe(first);
   });
 });
 

--- a/webcola-demo/react-component-integration.tsx
+++ b/webcola-demo/react-component-integration.tsx
@@ -10,7 +10,7 @@ import { createRoot } from 'react-dom/client';
 import { CndLayoutInterface } from '../src/components/CndLayoutInterface';
 import { InstanceBuilder } from '../src/components/InstanceBuilder/InstanceBuilder';
 import { ConstraintData, DirectiveData } from '../src/components/NoCodeView/interfaces';
-import { generateLayoutSpecYaml } from '../src/components/NoCodeView';
+import { generateLayoutSpecYaml, parseLayoutSpecToData } from '../src/components/NoCodeView';
 import { createEmptyAlloyDataInstance } from '../src/data-instance/alloy-data-instance';
 import { IInputDataInstance } from '../src/data-instance/interfaces';
 import { ErrorMessageContainer, ErrorStateManager, SelectorErrorDetail } from '../src/components/ErrorMessageModal/index'
@@ -95,6 +95,7 @@ export class CndLayoutStateManager {
   private directives: DirectiveData[] = [];
   private yamlValue: string = '';
   private isNoCodeView: boolean = false;
+  private yamlChangeCallbacks: ((yamlValue: string) => void)[] = [];
 
   public constructor() {}
 
@@ -152,6 +153,43 @@ export class CndLayoutStateManager {
    */
   public setYamlValue(yamlValue: string): void {
     this.yamlValue = yamlValue;
+  }
+
+  /**
+   * Push a new YAML spec from OUTSIDE the mounted editor (host code such as a
+   * "suggest layout" feature). Unlike `setYamlValue` — the editor's own outward
+   * sync, which stays silent so edits don't echo back into the editor — this
+   * notifies `onYamlValueChange` subscribers. A mounted editor picks the spec
+   * up live through the controlled SpecEditor's external-replace path: no
+   * remount, view/scroll preserved, and the change lands as one undo step.
+   * @param yamlValue - New YAML string
+   * @public
+   */
+  public updateYamlValue(yamlValue: string): void {
+    this.yamlValue = yamlValue;
+    this.yamlChangeCallbacks.forEach((callback) => {
+      try {
+        callback(yamlValue);
+      } catch (error) {
+        console.error('Error in YAML change callback:', error);
+      }
+    });
+  }
+
+  /**
+   * Register a callback for external YAML pushes (see `updateYamlValue`).
+   * Mirrors `InstanceStateManager.onInstanceChange`.
+   * @param callback - Function to call when a spec is pushed externally
+   * @returns Unsubscribe function that removes the callback
+   * @public
+   */
+  public onYamlValueChange(callback: (yamlValue: string) => void): () => void {
+    this.yamlChangeCallbacks.push(callback);
+    return () => {
+      this.yamlChangeCallbacks = this.yamlChangeCallbacks.filter(
+        (cb) => cb !== callback,
+      );
+    };
   }
 
   /**
@@ -482,6 +520,30 @@ const CndLayoutInterfaceWrapper: React.FC<{ config?: CndLayoutMountConfig }> = (
     [],
   );
 
+  // Inbound spec pushes (DataAPI.updateSpec / window.updateSpecFromReact):
+  // route into local state so the controlled SpecEditor takes the new value
+  // through its external-replace path — no remount, one undo step. The
+  // deprecated constraint/directive arrays are best-effort re-synced too, so
+  // legacy readers (getCurrentCndSpec in No-Code view) don't go stale.
+  useEffect(
+    () =>
+      stateManager.onYamlValueChange((yamlValue) => {
+        setYamlValue(yamlValue);
+        try {
+          const parsed = parseLayoutSpecToData(yamlValue);
+          setConstraints(parsed.constraints);
+          setDirectives(parsed.directives);
+        } catch {
+          // Invalid YAML: leave the legacy arrays untouched; SpecEditor
+          // surfaces the parse error in the code view.
+        }
+        window.dispatchEvent(
+          new CustomEvent('cnd-spec-changed', { detail: yamlValue }),
+        );
+      }),
+    [stateManager],
+  );
+
   // Initialize state manager with config on mount
   useEffect(() => {
     if (config) {
@@ -783,12 +845,19 @@ const ReplWithVisualizationWrapper: React.FC<{ config?: ReplWithVisualizationMou
  * 
  * @public
  */
+/**
+ * React roots created by `mountCndLayoutInterface`, keyed by container id, so
+ * `unmountCndLayoutInterface` can tear them down and a re-mount into the same
+ * container replaces the previous root instead of leaking it.
+ */
+const cndLayoutRoots = new Map<string, ReturnType<typeof createRoot>>();
+
 export function mountCndLayoutInterface(
   containerId: string = 'webcola-cnd-container',
   config?: CndLayoutMountConfig
 ): boolean {
   const container = document.getElementById(containerId);
-  
+
   if (!container) {
     console.error(`CnD Layout Interface: Container '${containerId}' not found`);
     return false;
@@ -805,7 +874,10 @@ export function mountCndLayoutInterface(
   }
 
   try {
+    // Mounting into a container that already has a live root replaces it.
+    unmountCndLayoutInterface(containerId);
     const root = createRoot(container);
+    cndLayoutRoots.set(containerId, root);
     root.render(<CndLayoutInterfaceWrapper config={config} />);
 
     if (config) {
@@ -823,6 +895,32 @@ export function mountCndLayoutInterface(
     console.error('Failed to mount CnD Layout Interface:', error);
     return false;
   }
+}
+
+/**
+ * Unmount a CnD Layout Interface previously mounted with
+ * `mountCndLayoutInterface`, releasing its React root and state-manager
+ * subscriptions. Hosts that re-key or tear down their embedding should call
+ * this instead of abandoning the root.
+ *
+ * @param containerId - DOM element ID the interface was mounted into
+ * @returns True if a mounted root existed for the container id
+ * @public
+ */
+export function unmountCndLayoutInterface(
+  containerId: string = 'webcola-cnd-container'
+): boolean {
+  const root = cndLayoutRoots.get(containerId);
+  if (!root) {
+    return false;
+  }
+  cndLayoutRoots.delete(containerId);
+  try {
+    root.unmount();
+  } catch (error) {
+    console.error('Failed to unmount CnD Layout Interface:', error);
+  }
+  return true;
 }
 
 /**
@@ -1740,6 +1838,21 @@ export const DataAPI = {
   },
 
   /**
+   * Push a new CND spec into the mounted layout editor programmatically.
+   * The editor replaces its document in place — no remount, Builder/Code view
+   * and scroll preserved, and the change lands in the editor's undo history.
+   * Mirror of `updateInstance` for the spec side.
+   * @param yamlValue - Layout-spec YAML (constraints/directives)
+   */
+  updateSpec: (yamlValue: string): void => {
+    try {
+      CndLayoutStateManager.getInstance().updateYamlValue(yamlValue);
+    } catch (error) {
+      console.error('Error updating CND spec:', error);
+    }
+  },
+
+  /**
    * Get current Pyret data instance from PyretReplInterface component
    * @returns Current Pyret data instance or undefined if not available
    */
@@ -1824,7 +1937,8 @@ export const DataAPI = {
 export const CnDCore = {
   // Mounting functions
   mountCndLayoutInterface,
-  mountInstanceBuilder, 
+  unmountCndLayoutInterface,
+  mountInstanceBuilder,
   mountErrorMessageModal,
   mountAllComponents,
   mountEvaluatorRepl,
@@ -1879,6 +1993,7 @@ if (typeof window !== 'undefined') {
   
   // Legacy compatibility - expose individual functions
   globalWindow.mountCndLayoutInterface = mountCndLayoutInterface;
+  globalWindow.unmountCndLayoutInterface = unmountCndLayoutInterface;
   globalWindow.mountInstanceBuilder = mountInstanceBuilder;
   globalWindow.mountErrorMessageModal = mountErrorMessageModal;
   globalWindow.mountIntegratedComponents = mountAllComponents;
@@ -1901,6 +2016,9 @@ if (typeof window !== 'undefined') {
   // Push a freshly parsed data instance to the shared state so the spec
   // editor picks up domain awareness (dropdowns, completions, warnings).
   globalWindow.updateInstanceFromReact = DataAPI.updateInstance;
+  // Push a new spec into the mounted editor (e.g. a host's "suggest layout"
+  // feature) without remounting it.
+  globalWindow.updateSpecFromReact = DataAPI.updateSpec;
   
   // Pyret-specific data functions for legacy compatibility
   globalWindow.getCurrentPyretInstanceFromReact = DataAPI.getCurrentPyretInstance;


### PR DESCRIPTION
Implements items 4 and 3a of #505 — the two enabling primitives hosts need before the bigger embedding work (ESM export, `LayoutAssistant`).

## Item 4 — inbound spec push + teardown (additive)

- `CndLayoutStateManager.updateYamlValue(yaml)` + `onYamlValueChange(cb)` — external pushes notify subscribers, mirroring `InstanceStateManager.onInstanceChange`. `setYamlValue` stays silent (it's the editor's own outward sync; notifying there would echo edits back into the editor).
- The mounted wrapper subscribes and routes pushes through the controlled `SpecEditor`'s existing external-replace path: the document updates **in place** — no remount, Builder/Code view + scroll preserved, one undo step. The deprecated constraint/directive arrays are best-effort re-synced so `getCurrentCndSpec` doesn't serve a stale spec in No-Code view.
- `DataAPI.updateSpec` / `window.updateSpecFromReact` expose the push (mirror of `updateInstance` / `updateInstanceFromReact`).
- `unmountCndLayoutInterface(id)` tears down a mounted root; `mountCndLayoutInterface` into a container that already has a root now replaces it instead of leaking it.

This lets Cope and Drag delete its suggest-layout remount hack (sidprasad/copeanddrag#141, Phase 1).

## Item 3a — preserve unknown top-level YAML sections (behavior fix)

The codec's state was `{constraints, directives}`, so top-level sections the editor doesn't interpret (a host's `projections:` / `temporal:` blocks) were silently deleted on the first serialize. Now:

- `parseYamlToState` captures every other top-level key into `state.otherSections` (document order).
- `serializeStateToYaml` re-emits them after the known sections — semantic, not byte-for-byte, same contract as unknown item nodes.
- `SpecDocument` clones/freezes them through undo/redo and snapshots; `OtherSection` is exported from the spec-editor barrel.
- **Demo audit** (per the #505 constraint): no in-repo demo feeds such sections into the editor, so nothing relied on the dropping.

## Multi-consumer constraints (per #505)

Everything is additive — new methods, new globals, new optional state field. Existing hosts (VS Code webview, Pyret REPL, plain-HTML demos) run unchanged with zero code edits. Version bumped 3.3.0 → 3.4.0.

## Verification

- Full suite: **2045 tests / 143 files, all passing** (includes 3 new integration tests for push/teardown and 5 new codec round-trip tests; `normalizeState` in the codec tests now also compares `otherSections`, so the property-based round-trip suite covers the new field).
- `npm run build:components` clean (bundle + DTS).
- `tsc --noEmit`: 73 pre-existing errors on main, 73 after — none in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
