### PR TITLE
SpecEditor: LayoutAssistant — whole-spec suggestion hook (#505 item 2)

### DIFF
--- a/docs/SPEC_EDITOR.md
+++ b/docs/SPEC_EDITOR.md
@@ -84,6 +84,7 @@ Defined in `src/spec-editor/ui/SpecEditor.tsx`.
 | `domain` | `DomainSchema` | `undefined` | Precomputed domain schema. **Wins over `instance`** if both are given. |
 | `theme` | `SpecEditorTheme \| string` | `undefined` | Either a partial token object (only the keys you set are applied as inline CSS variables on the editor root), or the **name** of a registered theme — `'light'`, `'dark'`, or anything added via `registerSpecEditorThemes` — mirroring `webcola-cnd-graph`'s by-name `theme` attribute. See [Theming](#theming-guide-hook-1). |
 | `selectorAssistant` | `SelectorAssistant` | `undefined` | Pluggable completion / synthesis / review hook for selector fields. See [Selector assistance](#selector-assistance-guide-hook-2). |
+| `layoutAssistant` | `LayoutAssistant` | `undefined` | Pluggable **whole-spec** suggestion hook. Providing `suggest` adds a Suggest button to the toolbar. See [Layout assistance](#layout-assistance-guide-hook-3). |
 | `density` | `'compact' \| 'comfortable'` | `'compact'` | Row padding / font sizing. `compact` is noticeably tighter than the old cards. |
 | `syntaxHighlighting` | `boolean` | `true` | Syntax highlighting in the code view and selector fields. Both use a mirror overlay (highlighted `<pre>` behind a transparent-text textarea, scroll-synced, with ligatures/kerning normalized on both elements). If a host's fonts or zoom ever misalign the overlay, set this to `false` to render plain visible text with no mirror — the escape hatch that the old, removed highlighter never had. |
 | `defaultView` | `'builder' \| 'code'` | `'builder'` | The view shown initially when the editor owns its own view state (i.e. `view` is not passed). |
@@ -122,8 +123,9 @@ in sync on a best-effort basis** and are no longer a source of truth:
 | `setDirectives` | Same best-effort sync as `setConstraints`, with `parsed.directives`. |
 
 New `SpecEditorProps` the wrapper accepts and forwards: `instance`, `domain`,
-`theme`, `selectorAssistant`, `density`, `onDiagnostics`, `className`,
-`disabled`, and `'aria-label'` (default `'CND Layout Specification Interface'`).
+`theme`, `selectorAssistant`, `layoutAssistant`, `density`, `onDiagnostics`,
+`className`, `disabled`, and `'aria-label'` (default
+`'CND Layout Specification Interface'`).
 It always forwards `defaultView: 'builder'`. It does not expose `defaultView` as
 its own prop — view selection goes through `isNoCodeView`.
 
@@ -464,6 +466,85 @@ the same label/insert text as a built-in suppresses the built-in. Atom
 completions from the domain are capped (`MAX_ATOM_COMPLETIONS = 200`) to keep the
 popup responsive on large instances; supply an `assistant.complete()` if you need
 instance-aware results beyond the cap.
+
+## Layout assistance guide (hook 3)
+
+Where `SelectorAssistant` assists one field, `LayoutAssistant` (in
+`src/spec-editor/domain/layout-assistant.ts`) proposes an **entire spec**. The
+host supplies the policy; the editor owns the affordance.
+
+```ts
+export interface LayoutAssistant {
+  suggest?(ctx: LayoutAssistContext): Promise<LayoutSuggestionResult>;
+}
+
+export interface LayoutAssistContext {
+  domain?: DomainSchema;          // as resolved by the editor
+  instance?: IInputDataInstance;  // when the host passed one
+  currentYaml: string;            // full current spec text
+}
+
+export interface LayoutSuggestionResult {
+  yaml: string;                                       // the proposed spec
+  suggestions?: readonly LayoutSuggestionDetail[];    // optional panel detail
+  notes?: readonly string[];                          // optional remarks
+}
+
+export interface LayoutSuggestionDetail {
+  id: string;                                          // stable, unique per result
+  rationale?: string;
+  confidence?: 'high' | 'medium' | 'low';
+  outcome?: 'applied' | 'weakened' | 'omitted';
+}
+```
+
+The context is deliberately those three fields and nothing else — no Alloy,
+Forge, or other host vocabulary — so any host can plug in any suggester
+(heuristic, model, synthesis engine). The per-suggestion metadata is optional
+and rendered generically; a suggester with no such vocabulary returns `{ yaml }`
+alone and the panel just confirms that a suggestion was applied.
+
+### What the editor does with a result
+
+1. **Applies the YAML through the document** — `replaceFromYaml` + the normal
+   emit path. That means it is **one undo step**, the builder repopulates in
+   place (no remount, no lost scroll or view), diagnostics re-run, and the host
+   sees it as an ordinary `onChange`. A host whose "apply" is a separate action
+   therefore gets the suggestion in its editor draft and nothing else — the same
+   mental model as a hand edit.
+2. **Renders the rationale** in a read-only suggestions panel below the toolbar,
+   dismissable, so the reasoning isn't discarded the way a bare YAML swap
+   discards it.
+
+Failure is a normal outcome. A rejected promise — or proposal YAML that does not
+parse — leaves the document **untouched** and surfaces the message in an alert
+above the editor body. Results that arrive after the editor unmounts, or after
+the user dismisses the panel, are dropped.
+
+```tsx
+const layoutAssistant: LayoutAssistant = {
+  async suggest({ domain, instance, currentYaml }) {
+    const draft = await analyze(instance, currentYaml, domain);
+    return {
+      yaml: draft.spec,
+      suggestions: draft.rules.map((r) => ({
+        id: r.id,
+        rationale: r.why,
+        confidence: r.confidence,
+        outcome: r.outcome,
+      })),
+      notes: draft.notes,
+    };
+  },
+};
+
+<SpecEditor value={yaml} onChange={setYaml} instance={instance} layoutAssistant={layoutAssistant} />;
+```
+
+Accepting or rejecting individual suggestions is deliberately **not** in this
+contract: recomposing a spec from a subset is host policy (dependencies between
+rules, weaker fallbacks), not something the editor can do generically. A host
+that wants it can expose its own panel and drive the editor through `value`.
 
 ## Adding a new constraint/directive type
 

--- a/docs/SPEC_EDITOR_REDESIGN.md
+++ b/docs/SPEC_EDITOR_REDESIGN.md
@@ -171,6 +171,34 @@ export interface SelectorAssistant {
   review?(ctx: SelectorAssistContext, value: string): Promise<Diagnostic[]>;
 }
 
+// ---- domain/layout-assistant.ts (HOOK: whole-spec suggestion) ----
+export interface LayoutAssistContext {
+  domain?: DomainSchema;
+  instance?: IInputDataInstance;
+  /** full current spec YAML, so a suggester can extend rather than replace */
+  currentYaml: string;
+}
+export interface LayoutSuggestionDetail {
+  id: string;                       // stable + unique per result; the React key
+  rationale?: string;
+  confidence?: 'high' | 'medium' | 'low';
+  outcome?: 'applied' | 'weakened' | 'omitted';
+}
+export interface LayoutSuggestionResult {
+  yaml: string;
+  suggestions?: readonly LayoutSuggestionDetail[];
+  notes?: readonly string[];
+}
+export interface LayoutAssistant {
+  /** whole-spec suggestion. Powers the Suggest affordance in the toolbar. */
+  suggest?(ctx: LayoutAssistContext): Promise<LayoutSuggestionResult>;
+}
+// Applied via `replaceFromYaml` + emit — one undo step, builder refreshed in
+// place, re-validated, and surfaced to the host as an ordinary onChange. A
+// rejection (or unparseable YAML) leaves the document untouched. The optional
+// per-suggestion metadata renders in a read-only panel; accept/reject of
+// individual suggestions is host policy, not part of this contract.
+
 // ---- ui/theme.ts (HOOK: appearance customization) ----
 /** Every visual knob is a token; tokens become --spytial-ed-* custom properties. */
 export interface SpecEditorTheme {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/types/index.d.ts",

--- a/src/components/CndLayoutInterface.tsx
+++ b/src/components/CndLayoutInterface.tsx
@@ -4,6 +4,7 @@ import type {
   SpecEditorProps,
   Diagnostic,
   DomainSchema,
+  LayoutAssistant,
   SelectorAssistant,
   SpecEditorThemeInput,
 } from '../spec-editor';
@@ -57,6 +58,12 @@ export interface CndLayoutInterfaceProps {
   theme?: SpecEditorThemeInput;
   /** Selector-writing assistant hook. */
   selectorAssistant?: SelectorAssistant;
+  /**
+   * Whole-spec suggestion hook. Supplying `suggest` adds a Suggest button to
+   * the editor toolbar; the proposal is applied to the document (one undo step)
+   * and surfaced through `onChange` like any other edit.
+   */
+  layoutAssistant?: LayoutAssistant;
   /** Row density. */
   density?: 'compact' | 'comfortable';
   /** Syntax highlighting in code view + selector fields (default true). */
@@ -105,6 +112,7 @@ const CndLayoutInterface: React.FC<CndLayoutInterfaceProps> = ({
   domain,
   theme,
   selectorAssistant,
+  layoutAssistant,
   density,
   syntaxHighlighting,
   onDiagnostics,
@@ -164,6 +172,7 @@ const CndLayoutInterface: React.FC<CndLayoutInterfaceProps> = ({
     if (domain !== undefined) props.domain = domain;
     if (theme !== undefined) props.theme = theme;
     if (selectorAssistant !== undefined) props.selectorAssistant = selectorAssistant;
+    if (layoutAssistant !== undefined) props.layoutAssistant = layoutAssistant;
     if (density !== undefined) props.density = density;
     if (syntaxHighlighting !== undefined)
       props.syntaxHighlighting = syntaxHighlighting;
@@ -179,6 +188,7 @@ const CndLayoutInterface: React.FC<CndLayoutInterfaceProps> = ({
     domain,
     theme,
     selectorAssistant,
+    layoutAssistant,
     density,
     syntaxHighlighting,
     onDiagnostics,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,6 +42,19 @@ export type {
 // Spec authoring (embeds the CodeMirror-based SpecEditor)
 export { CndLayoutInterface } from './CndLayoutInterface';
 export type { CndLayoutInterfaceProps } from './CndLayoutInterface';
+// Assistant hooks, re-exported so React hosts don't need the spec-editor entry
+// just to type the objects they pass to CndLayoutInterface.
+export type {
+  SelectorAssistant,
+  SelectorAssistContext,
+  Completion,
+  LayoutAssistant,
+  LayoutAssistContext,
+  LayoutSuggestionResult,
+  LayoutSuggestionDetail,
+  LayoutSuggestionConfidence,
+  LayoutSuggestionOutcome,
+} from '../spec-editor';
 export { generateLayoutSpecYaml, parseLayoutSpecToData } from './NoCodeView';
 export type { ConstraintData, DirectiveData } from './NoCodeView';
 

--- a/src/spec-editor/domain/layout-assistant.ts
+++ b/src/spec-editor/domain/layout-assistant.ts
@@ -1,0 +1,70 @@
+/**
+ * Whole-spec suggestion hook (HOOK 3).
+ *
+ * Where {@link SelectorAssistant} assists one selector field, a
+ * `LayoutAssistant` proposes an entire layout. Integrators provide the policy
+ * — a heuristic analyzer, a model, a synthesis engine — and the editor owns the
+ * affordance: a toolbar button, the apply-through-document semantics (so the
+ * suggestion is one undo step and refreshes the builder in place), and a
+ * read-only panel explaining what the suggester did.
+ *
+ * The contract is deliberately domain-agnostic. The context is
+ * `{domain, instance, currentYaml}` and nothing else; the optional
+ * per-suggestion metadata (`rationale`, `confidence`, `outcome`) is rendered
+ * generically, and a suggester with no such vocabulary simply omits it. Any
+ * host can plug in any suggester.
+ *
+ * Framework-agnostic — no React.
+ */
+
+import type { IInputDataInstance } from '../../data-instance/interfaces';
+import type { DomainSchema } from './domain-schema';
+
+export interface LayoutAssistContext {
+  /** Domain awareness, as resolved by the editor (`domain` prop ?? extracted from `instance`). */
+  domain?: DomainSchema;
+  /** The live data instance, when the host passed one. */
+  instance?: IInputDataInstance;
+  /** The full current spec text, so a suggester can extend rather than replace. */
+  currentYaml: string;
+}
+
+/** How much the suggester trusts an individual suggestion. */
+export type LayoutSuggestionConfidence = 'high' | 'medium' | 'low';
+
+/**
+ * What became of a suggestion in the returned YAML. Suggesters that validate
+ * their own output use this to admit a fallback (`weakened`) or a drop
+ * (`omitted`) instead of silently shipping a shorter spec.
+ */
+export type LayoutSuggestionOutcome = 'applied' | 'weakened' | 'omitted';
+
+/** One line of the suggestions panel. All fields beyond `id` are optional. */
+export interface LayoutSuggestionDetail {
+  /** Stable identifier, unique within a result. Used as the React key. */
+  id: string;
+  /** Why the suggester proposed this. Rendered as the body of the row. */
+  rationale?: string;
+  confidence?: LayoutSuggestionConfidence;
+  outcome?: LayoutSuggestionOutcome;
+}
+
+export interface LayoutSuggestionResult {
+  /** The proposed spec. Replaces the document wholesale, as one undo step. */
+  yaml: string;
+  /** Per-suggestion detail for the panel. Omit for an opaque suggestion. */
+  suggestions?: readonly LayoutSuggestionDetail[];
+  /** Result-level remarks (e.g. "2 suggestions used a weaker fallback"). */
+  notes?: readonly string[];
+}
+
+export interface LayoutAssistant {
+  /**
+   * Propose a whole spec for the current data. Powers the toolbar's Suggest
+   * affordance; the button is hidden entirely when this member is absent.
+   *
+   * Rejecting is a normal outcome — the editor surfaces the error message and
+   * leaves the document untouched.
+   */
+  suggest?(ctx: LayoutAssistContext): Promise<LayoutSuggestionResult>;
+}

--- a/src/spec-editor/index.ts
+++ b/src/spec-editor/index.ts
@@ -75,6 +75,16 @@ export type {
   Completion,
 } from './domain/assistant';
 
+// ---- layout assistance contract (HOOK 3) ----
+export type {
+  LayoutAssistant,
+  LayoutAssistContext,
+  LayoutSuggestionResult,
+  LayoutSuggestionDetail,
+  LayoutSuggestionConfidence,
+  LayoutSuggestionOutcome,
+} from './domain/layout-assistant';
+
 // ---- built-in completions (WP2) ----
 export {
   getSelectorKeywordCompletions,
@@ -111,6 +121,9 @@ export { CodeView } from './ui/CodeView';
 
 export type { BuilderViewProps } from './ui/BuilderView';
 export { BuilderView } from './ui/BuilderView';
+
+export type { SuggestionsPanelProps } from './ui/SuggestionsPanel';
+export { SuggestionsPanel } from './ui/SuggestionsPanel';
 
 export type { SpecEditorProps } from './ui/SpecEditor';
 export { SpecEditor } from './ui/SpecEditor';

--- a/src/spec-editor/ui/SpecEditor.tsx
+++ b/src/spec-editor/ui/SpecEditor.tsx
@@ -23,6 +23,11 @@
  * with `assistant.complete()`; `assistant.synthesize` powers the ✨ affordance;
  * `assistant.review()` results are merged into the field diagnostics (debounced,
  * stale-dropped, failures swallowed).
+ *
+ * Layout assistance: `layoutAssistant.suggest` powers the toolbar's Suggest
+ * button. The proposal is applied through `replaceFromYaml` + `emit`, so it is
+ * one undo step, refreshes the builder in place, and re-validates — the same
+ * path a code-view edit takes. Its rationale renders in the suggestions panel.
  */
 
 import React, {
@@ -49,6 +54,11 @@ import {
   mergeCompletions,
 } from '../domain/completions';
 import type { Completion, SelectorAssistant, SelectorAssistContext } from '../domain/assistant';
+import type {
+  LayoutAssistant,
+  LayoutAssistContext,
+  LayoutSuggestionResult,
+} from '../domain/layout-assistant';
 import type { IInputDataInstance } from '../../data-instance/interfaces';
 import {
   SpecEditorThemeInput,
@@ -57,6 +67,7 @@ import {
 } from './theme';
 import { BuilderView } from './BuilderView';
 import { CodeView } from './CodeView';
+import { SuggestionsPanel } from './SuggestionsPanel';
 import { lintYaml } from '../core/code-positioning';
 import type { SelectorFieldExtras } from './FieldRenderer';
 
@@ -76,6 +87,11 @@ export interface SpecEditorProps {
    */
   theme?: SpecEditorThemeInput;
   selectorAssistant?: SelectorAssistant;
+  /**
+   * Whole-spec suggestion hook. When it provides `suggest`, the toolbar grows a
+   * Suggest button; otherwise nothing is rendered and the editor is unchanged.
+   */
+  layoutAssistant?: LayoutAssistant;
   /** appearance */
   density?: 'compact' | 'comfortable';
   /**
@@ -112,6 +128,7 @@ export const SpecEditor: React.FC<SpecEditorProps> = ({
   domain: domainProp,
   theme,
   selectorAssistant,
+  layoutAssistant,
   density = 'compact',
   syntaxHighlighting = true,
   defaultView = 'builder',
@@ -320,11 +337,60 @@ export const SpecEditor: React.FC<SpecEditorProps> = ({
 
   useEffect(
     () => () => {
+      alive.current = false;
       if (parseTimer.current) clearTimeout(parseTimer.current);
       if (reviewTimer.current) clearTimeout(reviewTimer.current);
     },
     [],
   );
+
+  // ── Layout assistance (whole-spec suggestion) ───────────────────────────
+  const [suggestion, setSuggestion] = useState<{
+    running: boolean;
+    result: LayoutSuggestionResult | null;
+    error: string | null;
+  }>({ running: false, result: null, error: null });
+  // Dropped-result guards: a superseded run (the user clicked Suggest again)
+  // and an unmount both mean the resolved promise must not touch the document.
+  const suggestSeq = useRef(0);
+  const alive = useRef(true);
+
+  const handleSuggest = useCallback(() => {
+    const suggest = layoutAssistant?.suggest;
+    if (!suggest || disabled) return;
+    // Land any debounced code-view parse first, so the suggester sees the text
+    // the user is looking at rather than the last-parsed model.
+    flushParseRef.current();
+    const seq = ++suggestSeq.current;
+    setSuggestion({ running: true, result: null, error: null });
+    const ctx: LayoutAssistContext = { domain, instance, currentYaml: value };
+    Promise.resolve()
+      .then(() => suggest(ctx))
+      .then((result) => {
+        if (seq !== suggestSeq.current || !alive.current) return;
+        // Same path as a code-view edit: one undo step, builder refreshed in
+        // place, re-validated. Throws on unparseable YAML WITHOUT mutating,
+        // which the catch below turns into a panel error.
+        doc.replaceFromYaml(result.yaml);
+        emit();
+        setSuggestion({ running: false, result, error: null });
+      })
+      .catch((err: unknown) => {
+        if (seq !== suggestSeq.current || !alive.current) return;
+        setSuggestion({
+          running: false,
+          result: null,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }, [layoutAssistant, disabled, domain, instance, value, doc, emit]);
+
+  const dismissSuggestion = useCallback(() => {
+    // Bump the token too: a run still in flight when the user dismisses should
+    // not reopen the panel behind them.
+    suggestSeq.current += 1;
+    setSuggestion({ running: false, result: null, error: null });
+  }, []);
 
   // ── Builder mutations ───────────────────────────────────────────────────
   const handleAddItem = useCallback(
@@ -609,29 +675,58 @@ export const SpecEditor: React.FC<SpecEditorProps> = ({
           </button>
         </div>
 
-        <div className="spytial-ed-history">
-          <button
-            type="button"
-            className="spytial-ed-history-btn"
-            aria-label="Undo"
-            title="Undo (Cmd/Ctrl+Z)"
-            disabled={disabled || !doc.canUndo()}
-            onClick={handleUndo}
-          >
-            <span aria-hidden="true">↶</span>
-          </button>
-          <button
-            type="button"
-            className="spytial-ed-history-btn"
-            aria-label="Redo"
-            title="Redo (Shift+Cmd/Ctrl+Z)"
-            disabled={disabled || !doc.canRedo()}
-            onClick={handleRedo}
-          >
-            <span aria-hidden="true">↷</span>
-          </button>
+        <div className="spytial-ed-toolbar-actions">
+          {layoutAssistant?.suggest ? (
+            <button
+              type="button"
+              className="spytial-ed-suggest-btn"
+              title="Suggest a layout for the current data"
+              disabled={disabled || suggestion.running}
+              aria-busy={suggestion.running}
+              onClick={handleSuggest}
+            >
+              <span aria-hidden="true">✦</span>
+              {suggestion.running ? 'Analyzing…' : 'Suggest'}
+            </button>
+          ) : null}
+
+          <div className="spytial-ed-history">
+            <button
+              type="button"
+              className="spytial-ed-history-btn"
+              aria-label="Undo"
+              title="Undo (Cmd/Ctrl+Z)"
+              disabled={disabled || !doc.canUndo()}
+              onClick={handleUndo}
+            >
+              <span aria-hidden="true">↶</span>
+            </button>
+            <button
+              type="button"
+              className="spytial-ed-history-btn"
+              aria-label="Redo"
+              title="Redo (Shift+Cmd/Ctrl+Z)"
+              disabled={disabled || !doc.canRedo()}
+              onClick={handleRedo}
+            >
+              <span aria-hidden="true">↷</span>
+            </button>
+          </div>
         </div>
       </div>
+
+      {suggestion.error !== null ? (
+        <p className="spytial-ed-suggest-error" role="alert">
+          {suggestion.error}
+        </p>
+      ) : null}
+
+      {suggestion.result !== null ? (
+        <SuggestionsPanel
+          result={suggestion.result}
+          onDismiss={dismissSuggestion}
+        />
+      ) : null}
 
       <div className="spytial-ed-body">
         {view === 'builder' ? (

--- a/src/spec-editor/ui/SuggestionsPanel.tsx
+++ b/src/spec-editor/ui/SuggestionsPanel.tsx
@@ -1,0 +1,110 @@
+/**
+ * {@link SuggestionsPanel} — the read-only explanation of a
+ * {@link LayoutAssistant} run.
+ *
+ * The suggestion itself has already been applied to the document by the time
+ * this renders; the panel exists so the reasoning isn't thrown away. Each row
+ * shows the suggester's rationale plus two optional generic chips (confidence,
+ * outcome), and result-level `notes` follow the list. Nothing here is
+ * interactive beyond dismissal — accepting or rejecting individual suggestions
+ * would require the suggester to recompose the spec, which is host policy.
+ */
+
+import React from 'react';
+import type {
+  LayoutSuggestionDetail,
+  LayoutSuggestionResult,
+} from '../domain/layout-assistant';
+
+export interface SuggestionsPanelProps {
+  result: LayoutSuggestionResult;
+  onDismiss(): void;
+}
+
+export const SuggestionsPanel: React.FC<SuggestionsPanelProps> = ({
+  result,
+  onDismiss,
+}) => {
+  const suggestions = result.suggestions ?? [];
+  const notes = result.notes ?? [];
+
+  return (
+    <div
+      className="spytial-ed-suggestions"
+      role="region"
+      aria-label="Layout suggestions"
+    >
+      <div className="spytial-ed-suggestions-head">
+        <span className="spytial-ed-suggestions-title">
+          {suggestions.length > 0
+            ? `${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'}`
+            : 'Suggestion applied'}
+        </span>
+        <button
+          type="button"
+          className="spytial-ed-suggestions-dismiss"
+          aria-label="Dismiss suggestions"
+          title="Dismiss"
+          onClick={onDismiss}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+
+      {suggestions.length > 0 ? (
+        <ul className="spytial-ed-suggestions-list">
+          {suggestions.map((s) => (
+            <SuggestionRow key={s.id} suggestion={s} />
+          ))}
+        </ul>
+      ) : null}
+
+      {notes.length > 0 ? (
+        <ul className="spytial-ed-suggestions-notes">
+          {notes.map((note, i) => (
+            // Notes are free-form host strings with no stable identity; index
+            // keys are correct here because the list is replaced wholesale.
+            <li key={i}>{note}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+};
+
+const SuggestionRow: React.FC<{ suggestion: LayoutSuggestionDetail }> = ({
+  suggestion,
+}) => {
+  const { id, rationale, confidence, outcome } = suggestion;
+  return (
+    <li
+      className={`spytial-ed-suggestion${
+        outcome === 'omitted' ? ' spytial-ed-suggestion--omitted' : ''
+      }`}
+    >
+      <div className="spytial-ed-suggestion-head">
+        {/* Ids are machine-facing (`orientation:synth-union:Node`), so the
+            rationale leads and the id trails as a mono tag. With no rationale
+            the id is all we have, so it becomes the label. */}
+        <span className="spytial-ed-suggestion-text">{rationale || id}</span>
+        {confidence ? (
+          <span
+            className={`spytial-ed-suggestion-chip spytial-ed-suggestion-chip--${confidence}`}
+            title={`${confidence} confidence`}
+          >
+            {confidence}
+          </span>
+        ) : null}
+        {outcome ? (
+          <span
+            className={`spytial-ed-suggestion-chip spytial-ed-suggestion-chip--${outcome}`}
+            title={`Outcome: ${outcome}`}
+          >
+            {outcome}
+          </span>
+        ) : null}
+      </div>
+      {rationale ? <code className="spytial-ed-suggestion-id">{id}</code> : null}
+    </li>
+  );
+};

--- a/src/spec-editor/ui/index.ts
+++ b/src/spec-editor/ui/index.ts
@@ -44,6 +44,10 @@ export { CodeView } from './CodeView';
 export type { BuilderViewProps } from './BuilderView';
 export { BuilderView } from './BuilderView';
 
+// ---- layout-suggestion panel (HOOK 3) ----
+export type { SuggestionsPanelProps } from './SuggestionsPanel';
+export { SuggestionsPanel } from './SuggestionsPanel';
+
 // ---- the public component (WP4) ----
 export type { SpecEditorProps } from './SpecEditor';
 export { SpecEditor } from './SpecEditor';

--- a/src/spec-editor/ui/spec-editor.css
+++ b/src/spec-editor/ui/spec-editor.css
@@ -877,9 +877,182 @@
   cursor: not-allowed;
 }
 
+.spytial-ed-toolbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spytial-ed-gap, 8px);
+}
+
 .spytial-ed-history {
   display: inline-flex;
   gap: 4px;
+}
+
+/* ─── Layout suggestion (HOOK 3) ────────────────────────────────────────── */
+
+.spytial-ed-suggest-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  font-family: var(--spytial-ed-chrome-font);
+  font-size: 0.78em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--spytial-ed-accent, #b5431a);
+  background: transparent;
+  border: 1px solid var(--spytial-ed-accent, #b5431a);
+  border-radius: var(--spytial-ed-radius-sm, 2px);
+  padding: 0.3em 0.7em;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.spytial-ed-suggest-btn:hover:not(:disabled) {
+  color: var(--spytial-ed-accent-text, #fdf6ec);
+  background: var(--spytial-ed-accent, #b5431a);
+}
+
+.spytial-ed-suggest-btn:focus-visible {
+  outline: 2px solid var(--spytial-ed-accent, #b5431a);
+  outline-offset: 2px;
+}
+
+.spytial-ed-suggest-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spytial-ed-suggest-error {
+  margin: 0;
+  padding: calc(var(--spytial-ed-gap, 8px) * 0.75) var(--spytial-ed-gap, 8px);
+  font-size: 0.85em;
+  color: var(--spytial-ed-danger, #a32014);
+  background: color-mix(
+    in srgb,
+    var(--spytial-ed-danger, #a32014) 8%,
+    transparent
+  );
+  border-bottom: 1px solid var(--spytial-ed-border, #d9d2c0);
+}
+
+.spytial-ed-suggestions {
+  padding: calc(var(--spytial-ed-gap, 8px) * 0.75) var(--spytial-ed-gap, 8px);
+  background: var(--spytial-ed-surface-raised, #f1ecdf);
+  border-bottom: 1px solid var(--spytial-ed-border, #d9d2c0);
+  border-left: 3px solid var(--spytial-ed-accent, #b5431a);
+  animation: spytial-ed-unfold 0.14s ease-out;
+}
+
+.spytial-ed-suggestions-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spytial-ed-gap, 8px);
+}
+
+.spytial-ed-suggestions-title {
+  font-family: var(--spytial-ed-chrome-font);
+  font-size: 0.74em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--spytial-ed-text-muted, #6e6553);
+}
+
+.spytial-ed-suggestions-dismiss {
+  font: inherit;
+  font-size: 1.05em;
+  line-height: 1;
+  color: var(--spytial-ed-text-muted, #6e6553);
+  background: transparent;
+  border: none;
+  padding: 0 0.2em;
+  cursor: pointer;
+}
+
+.spytial-ed-suggestions-dismiss:hover {
+  color: var(--spytial-ed-accent, #b5431a);
+}
+
+.spytial-ed-suggestions-dismiss:focus-visible {
+  outline: 2px solid var(--spytial-ed-accent, #b5431a);
+  outline-offset: 1px;
+}
+
+.spytial-ed-suggestions-list,
+.spytial-ed-suggestions-notes {
+  list-style: none;
+  margin: calc(var(--spytial-ed-gap, 8px) * 0.5) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spytial-ed-gap, 8px) * 0.5);
+}
+
+.spytial-ed-suggestions-notes {
+  font-size: 0.82em;
+  color: var(--spytial-ed-text-muted, #6e6553);
+  border-top: 1px solid var(--spytial-ed-border, #d9d2c0);
+  padding-top: calc(var(--spytial-ed-gap, 8px) * 0.5);
+}
+
+.spytial-ed-suggestion--omitted {
+  opacity: 0.62;
+}
+
+.spytial-ed-suggestion-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.4em;
+}
+
+.spytial-ed-suggestion-text {
+  flex: 1 1 12em;
+  font-size: 0.88em;
+  color: var(--spytial-ed-text, #221d14);
+}
+
+.spytial-ed-suggestion-id {
+  display: block;
+  margin-top: 0.15em;
+  font-family: var(
+    --spytial-ed-mono-font-family,
+    ui-monospace, 'Cascadia Code', 'JetBrains Mono', 'SF Mono', Menlo,
+    Consolas, 'Liberation Mono', monospace
+  );
+  font-size: 0.74em;
+  color: var(--spytial-ed-text-muted, #6e6553);
+  word-break: break-all;
+}
+
+.spytial-ed-suggestion-chip {
+  font-family: var(--spytial-ed-chrome-font);
+  font-size: 0.66em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  border: 1px solid currentColor;
+  border-radius: var(--spytial-ed-radius-sm, 2px);
+  padding: 0.15em 0.4em;
+  white-space: nowrap;
+  color: var(--spytial-ed-text-muted, #6e6553);
+}
+
+.spytial-ed-suggestion-chip--high,
+.spytial-ed-suggestion-chip--applied {
+  color: var(--spytial-ed-success, #2f6c43);
+}
+
+.spytial-ed-suggestion-chip--medium,
+.spytial-ed-suggestion-chip--weakened {
+  color: var(--spytial-ed-warning, #8a6200);
+}
+
+.spytial-ed-suggestion-chip--omitted {
+  color: var(--spytial-ed-danger, #a32014);
 }
 
 .spytial-ed-history-btn {

--- a/tests/spec-editor-layout-assistant.test.tsx
+++ b/tests/spec-editor-layout-assistant.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * HOOK 3 — `LayoutAssistant` (whole-spec suggestion) integration tests.
+ *
+ * Covers the behavioural contract from `docs/SPEC_EDITOR_REDESIGN.md`:
+ *
+ *   - the Suggest button appears only when the assistant provides `suggest`,
+ *   - the suggester receives `{domain, instance, currentYaml}` and nothing else,
+ *   - an accepted proposal is applied through the document — `onChange` fires
+ *     with canonical YAML, the builder repopulates, and it is ONE undo step
+ *     that restores the previous spec,
+ *   - the panel renders rationale / confidence / outcome / notes,
+ *   - a rejected promise leaves the document untouched and shows the message,
+ *   - unparseable proposal YAML is an error, not a wiped document,
+ *   - a superseded run's result is dropped rather than applied late,
+ *   - the rendered panel has no axe violations.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React, { useState } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import axe from 'axe-core'
+
+import { SpecEditor } from '../src/spec-editor/ui/SpecEditor'
+import { parseYamlToState } from '../src/spec-editor'
+import type {
+  LayoutAssistant,
+  LayoutAssistContext,
+  LayoutSuggestionResult,
+} from '../src/spec-editor'
+import type { IInputDataInstance } from '../src/data-instance/interfaces'
+import { buildSampleBstInstance } from './helpers/bst-instance-fixture'
+
+const EXISTING_SPEC = `constraints:
+  - cyclic:
+      selector: left
+      direction: clockwise
+`
+
+const PROPOSAL = `constraints:
+  - orientation:
+      selector: left
+      directions:
+        - below
+`
+
+function Host(props: {
+  initial?: string
+  instance?: IInputDataInstance
+  layoutAssistant?: LayoutAssistant
+  onChangeSpy?: (v: string) => void
+}) {
+  const [value, setValue] = useState(props.initial ?? '')
+  return (
+    <SpecEditor
+      value={value}
+      onChange={(v) => {
+        props.onChangeSpy?.(v)
+        setValue(v)
+      }}
+      instance={props.instance}
+      layoutAssistant={props.layoutAssistant}
+      defaultView="builder"
+      aria-label="Spec editor under test"
+    />
+  )
+}
+
+// The trigger's accessible name IS its visible text, which swaps to
+// "Analyzing…" mid-run (no aria-label — that would desync name from label).
+const suggestButton = () => screen.getByRole('button', { name: /Suggest|Analyzing/ })
+
+describe('SpecEditor — Suggest affordance gating', () => {
+  it('is absent with no assistant', () => {
+    render(<Host />)
+    expect(screen.queryByRole('button', { name: /Suggest/ })).toBeNull()
+  })
+
+  it('is absent when the assistant provides no suggest member', () => {
+    render(<Host layoutAssistant={{}} />)
+    expect(screen.queryByRole('button', { name: /Suggest/ })).toBeNull()
+  })
+
+  it('appears when the assistant provides suggest', () => {
+    render(<Host layoutAssistant={{ suggest: vi.fn() }} />)
+    expect(suggestButton()).toBeInTheDocument()
+  })
+})
+
+describe('SpecEditor — applying a suggestion', () => {
+  it('passes the domain, instance, and current YAML to the suggester', async () => {
+    const user = userEvent.setup()
+    const instance = buildSampleBstInstance()
+    let seen: LayoutAssistContext | null = null
+    const suggest = vi.fn(async (ctx: LayoutAssistContext) => {
+      seen = ctx
+      return { yaml: PROPOSAL }
+    })
+
+    render(
+      <Host initial={EXISTING_SPEC} instance={instance} layoutAssistant={{ suggest }} />,
+    )
+    await user.click(suggestButton())
+
+    await waitFor(() => expect(suggest).toHaveBeenCalledTimes(1))
+    const ctx = seen as unknown as LayoutAssistContext
+    expect(ctx.currentYaml).toBe(EXISTING_SPEC)
+    expect(ctx.instance).toBe(instance)
+    // The domain is the editor-resolved schema, not the raw instance.
+    expect(ctx.domain?.relations.map((r) => r.name)).toEqual(
+      expect.arrayContaining(['left', 'right']),
+    )
+    // Domain-agnostic contract: exactly these three keys, no host concepts.
+    expect(Object.keys(ctx).sort()).toEqual(['currentYaml', 'domain', 'instance'])
+  })
+
+  it('emits the proposal as canonical YAML and repopulates the builder', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <Host
+        initial={EXISTING_SPEC}
+        onChangeSpy={onChange}
+        layoutAssistant={{ suggest: async () => ({ yaml: PROPOSAL }) }}
+      />,
+    )
+
+    await user.click(suggestButton())
+    await waitFor(() => expect(onChange).toHaveBeenCalled())
+
+    const emitted = onChange.mock.calls.at(-1)![0] as string
+    const state = parseYamlToState(emitted)
+    expect(state.constraints).toHaveLength(1)
+    expect(state.constraints[0].type).toBe('orientation')
+
+    // The builder shows the suggested row, not the replaced one.
+    await waitFor(() => {
+      expect(screen.getByText(/Orientation/i)).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/^Cyclic/i)).toBeNull()
+  })
+
+  it('is a single undo step back to the previous spec', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <Host
+        initial={EXISTING_SPEC}
+        onChangeSpy={onChange}
+        layoutAssistant={{ suggest: async () => ({ yaml: PROPOSAL }) }}
+      />,
+    )
+
+    await user.click(suggestButton())
+    await waitFor(() =>
+      expect(parseYamlToState(onChange.mock.calls.at(-1)![0] as string).constraints[0].type).toBe(
+        'orientation',
+      ),
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Undo' }))
+
+    const afterUndo = parseYamlToState(onChange.mock.calls.at(-1)![0] as string)
+    expect(afterUndo.constraints).toHaveLength(1)
+    expect(afterUndo.constraints[0].type).toBe('cyclic')
+  })
+})
+
+describe('SpecEditor — suggestions panel', () => {
+  const RESULT: LayoutSuggestionResult = {
+    yaml: PROPOSAL,
+    suggestions: [
+      {
+        id: 'orientation:left:below',
+        rationale: 'left forms an acyclic tree over Node.',
+        confidence: 'high',
+        outcome: 'applied',
+      },
+      {
+        id: 'cyclic:next',
+        rationale: 'Primary form failed validation; applied fallback 1.',
+        confidence: 'medium',
+        outcome: 'weakened',
+      },
+      { id: 'group:owner', rationale: 'Requires a suggestion that was omitted.', outcome: 'omitted' },
+    ],
+    notes: ['1 suggestion used a weaker fallback.'],
+  }
+
+  async function renderWithResult(result = RESULT) {
+    const user = userEvent.setup()
+    render(<Host initial={EXISTING_SPEC} layoutAssistant={{ suggest: async () => result }} />)
+    await user.click(suggestButton())
+    const panel = await screen.findByRole('region', { name: 'Layout suggestions' })
+    return { user, panel }
+  }
+
+  it('renders each rationale with its confidence and outcome', async () => {
+    const { panel } = await renderWithResult()
+    expect(within(panel).getByText('3 suggestions')).toBeInTheDocument()
+    expect(within(panel).getByText('left forms an acyclic tree over Node.')).toBeInTheDocument()
+    expect(within(panel).getByText('high')).toBeInTheDocument()
+    expect(within(panel).getByText('weakened')).toBeInTheDocument()
+    expect(within(panel).getByText('omitted')).toBeInTheDocument()
+    expect(within(panel).getByText('1 suggestion used a weaker fallback.')).toBeInTheDocument()
+    // Ids are machine-facing, shown as a secondary tag.
+    expect(within(panel).getByText('orientation:left:below')).toBeInTheDocument()
+  })
+
+  it('renders opaque results (yaml only) without inventing rows', async () => {
+    const { panel } = await renderWithResult({ yaml: PROPOSAL })
+    expect(within(panel).getByText('Suggestion applied')).toBeInTheDocument()
+    expect(within(panel).queryByRole('listitem')).toBeNull()
+  })
+
+  it('dismisses without reverting the applied spec', async () => {
+    const { user, panel } = await renderWithResult()
+    await user.click(within(panel).getByRole('button', { name: 'Dismiss suggestions' }))
+    await waitFor(() =>
+      expect(screen.queryByRole('region', { name: 'Layout suggestions' })).toBeNull(),
+    )
+    expect(screen.getByText(/Orientation/i)).toBeInTheDocument()
+  })
+
+  it('has no axe violations', async () => {
+    const { panel } = await renderWithResult()
+    const results = await axe.run(panel, {
+      runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'best-practice'] },
+      rules: { 'color-contrast': { enabled: false } },
+    })
+    expect(results.violations).toEqual([])
+  })
+})
+
+describe('SpecEditor — suggestion failures leave the document alone', () => {
+  it('surfaces a rejected suggester without touching the spec', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <Host
+        initial={EXISTING_SPEC}
+        onChangeSpy={onChange}
+        layoutAssistant={{
+          suggest: async () => {
+            throw new Error('No instance is available to analyze.')
+          },
+        }}
+      />,
+    )
+
+    await user.click(suggestButton())
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'No instance is available to analyze.',
+    )
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByText(/^Cyclic/i)).toBeInTheDocument()
+    // The button is usable again after a failure.
+    expect(suggestButton()).toBeEnabled()
+  })
+
+  it('treats unparseable proposal YAML as an error, not a wipe', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <Host
+        initial={EXISTING_SPEC}
+        onChangeSpy={onChange}
+        layoutAssistant={{ suggest: async () => ({ yaml: 'constraints: [unclosed' }) }}
+      />,
+    )
+
+    await user.click(suggestButton())
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByText(/^Cyclic/i)).toBeInTheDocument()
+  })
+
+  it('disables the trigger while a run is in flight', async () => {
+    const user = userEvent.setup()
+    let release: (r: LayoutSuggestionResult) => void = () => {}
+    const pending = new Promise<LayoutSuggestionResult>((resolve) => {
+      release = resolve
+    })
+    render(<Host initial={EXISTING_SPEC} layoutAssistant={{ suggest: () => pending }} />)
+
+    await user.click(suggestButton())
+    await waitFor(() => expect(suggestButton()).toBeDisabled())
+    expect(suggestButton()).toHaveTextContent('Analyzing…')
+
+    release({ yaml: PROPOSAL })
+    await waitFor(() => expect(suggestButton()).toBeEnabled())
+  })
+
+  it('drops a result that resolves after unmount', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    let release: (r: LayoutSuggestionResult) => void = () => {}
+    const pending = new Promise<LayoutSuggestionResult>((resolve) => {
+      release = resolve
+    })
+
+    const { unmount } = render(
+      <Host
+        initial={EXISTING_SPEC}
+        onChangeSpy={onChange}
+        layoutAssistant={{ suggest: () => pending }}
+      />,
+    )
+    await user.click(suggestButton())
+    unmount()
+
+    release({ yaml: PROPOSAL })
+    await pending
+    // Flush the .then chain the handler attached.
+    await Promise.resolve()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes the last open item of #505: the editor now owns a Suggest affordance, and hosts plug in the policy behind it.

## What this adds

`LayoutAssistant` (`src/spec-editor/domain/layout-assistant.ts`), mirroring `SelectorAssistant` one level up:

```ts
export interface LayoutAssistant {
  suggest?(ctx: LayoutAssistContext): Promise<LayoutSuggestionResult>;
}
```

`SpecEditor` and the `CndLayoutInterface` wrapper take a `layoutAssistant` prop. When it provides `suggest`, a **Suggest** button appears in the toolbar next to the Builder/Code toggle; when it doesn't, nothing renders and the editor is byte-for-byte what it was.

## How a result is handled

The proposal is applied **through the document** — `replaceFromYaml` + the normal emit path — which is the whole reason this belongs in core rather than in each host:

- one undo step, so a suggestion is as reversible as a keystroke,
- the builder repopulates in place; no remount, no lost view/scroll,
- diagnostics re-run,
- the host just sees an ordinary `onChange`.

That last point decides apply semantics for free: a host whose "apply" is a separate action gets the suggestion in its editor draft and nothing else, so a suggestion behaves exactly like a hand edit.

Failure is a normal outcome. A rejected promise — or proposal YAML that doesn't parse — leaves the document **untouched** and surfaces the message in an alert. Results arriving after unmount, or after the user dismisses the panel, are dropped.

## The suggestions panel

Optional per-suggestion metadata (`rationale`, `confidence`, `outcome`) renders in a read-only panel below the toolbar, so a suggester's reasoning is no longer computed and thrown away — which is exactly the complaint that opened #505's companion issue.

Accepting or rejecting *individual* suggestions is deliberately **not** in this contract. Recomposing a spec from a subset means knowing the dependencies and weaker fallbacks between rules, which is host policy; a host that wants it can render its own panel and drive the editor through `value`.

## Multi-consumer constraints

Per the "Design constraints" section of #505:

- **Domain-agnostic.** The context is `{domain, instance, currentYaml}` and nothing else — no Alloy, Forge, or other host vocabulary. The metadata fields are optional and rendered generically; a suggester without that vocabulary returns `{ yaml }` alone.
- **Additive only.** New optional prop, new export subpath entries. The VS Code extension, Pyret REPL, demos, and language bindings run unchanged — which is why this is **4.0.1**, a patch, and not a minor.

## Testing

`tests/spec-editor-layout-assistant.test.tsx` — 14 new tests covering button gating, the exact context keys, apply-through-document, the single undo step, panel rendering (including the opaque `{yaml}`-only case), rejection and unparseable-YAML paths leaving the spec alone, in-flight disabling, post-unmount drops, and axe.

Full suite: **2073 tests / 145 files, green.** `build:all` emits the new types into `dist/types`.

## Downstream

copeanddrag adopts this in sidprasad/copeanddrag#141 Phase 3, whose PR is blocked until 4.0.1 is on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)