### PR TITLE
Surface simple-graph-query 3.0 unresolved-name warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "3.3.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "3.3.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
@@ -21,20 +21,16 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@xmldom/xmldom": "^0.9.8",
-        "alasql": "^4.17.0",
         "chroma-js": "^3.1.2",
         "d3": "^7.9.0",
         "dagre": "^0.8.5",
-        "data-navigator": "^2.4.1",
         "forge-expr-evaluator": "^1.1.0",
         "graphlib": "^2.1.8",
         "graphlib-dot": "^0.6.4",
         "js-yaml": "^4.1.0",
         "kiwi.js": "^1.1.3",
         "lodash": "^4.17.21",
-        "react": "19.1.0",
-        "react-dom": "19.1.0",
-        "simple-graph-query": "^2.8.2",
+        "simple-graph-query": "^3.0.0",
         "webcola": "^3.4.0",
         "yaml": "^2.9.0"
       },
@@ -55,13 +51,17 @@
         "@typescript-eslint/parser": "^8.34.1",
         "@vitejs/plugin-react": "^4.6.0",
         "@vitest/ui": "^3.2.4",
+        "alasql": "^4.17.0",
         "axe-core": "^4.11.2",
+        "data-navigator": "^2.4.1",
         "eslint": "^9.29.0",
         "fast-check": "^4.6.0",
         "globals": "^17.6.0",
         "jsdom": "^26.1.0",
         "peggy": "^3.0.2",
         "prettier": "^3.5.3",
+        "react": "19.1.0",
+        "react-dom": "19.1.0",
         "ts-pegjs": "^4.2.1",
         "tsup": "^8.5.0",
         "tsx": "^4.21.0",
@@ -73,6 +73,26 @@
       },
       "engines": {
         "node": ">=16"
+      },
+      "peerDependencies": {
+        "alasql": "^4.0.0",
+        "data-navigator": "^2.4.1",
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "alasql": {
+          "optional": true
+        },
+        "data-navigator": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -107,7 +127,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -122,7 +142,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
       "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -132,7 +152,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -163,7 +183,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -173,7 +193,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -190,7 +210,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -207,7 +227,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -217,7 +237,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -227,7 +247,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -241,7 +261,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -259,7 +279,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -269,7 +289,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -279,7 +299,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -289,7 +309,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -299,7 +319,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -313,7 +333,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -329,6 +349,7 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -342,6 +363,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -355,6 +377,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -368,6 +391,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -384,6 +408,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
       "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -400,6 +425,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -413,6 +439,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -426,6 +453,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -439,6 +467,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -452,6 +481,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -465,6 +495,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -478,6 +509,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -491,6 +523,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -504,6 +537,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -520,6 +554,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -568,7 +603,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -578,7 +613,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -593,7 +628,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -612,7 +647,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1522,6 +1557,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
       "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -1532,6 +1568,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1549,6 +1586,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1559,6 +1597,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1573,6 +1612,7 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1587,6 +1627,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1600,6 +1641,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1616,6 +1658,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1629,6 +1672,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -1639,6 +1683,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -1649,6 +1694,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
       "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1662,6 +1708,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1678,6 +1725,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1696,6 +1744,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1709,6 +1758,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1736,6 +1786,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1754,7 +1805,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1765,7 +1816,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1776,7 +1827,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1786,6 +1837,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1797,14 +1849,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2222,6 +2274,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.84.1.tgz",
       "integrity": "sha512-lAJ6PDZv95FdT9s9uhc9ivhikW1Zwh4j9XdXM7J2l4oUA3t37qfoBmTSDLuPyE3Bi+Xtwa11hJm0BUTT2sc/gg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -2232,6 +2285,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.84.1.tgz",
       "integrity": "sha512-n1RIU0QAavgCg1uC5+s53arL7/mpM+16IBhJ3nCFSd/iK5tUmCwxQDcIDC703fuXfpub/ZygeSjVN8bcOWn0gA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -2254,6 +2308,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -2269,6 +2324,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -2288,6 +2344,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -2298,6 +2355,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.84.1.tgz",
       "integrity": "sha512-f6a+mJEJ6Joxlt/050TqYUr7uRRbeKnz8lnpL7JajhpsgZLEbkJRjH8HY5QiLcRdUwWFtizml4V+vcO3P4RxoQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -2329,6 +2387,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.84.1.tgz",
       "integrity": "sha512-rUU/Pyh3R5zT0WkVgB+yA6VwOp7HM5Hz4NYE97ajFS07OUIcv8JzBL3MXVdSSjLfldfqOuPEuKUaZcAOwPgabw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -2339,6 +2398,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.84.1.tgz",
       "integrity": "sha512-LIGhh4q4ette3yW5OzmukNMYwmINYrRGDZqKyTYc/VZyNpblZPw72coXVHXdfpPT6+YlxHqXzn3UjFZpNODGCQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -2354,6 +2414,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.84.1.tgz",
       "integrity": "sha512-Z83ra+Gk6ElAhH3XRrv3vwbwCPTb04sPPlNpotxcFZb5LtRQZwT91ZQEXw3GOJCVIFp9EQ/gj8AQbVvtHKOUlQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -2378,6 +2439,7 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -2400,6 +2462,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.84.1.tgz",
       "integrity": "sha512-7uVlPBE3uluRNRX4MW7PUJIO1LDBTpAqStKHU7LHH+GRrdZbHsWtOEAX8PiY4GFfBEvG8hEjiuTOqAxMjV+hDg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -2410,6 +2473,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.84.1.tgz",
       "integrity": "sha512-UsTe2AbUugsfyI7XIHMQq4E7xeC8a6GrYwuK+NohMMMJMxmyM3JkzIk+GB9e2il6ScEQNMJNaj+q+i5za8itxQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -2420,6 +2484,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.84.1.tgz",
       "integrity": "sha512-/UPaQ4jl95soXnLDEJ6Cs6lnRXhwbxtT4KbZz+AFDees7prMV2NOLcHfCnzmTabf5Y3oxENMVBL666n4GMLcTA==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -2770,6 +2835,7 @@
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -2777,6 +2843,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -2787,6 +2854,7 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -2937,7 +3005,7 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -2951,7 +3019,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -2961,7 +3029,7 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -2972,7 +3040,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -3283,6 +3351,7 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -3308,6 +3377,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -3315,6 +3385,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -3325,6 +3396,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -3355,7 +3427,7 @@
       "version": "24.10.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -3403,6 +3475,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -3424,6 +3497,7 @@
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -3434,6 +3508,7 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -3841,6 +3916,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -3854,6 +3930,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -3868,7 +3945,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3891,7 +3968,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3918,6 +3995,7 @@
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/alasql/-/alasql-4.17.0.tgz",
       "integrity": "sha512-bU6tEjs0KVW3tesOBJBGE1Pl+LUt1epDSjb6yLo7GJZ4n9Gm+EjVgDl3HS+6rfCUARiNiWISTI1b7Zf/ljhKzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "4.1.0",
@@ -3937,6 +4015,7 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
       "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -3944,6 +4023,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3953,6 +4033,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3981,6 +4062,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4011,6 +4093,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -4047,6 +4130,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4069,6 +4153,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4086,6 +4171,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4102,6 +4188,7 @@
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
       "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4112,6 +4199,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4139,6 +4227,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4156,19 +4245,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base-64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4190,7 +4281,7 @@
       "version": "2.9.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
       "integrity": "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -4210,7 +4301,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -4222,7 +4313,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4256,6 +4347,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4266,6 +4358,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -4309,6 +4402,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -4319,7 +4413,7 @@
       "version": "1.0.30001766",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
       "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4357,7 +4451,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4406,6 +4500,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
       "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4425,6 +4520,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
       "integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4440,6 +4536,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4456,6 +4553,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4473,6 +4571,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4485,6 +4584,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -4500,7 +4600,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -4514,6 +4614,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
       "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4530,6 +4631,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4540,6 +4642,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -4557,7 +4660,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-anything": {
@@ -4583,6 +4686,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
@@ -4592,7 +4696,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5057,7 +5161,8 @@
     "node_modules/data-navigator": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/data-navigator/-/data-navigator-2.4.1.tgz",
-      "integrity": "sha512-JYoSq2Wt1PTNuFRj+eUuUVfGTOOpc/XgJYiDMri+c35NRuCDDY/H+WeFr+SxZYmP6HlgV40VWXjBTVr1TFM0ww=="
+      "integrity": "sha512-JYoSq2Wt1PTNuFRj+eUuUVfGTOOpc/XgJYiDMri+c35NRuCDDY/H+WeFr+SxZYmP6HlgV40VWXjBTVr1TFM0ww==",
+      "dev": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -5077,7 +5182,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5128,6 +5233,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -5148,6 +5254,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -5191,6 +5298,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -5198,19 +5306,21 @@
       "version": "1.5.279",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
       "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -5247,6 +5357,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
       "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5306,6 +5417,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5315,6 +5427,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -5322,7 +5435,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5503,6 +5616,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "bin": {
@@ -5573,6 +5687,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -5583,6 +5698,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -5603,6 +5719,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -5668,7 +5785,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -5691,6 +5808,7 @@
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
       "integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "bin": {
@@ -5704,6 +5822,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5734,7 +5853,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5746,6 +5865,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5765,6 +5885,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5775,6 +5896,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -5832,6 +5954,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
       "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -5867,6 +5990,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -5877,6 +6001,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -5884,6 +6009,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5898,7 +6024,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5908,6 +6034,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -5917,6 +6044,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -5941,6 +6069,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -5975,6 +6104,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5986,6 +6116,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6012,6 +6143,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -6038,7 +6170,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6048,6 +6180,7 @@
       "version": "250829098.0.9",
       "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.9.tgz",
       "integrity": "sha512-hZ5O7PDz1vQ99TS7HD3FJ9zVynfU1y+VWId6U1Pldvd8hmAYrNec/XLPYJKD3dLOW6NXak6aAQAuMuSo3ji0tQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -6055,6 +6188,7 @@
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
       "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -6062,6 +6196,7 @@
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
       "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6085,6 +6220,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6106,6 +6242,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -6130,7 +6267,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -6179,6 +6316,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
       "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6219,7 +6357,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -6240,6 +6378,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6251,6 +6390,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -6267,6 +6407,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6277,6 +6418,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "bin": {
@@ -6303,6 +6445,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6325,7 +6468,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6348,6 +6491,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6361,13 +6505,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -6378,6 +6523,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6395,6 +6541,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "bin": {
@@ -6405,6 +6552,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6423,6 +6571,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -6433,6 +6582,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6459,6 +6609,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6480,6 +6631,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -6493,6 +6645,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6508,6 +6661,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -6515,6 +6669,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6530,6 +6685,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -6540,6 +6696,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6558,6 +6715,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6576,6 +6734,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -6589,6 +6748,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -6602,6 +6762,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6617,6 +6778,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -6624,6 +6786,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6640,6 +6803,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6666,7 +6830,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6685,6 +6849,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -6731,7 +6896,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -6765,7 +6930,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -6847,6 +7012,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -6871,6 +7037,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
       "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6882,6 +7049,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6892,6 +7060,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -6965,6 +7134,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -6972,6 +7142,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6992,7 +7163,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -7049,6 +7220,7 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7059,6 +7231,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -7066,6 +7239,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -7073,6 +7247,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -7089,6 +7264,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.5.tgz",
       "integrity": "sha512-BgsXevY1MBac/3ZYv/RfNFf/4iuW9X7f4H8ZNkiH+r667HD9sVujxcmu4jvEzGCAm4/WyKdZCuyhAcyhTHOucQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7144,6 +7320,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.5.tgz",
       "integrity": "sha512-d9FfmgUEVejTiSb7bkQeLRGl6aeno2UpuPm3bo3rCYwxewj03ymvOn8s8vnS4fBqAPQ+cE9iQM40wh7nGXR+eA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7160,6 +7337,7 @@
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
       "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -7167,6 +7345,7 @@
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
       "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7177,6 +7356,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.5.tgz",
       "integrity": "sha512-oH+s4U+IfZyg8J42bne2Skc90rcuESIYf86dYittcdWQtPfcaFXWpByPyTuWk3rR1Zz3Eh5HOrcVImfEhhJLng==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7193,6 +7373,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.5.tgz",
       "integrity": "sha512-Ycl8PBajB7bhbAI7Rt0xEyiF8oJ0RWX8EKkolV1KfCUlC++V/GStMSGpPLwnnBZXZWkCC5edBPzv1Hz1Yi0Euw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7206,6 +7387,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.5.tgz",
       "integrity": "sha512-JQ/PAASXH7yczgV6OCUSRhZYME+NU8NYjI2RcaG5ga4QfQ3T/XdiLzpSb3awWZYlDCcQb36l4Vl7i0Zw7/Tf9w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7226,6 +7408,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.5.tgz",
       "integrity": "sha512-YcVcLCrf0ed4mdLa82Qob0VxYqfhmlRxUS8+TO4gosZo/gLwSvtdeOjc/Vt0pe/lvMNrBap9LlmvZM8FIsMgJQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7241,6 +7424,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.5.tgz",
       "integrity": "sha512-ZEt8s3a1cnYbn40nyCD+CsZdYSlwtFh2kFym4lo+uvfM+UMMH+r/BsrC6rbNClSrt+B7rU9T+Te/sh/NL8ZZKQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7262,6 +7446,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.5.tgz",
       "integrity": "sha512-Toe4Md1wS1PBqbvB0cFxBzKEVyyuYTUb0sgifAZh/mSvLH84qA1NAWik9sISWatzvfWf3rOGoUoO5E3f193a3Q==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7276,6 +7461,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.5.tgz",
       "integrity": "sha512-7p3GtzVUpbAweJeCcUJihJeOQl1bDuimO5ueo1K0BUpUtR41q5EilbQ3klt16UTPPMpA+tISWBtsrqU556mY1A==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7289,6 +7475,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.5.tgz",
       "integrity": "sha512-f+b3ue9AWTVlZe2Xrki6TAoFtKIqw30jwfk7GQ1rDUBQaE0ZQ+NkiMEtb9uwH7uAjJ87U7Tdx1Jg1OJqUfEVlA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7303,6 +7490,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.5.tgz",
       "integrity": "sha512-VT9bb2KO2/4tWY9Z2yeZqTUao7CicKAOps9LUg2aQzsz+04QyuXL3qgf1cLUVRjA/D6G5u1RJAlN1w9VNHtODQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7324,6 +7512,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.5.tgz",
       "integrity": "sha512-EMIkrjNRz/hF+p0RDdxoE60+dkaTLPN3vaaGkFmX5lvFdO6HPfHA/Ywznzkev+za0VhPQ5KSdz49/MALBRteHA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7345,6 +7534,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.5.tgz",
       "integrity": "sha512-KxYKzZL+lt3Os5H2nx7YkbkWVduLZL5kPrE/Yq+Prm/DE1VLhpfnO6HtPs8vimYFKOa58ncl60GpoX0h7Wm0Vw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7363,6 +7553,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.5.tgz",
       "integrity": "sha512-8N4pjkNXc6ytlP9oAM6MwqkvUepNSW39LKYl9NjUMpRDazBQ7oBpQDc8Sz4aI8jnH6AGhF7s1m/ayxkN1t04yA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7388,6 +7579,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -7395,6 +7587,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7410,6 +7603,7 @@
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
       "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -7417,6 +7611,7 @@
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
       "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7427,6 +7622,7 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -7449,6 +7645,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7468,6 +7665,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -7478,7 +7676,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -7491,6 +7689,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -7504,6 +7703,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -7514,6 +7714,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7567,6 +7768,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "bin": {
@@ -7603,7 +7805,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -7666,6 +7868,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -7684,6 +7887,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -7704,18 +7908,21 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -7726,6 +7933,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -7733,13 +7941,14 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -7750,6 +7959,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -7764,6 +7974,7 @@
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.5.tgz",
       "integrity": "sha512-vNKPYC8L5ycVANANpF/S+WZHpfnRWKx/F3AYP4QMn6ZJTh+l2HOrId0clNkEmua58NB9vmI9Qh7YOoV/4folYg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7787,6 +7998,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7800,6 +8012,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7810,6 +8023,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7877,6 +8091,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -7923,6 +8138,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -7939,7 +8155,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7949,6 +8165,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7959,7 +8176,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8011,14 +8228,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -8041,7 +8258,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8259,6 +8476,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8304,6 +8522,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8334,6 +8553,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8344,6 +8564,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8353,6 +8574,7 @@
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8364,6 +8586,7 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8386,6 +8609,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"
@@ -8406,6 +8630,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.84.1.tgz",
       "integrity": "sha512-0PjxOyXRu3tZ8EobabxSukvhKje2HJbsZikR0U+pvS0pYZza2hXKjcSBiBdFN4h9D0S3v6a8kkrDK6WTRKMwzg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8465,6 +8690,7 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/react-native-fs/-/react-native-fs-2.20.0.tgz",
       "integrity": "sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8485,6 +8711,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.84.1.tgz",
       "integrity": "sha512-sJoDunzhci8ZsqxlUiKoLut4xQeQcmbIgvDHGQKeBz6uEq9HgU+hCWOijMRr6sLP0slQVfBAza34Rq7IbXZZOA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8509,6 +8736,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8522,6 +8750,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8537,6 +8766,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8547,6 +8777,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8562,6 +8793,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -8569,6 +8801,7 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8579,6 +8812,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -8586,6 +8820,7 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8608,6 +8843,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8627,6 +8863,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8675,6 +8912,7 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -8682,6 +8920,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8729,6 +8968,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8896,13 +9136,14 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8915,6 +9156,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
       "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8940,6 +9182,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8950,6 +9193,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -8957,6 +9201,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8967,6 +9212,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -8980,6 +9226,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -8990,6 +9237,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9000,6 +9248,7 @@
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
       "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9016,6 +9265,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9026,6 +9276,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -9033,7 +9284,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9046,7 +9297,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9056,6 +9307,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9076,13 +9328,14 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
     "node_modules/simple-graph-query": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/simple-graph-query/-/simple-graph-query-2.8.2.tgz",
-      "integrity": "sha512-OvFX13eb4xC/ckqVwRWXBVEdKlvQRZ8IsgyjPighYkxssLRuT03xjNhfDsuIYqwjWI8+q+MR5IjjQolM/88HIg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/simple-graph-query/-/simple-graph-query-3.0.0.tgz",
+      "integrity": "sha512-WekCQ8pozGLCObrqsPsosMn/RzYTHbIubP+hCBK1V6dMQPIuSw2vmHYRtA0ozv4p6uQ+fbQPEijId7MpiXawQg==",
       "dependencies": {
         "@types/lodash": "^4.17.16",
         "@types/node": "^22.14.0",
@@ -9125,6 +9378,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9135,6 +9389,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9164,6 +9419,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9175,6 +9431,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9185,6 +9442,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -9192,6 +9450,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9205,6 +9464,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9222,6 +9482,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -9229,6 +9490,7 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
       "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9242,6 +9504,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9259,6 +9522,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9273,6 +9537,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9431,7 +9696,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9451,6 +9716,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9470,6 +9736,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -9477,6 +9744,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9492,6 +9760,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9503,6 +9772,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9539,6 +9809,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -9560,7 +9831,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -9577,7 +9848,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -9595,7 +9866,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9658,6 +9929,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -9665,7 +9937,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -9677,6 +9949,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9922,6 +10195,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -9932,6 +10206,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -10043,13 +10318,14 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -10060,7 +10336,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10101,6 +10377,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10115,6 +10392,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "engines": {
@@ -10824,6 +11102,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -10850,6 +11129,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -10939,6 +11219,7 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -10970,7 +11251,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11013,6 +11294,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -11030,6 +11312,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -11037,6 +11320,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -11090,6 +11374,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -11099,7 +11384,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -11121,6 +11406,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
@@ -11139,6 +11425,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "js-yaml": "^4.1.0",
     "kiwi.js": "^1.1.3",
     "lodash": "^4.17.21",
-    "simple-graph-query": "^2.8.2",
+    "simple-graph-query": "^3.0.0",
     "webcola": "^3.4.0",
     "yaml": "^2.9.0"
   },

--- a/src/evaluators/data/sgq-evaluator.ts
+++ b/src/evaluators/data/sgq-evaluator.ts
@@ -13,6 +13,7 @@ import type {
     SimpleGraphQueryEvaluator as SimpleGraphQueryEvaluatorType,
     EvaluationResult,
     ErrorResult,
+    Diagnostic,
 } from "simple-graph-query";
 const sgq: any = (sgqNamespace as any).SimpleGraphQueryEvaluator ? sgqNamespace : (sgqNamespace as any).default;
 const { SimpleGraphQueryEvaluator } = sgq;
@@ -75,16 +76,34 @@ export class SGQEvaluatorResult implements IEvaluatorResult {
     private isErrorResult: boolean = false;
     private isSingletonResult: boolean = false;
     private expr: string;
+    /**
+     * Advisory diagnostics raised while evaluating `expr` — today only
+     * `unresolved-name`, which evaluates to the empty set rather than failing.
+     *
+     * These live on the *result*, not on the evaluator, and that placement is
+     * load-bearing. `SGraphQueryEvaluator` memoizes whole `SGQEvaluatorResult`
+     * objects, so keeping diagnostics here means a cache hit replays them. A
+     * drain-once channel on the evaluator (a `getLastDiagnostics()`, or an array
+     * the reader empties) would report on the first evaluation and go silent on
+     * every one after — which is precisely the failure this whole feature exists
+     * to prevent. simple-graph-query hit the identical bug twice internally.
+     */
+    private readonly diagnostics: readonly Diagnostic[];
 
-    constructor(result: EvaluationResult, expr: string) {
+    constructor(result: EvaluationResult, expr: string, diagnostics: readonly Diagnostic[] = []) {
         this.result = result;
         this.expr = expr;
         this.isErrorResult = isErrorResult(result);
         this.isSingletonResult = isSingleValue(result);
+        this.diagnostics = diagnostics;
     }
 
     isError(): boolean {
         return this.isErrorResult;
+    }
+
+    getDiagnostics(): readonly Diagnostic[] {
+        return this.diagnostics;
     }
 
     isSingleton(): boolean {
@@ -306,11 +325,14 @@ export class SGraphQueryEvaluator implements IEvaluator {
       return cachedResult;
     }
 
-    const result = this.eval.evaluateExpression(expression);
-
+    // Take the diagnostics-bearing entry point, and cache them *with* the value.
+    // An unresolved name evaluates to the empty set, so a typo and a legitimately
+    // empty set are indistinguishable from the value alone — the diagnostic is
+    // the only thing that tells them apart.
+    const { value, diagnostics } = this.eval.evaluateExpressionWithDiagnostics(expression);
 
     // Now we need to wrap the result in our IEvaluatorResult interface
-    const wrappedResult = new SGQEvaluatorResult(result, expression);
+    const wrappedResult = new SGQEvaluatorResult(value, expression, diagnostics);
     
     // Implement LRU eviction: if cache is at max size, remove oldest entry
     if (this.evaluatorCache.size >= this.MAX_CACHE_SIZE) {

--- a/src/evaluators/interfaces.ts
+++ b/src/evaluators/interfaces.ts
@@ -46,6 +46,30 @@ export interface ErrorResult {
 }
 
 /**
+ * An advisory note raised while evaluating an expression. The evaluation still
+ * produced a value — this says something about *how*.
+ *
+ * Declared structurally rather than re-exported from simple-graph-query so this
+ * module stays free of evaluator-specific imports; sgq's `Diagnostic` is
+ * assignable to it. Today the only kind is `'unresolved-name'`, which evaluates
+ * to the empty set. That matters more than it sounds: an empty set satisfies
+ * predicates vacuously (`no Playr` is `true`), so a typo produces the same
+ * *value* as a selector that legitimately matched nothing. This is the only
+ * signal separating the two.
+ */
+export interface EvaluationDiagnostic {
+  /** Machine-readable category, e.g. `'unresolved-name'`. */
+  kind: string;
+  severity: 'warning' | 'info';
+  /** The name that could not be resolved, when the kind carries one. */
+  name?: string;
+  /** Human-readable message suitable for showing to a spec author. */
+  message: string;
+  /** Closest name in the instance, when one is near enough to be worth offering. */
+  suggestion?: string;
+}
+
+/**
  * Configuration options for evaluators
  */
 export interface EvaluatorConfig {
@@ -113,7 +137,16 @@ export interface IEvaluatorResult {
   /** Get the raw result data */
   getRawResult(): EvaluatorResult;
 
-  
+  /**
+   * Advisory diagnostics raised while evaluating the expression — a name that
+   * resolved to nothing, say. Distinct from {@link isError}: the evaluation
+   * succeeded, but something about it is worth telling the spec author.
+   *
+   * Optional because only the simple-graph-query evaluator produces these; the
+   * SQL, Forge and layout evaluators simply omit it. Callers should reach for it
+   * with `result.getDiagnostics?.() ?? []`.
+   */
+  getDiagnostics?(): readonly EvaluationDiagnostic[];
 }
 
 /**

--- a/src/layout/error-state.ts
+++ b/src/layout/error-state.ts
@@ -22,6 +22,57 @@ export interface SelectorErrorDetail {
 }
 
 /**
+ * An advisory note about one constraint or directive, raised while generating a
+ * layout. Unlike {@link SelectorErrorDetail} — which records a selector that
+ * *failed* — a warning means the selector evaluated fine but produced something
+ * the spec author probably did not intend.
+ *
+ * The motivating case is an unresolved name. simple-graph-query 3.0 evaluates a
+ * name matching nothing to the empty relation rather than throwing, because an
+ * instance carries only *populated* types and relations: a legitimately-empty
+ * sig looks byte-for-byte like a typo, and a sig can empty out mid-trace. Since
+ * an empty set satisfies predicates vacuously (`no Playr` is `true`), the
+ * warning is the only thing distinguishing a typo from a real empty result —
+ * which is why these must reach the user rather than being dropped.
+ *
+ * Carried on {@link CounterfactualLayoutResult} and on `InstanceLayout` beside
+ * `selectorErrors`, never merged into it: `selectorErrors` stays errors-only so
+ * existing consumers keep their meaning.
+ */
+export interface LayoutWarning {
+  severity: 'warning' | 'error';
+  /** Machine-readable category, so consumers can filter without matching prose. */
+  code: 'unresolved-name' | 'selector-arity' | 'evaluation-failed' | (string & {});
+  /** Human-readable explanation, including what the consequence was. */
+  message: string;
+  /** The selector expression this warning is about. */
+  selector: string;
+  /** Where the selector was being used, e.g. `'orientation selector'`. */
+  context: string;
+  /**
+   * Registry type key of the owning spec item — `'orientation'`, `'atomStyle'`.
+   * Together with {@link specIndex} this names the item the warning came from.
+   */
+  specType?: string;
+  /**
+   * Position within the owning parsed section array.
+   *
+   * This is an index into the *parsed* spec, not a YAML line: `parseLayoutSpec`
+   * uses js-yaml (which discards positions), dedupes entries, and merges `size`
+   * and `hideAtom` across both sections. So it is deterministic and stable, but
+   * not guaranteed to equal the YAML ordinal. Enough to name an item in a
+   * warning; not enough to anchor an editor marker.
+   */
+  specIndex?: number;
+  /** Display label — a constraint's `toHTML()`, else `type[index] · selector`. */
+  label?: string;
+  /** The unresolved name, when the kind carries one. Doubles as the dedup key. */
+  name?: string;
+  /** simple-graph-query's "did you mean" suggestion, when it offers one. */
+  suggestion?: string;
+}
+
+/**
  * Represents different types of errors that can occur in the system
  */
 export type SystemError = {

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -2,6 +2,7 @@ import { Group } from "webcola";
 import { RelativeOrientationConstraint, CyclicOrientationConstraint, AlignConstraint, GroupByField, GroupBySelector, RelativeDirection } from "./layoutspec";
 import { EdgeStyle } from "./edge-style";
 import type { TextStyle } from "./style/text-style";
+import type { LayoutWarning } from "./error-state";
 
 export interface LayoutGroup {
     // The name of the group
@@ -265,6 +266,16 @@ export interface InstanceLayout {
     groups: LayoutGroup[];
     conflictingConstraints?: LayoutConstraint[];
     overlappingNodes?: LayoutNode[]; // IDs of overlapping nodes
+    /**
+     * Advisory notes about constraints and directives that quietly had no effect —
+     * a selector naming something absent from the instance, say.
+     *
+     * Rides on the layout, like `conflictingConstraints` and `overlappingNodes`,
+     * for the same reason: every host calls `generateLayout` itself and then hands
+     * the diagram element only the layout. Carrying warnings here means the
+     * element can surface them without any host wiring.
+     */
+    warnings?: LayoutWarning[];
     /**
      * Disjunctive constraints, where at least one alternative in each disjunction must be satisfiable.
      * These are separate from conjunctive constraints for clearer solver integration.

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -3,7 +3,7 @@ import { IAtom, IDataInstance } from '../data-instance/interfaces';
 import { type PositionalConstraintError, type GroupOverlapError, type HiddenNodeConflictError, type IConstraintValidator, isPositionalConstraintError, isGroupOverlapError, isHiddenNodeConflictError } from './constraint-types';
 import { EdgeStyle, normalizeEdgeStyle } from './edge-style';
 import { resolveIconPath } from './icon-registry';
-import type { SelectorErrorDetail } from './error-state';
+import type { SelectorErrorDetail, LayoutWarning } from './error-state';
 
 
 import {
@@ -51,6 +51,60 @@ const UNIVERSAL_TYPE = "univ";
 type ConstraintSource = RelativeOrientationConstraint | CyclicOrientationConstraint | AlignConstraint | ImplicitConstraint;
 
 /**
+ * Reduces a constraint's `toHTML()` output to plain text.
+ *
+ * `toHTML()` exists to be injected into the error modal's markup, so it wraps
+ * selectors in `<code>`. Warning labels are consumed as *text* — rendered with
+ * textContent, logged to a console, asserted in a test — so the tags have to go,
+ * or every consumer sees a literal `<code>next</code>`. Stripping here rather
+ * than at each render point keeps the label usable everywhere.
+ */
+/**
+ * Spec types written under `constraints:` rather than `directives:`, so a warning
+ * can call the offending item by the name its author used. Mirrors the
+ * `kind: 'constraint'` classification in `src/spec-editor/core/registry.ts` —
+ * note `size` and `hideAtom` are authored as constraints even though
+ * `parseLayoutSpec` files them under `directives`.
+ */
+const CONSTRAINT_SPEC_TYPES: ReadonlySet<string> = new Set([
+    'orientation', 'cyclic', 'align', 'group', 'size', 'hideAtom'
+]);
+
+/**
+ * Composes the user-facing text for an evaluator diagnostic.
+ *
+ * Written here rather than passed through from simple-graph-query: sgq's own
+ * message has to stand alone for any consumer, so it re-explains the empty-set
+ * semantics and how to write a string literal. We already show the offending
+ * item's label above the message and the selector below it, so most of that is
+ * redundant here. What the spec author actually needs is the name that missed
+ * and the consequence.
+ */
+function warningMessage(
+    d: { kind: string; name?: string; message: string },
+    specType: string
+): string {
+    if (d.kind !== 'unresolved-name' || !d.name) {
+        return d.message;
+    }
+    const noun = CONSTRAINT_SPEC_TYPES.has(specType) ? 'constraint' : 'directive';
+    return `'${d.name}' did not match any type, relation, or atom. `
+        + `This ${noun} does not apply to anything.`;
+}
+
+function stripHtml(html: string): string {
+    return html
+        .replace(/<[^>]*>/g, '')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&amp;/g, '&')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+/**
  * Result of layout generation. When constraints are unsatisfiable, `layout`
  * contains a counterfactual diagram built from the maximal feasible subset
  * of constraints, annotated with error metadata (conflictingConstraints,
@@ -60,6 +114,14 @@ type CounterfactualLayoutResult = {
     layout: InstanceLayout;
     error: ConstraintError | null;
     selectorErrors: SelectorErrorDetail[];
+    /**
+     * Advisory notes about individual constraints and directives — a selector
+     * naming something that does not exist, say. The layout still rendered; each
+     * warning explains one item that quietly had no effect. Separate from
+     * `selectorErrors` so that list keeps its errors-only meaning for existing
+     * consumers.
+     */
+    warnings: LayoutWarning[];
     /** The qualitative constraint validator, if used. Exposes modal spatial queries (must/can/cannot). */
     validator?: QualitativeConstraintValidator;
 };
@@ -256,6 +318,24 @@ export class LayoutInstance {
     private selectorErrors: SelectorErrorDetail[] = [];
 
     /**
+     * Collector for advisory warnings about individual constraints and
+     * directives. Reset at the start of each generateLayout() call, so on an
+     * animated trace each frame reports its own state rather than accumulating.
+     */
+    private warnings: LayoutWarning[] = [];
+
+    /**
+     * Dedup keys for {@link warnings}, scoped to one generateLayout() call.
+     *
+     * A single render evaluates the same selector many times over — isAttributeField
+     * and isHiddenField re-evaluate theirs once per graph edge — and one selector
+     * can name the same missing thing repeatedly. Keyed by spec item plus the
+     * unresolved name, so two different constraints with the same typo are still
+     * reported separately.
+     */
+    private warningKeys: Set<string> = new Set();
+
+    /**
      * Map of hidden node IDs to the hideAtom selector that caused them to be hidden.
      * Populated by ensureNoExtraNodes() and used by constraint generation to detect conflicts.
      * Reset at the start of each generateLayout() call.
@@ -302,6 +382,67 @@ export class LayoutInstance {
     }
 
     /**
+     * Records an advisory warning about one constraint or directive.
+     *
+     * Deduplicated within the render, because a selector is typically evaluated
+     * many times per layout and would otherwise report the same missing name once
+     * per evaluation.
+     */
+    private recordWarning(warning: LayoutWarning): void {
+        const key = `${warning.code}|${warning.specType ?? ''}|${warning.specIndex ?? ''}|${warning.name ?? warning.selector}`;
+        if (this.warningKeys.has(key)) {
+            return;
+        }
+        this.warningKeys.add(key);
+        this.warnings.push(warning);
+    }
+
+    /**
+     * Drains any diagnostics the evaluator raised for `selector` and records one
+     * warning per diagnostic, attributed to the spec item that owns the selector.
+     *
+     * Call this after every successful `evaluator.evaluate(...)`. An unresolved
+     * name does not fail evaluation — it yields the empty set — so without this
+     * the constraint silently does nothing and looks identical to one that
+     * legitimately matched nothing.
+     *
+     * @param source - The owning constraint or directive. Constraints supply a
+     *   `toHTML()` label; directives are plain objects and fall back to
+     *   `type[index] · selector`.
+     */
+    private collectSelectorDiagnostics(
+        selectorRes: IEvaluatorResult,
+        selector: string,
+        context: string,
+        specType: string,
+        specIndex: number,
+        source?: { toHTML?: () => string }
+    ): void {
+        const diagnostics = selectorRes.getDiagnostics?.() ?? [];
+        if (diagnostics.length === 0) {
+            return;
+        }
+        const label = typeof source?.toHTML === 'function'
+            ? stripHtml(source.toHTML())
+            : `${specType}[${specIndex}] · ${selector}`;
+
+        for (const d of diagnostics) {
+            this.recordWarning({
+                severity: 'warning',
+                code: d.kind,
+                message: warningMessage(d, specType),
+                selector,
+                context,
+                specType,
+                specIndex,
+                label,
+                name: d.name,
+                suggestion: d.suggestion
+            });
+        }
+    }
+
+    /**
      * Checks whether the selector result has the expected arity.
      * Records a SelectorArityError and returns false if mismatched.
      * @param selectorRes - The evaluated selector result
@@ -335,6 +476,50 @@ export class LayoutInstance {
                 context,
                 new SelectorArityError(selector, 'unary', 'binary')
             );
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Decides whether a just-evaluated selector result is usable, recording
+     * anything noteworthy on the way. Returns false when the owning constraint or
+     * directive should be skipped — every *other* one still applies.
+     *
+     * This exists because `evaluator.evaluate()` does not throw on a bad selector:
+     * simple-graph-query returns an error *result*, and the throw only happens
+     * later, inside `selectedTwoples()` / `selectedAtoms()` / `selectedTuplesAll()`.
+     * At several call sites those extractors sat outside the try/catch, so a single
+     * malformed selector escaped the local handler and killed the whole layout.
+     * `checkSelectorArity` did not catch it either — `maxArity()` reports 0 for an
+     * error result, and arity 0 reads as "no results, nothing to validate".
+     *
+     * @param expectedArity - `'any'` skips the arity check, for sites that legitimately
+     *   accept both (group-by-selector) or validate arity themselves.
+     */
+    private acceptSelectorResult(
+        selectorRes: IEvaluatorResult,
+        selector: string,
+        context: string,
+        expectedArity: 'unary' | 'binary' | 'any',
+        specType: string,
+        specIndex: number,
+        source?: { toHTML?: () => string }
+    ): boolean {
+        // Collect diagnostics before the error check. A selector that warns about an
+        // unresolved name and *then* fails for an unrelated reason should still
+        // surface the warning — that is when it is most worth having.
+        this.collectSelectorDiagnostics(selectorRes, selector, context, specType, specIndex, source);
+
+        // Guarded rather than called outright: `isError` is part of IEvaluatorResult,
+        // but hand-rolled and third-party evaluators in the wild implement only the
+        // extractors they need. Skipping the check for those leaves them exactly as
+        // they behaved before, instead of failing on a missing method.
+        if (typeof selectorRes.isError === 'function' && selectorRes.isError()) {
+            this.recordSelectorError(selector, context, new Error(selectorRes.prettyPrint()));
+            return false;
+        }
+        if (expectedArity !== 'any' && !this.checkSelectorArity(selectorRes, selector, expectedArity, context)) {
             return false;
         }
         return true;
@@ -621,7 +806,7 @@ export class LayoutInstance {
         let groups: LayoutGroup[] = [];
 
         // First we go through the group by selector constraints.
-        for (var gc of groupBySelectorConstraints) {
+        for (const [specIndex, gc] of groupBySelectorConstraints.entries()) {
 
             let selector = gc.selector;
             let selectorRes;
@@ -632,6 +817,11 @@ export class LayoutInstance {
                 continue; // Skip this group constraint
             }
 
+            // Arity is 'any' here: groups intentionally accept both unary and binary
+            // selectors, and the branch below picks the path from maxArity().
+            if (!this.acceptSelectorResult(selectorRes, selector, 'groupBySelector selector', 'any', 'group', specIndex, gc)) {
+                continue; // Skip this group only — every other constraint still applies
+            }
 
             // Now, we should support both unary and binary selectors.
 
@@ -1086,11 +1276,11 @@ export class LayoutInstance {
         // Pre-evaluate all hideAtom directives once (not per node)
         const hiddenAtomDirectives = this._layoutSpec.directives.hiddenAtoms;
         const evaluatedHideDirectives: { selector: string; hiddenSet: Set<string> }[] = [];
-        for (const directive of hiddenAtomDirectives) {
+        for (const [specIndex, directive] of hiddenAtomDirectives.entries()) {
             try {
                 const selectorResult = this.evaluator.evaluate(directive.selector, { instanceIndex: this.instanceNum });
-                if (!this.checkSelectorArity(selectorResult, directive.selector, 'unary', 'hideAtom selector')) {
-                    continue; // Skip — binary selector in unary position (recorded once)
+                if (!this.acceptSelectorResult(selectorResult, directive.selector, 'hideAtom selector', 'unary', 'hideAtom', specIndex)) {
+                    continue; // Skip this directive only (recorded once)
                 }
                 const selectedAtoms = selectorResult.selectedAtoms();
                 evaluatedHideDirectives.push({
@@ -1191,6 +1381,8 @@ export class LayoutInstance {
     ): CounterfactualLayoutResult {
         // Reset selector errors at the start of each layout generation
         this.selectorErrors = [];
+        this.warnings = [];
+        this.warningKeys.clear();
         // Reset hidden-node tracking at the start of each layout generation
         this.hiddenNodeSelectors = new Map();
         this.hiddenNodeConflicts = new Map();
@@ -1405,10 +1597,11 @@ export class LayoutInstance {
         layout.constraints = constraints;
         layout.groups = groups.filter(g => !g.negated);
 
-        // Return layout with selectorErrors (if any) - these don't block the layout
-        // but callers should check and display them to the user
+        // Return layout with selectorErrors and warnings (if any) - neither blocks
+        // the layout, but callers should check and display them to the user
         const qualitativeValidator = validator instanceof QualitativeConstraintValidator ? validator : undefined;
-        return { layout, error: null, selectorErrors: this.selectorErrors, validator: qualitativeValidator };
+        layout.warnings = this.warnings;
+        return { layout, error: null, selectorErrors: this.selectorErrors, warnings: this.warnings, validator: qualitativeValidator };
     }
 
     /**
@@ -1436,13 +1629,15 @@ export class LayoutInstance {
             edges: layoutEdges,
             constraints: context.constraints,
             groups: layoutGroups,
-            disjunctiveConstraints: []
+            disjunctiveConstraints: [],
+            warnings: this.warnings
         };
 
         return {
             layout: counterfactualLayout,
             error,
-            selectorErrors: this.selectorErrors
+            selectorErrors: this.selectorErrors,
+            warnings: this.warnings
         };
     }
 
@@ -1514,13 +1709,15 @@ export class LayoutInstance {
         // Apply the same edge-visibility post-processing that the normal path performs.
         const counterfactualLayout: InstanceLayout = {
             ...layout,
-            edges: this.filterHiddenEdges(layout.edges)
+            edges: this.filterHiddenEdges(layout.edges),
+            warnings: this.warnings
         };
 
         return {
             layout: counterfactualLayout,
             error,
-            selectorErrors: this.selectorErrors
+            selectorErrors: this.selectorErrors,
+            warnings: this.warnings
         };
     }
 
@@ -1549,12 +1746,14 @@ export class LayoutInstance {
             edges: layout.edges,
             constraints,
             groups: layout.groups,
-            conflictingConstraints: [...minimalConflictingSet.values()].flat()
+            conflictingConstraints: [...minimalConflictingSet.values()].flat(),
+            warnings: this.warnings
         };
         return {
             layout: counterfactualLayout,
             error: error,
-            selectorErrors: this.selectorErrors
+            selectorErrors: this.selectorErrors,
+            warnings: this.warnings
         };
     }
 
@@ -1588,11 +1787,13 @@ export class LayoutInstance {
             constraints: layout.constraints,
             groups: overlappingGroups,
             overlappingNodes: error.overlappingNodes,
+            warnings: this.warnings
         }
         return { 
             layout: counterfactualLayout, 
             error: error,
-            selectorErrors: this.selectorErrors
+            selectorErrors: this.selectorErrors,
+            warnings: this.warnings
         };
     }
 
@@ -1615,7 +1816,7 @@ export class LayoutInstance {
         const disjunctions: DisjunctiveConstraint[] = [];
 
         // For each cyclic constraint, extract fragments
-        for (const [, c] of cyclicConstraints.entries()) {
+        for (const [specIndex, c] of cyclicConstraints.entries()) {
             let selectorRes;
             try {
                 selectorRes = this.evaluator.evaluate(c.selector, { instanceIndex: this.instanceNum });
@@ -1623,8 +1824,8 @@ export class LayoutInstance {
                 this.recordSelectorError(c.selector, 'cyclic orientation selector', error);
                 continue; // Skip this cyclic constraint
             }
-            if (!this.checkSelectorArity(selectorRes, c.selector, 'binary', 'cyclic orientation selector')) {
-                continue; // Skip — unary selector in binary position
+            if (!this.acceptSelectorResult(selectorRes, c.selector, 'cyclic orientation selector', 'binary', 'cyclic', specIndex, c)) {
+                continue; // Skip this constraint only — every other one still applies
             }
             let selectedTuples: string[][] = selectorRes.selectedTwoples();
             let nextNodeMap: Map<LayoutNode, LayoutNode[]> = new Map<LayoutNode, LayoutNode[]>();
@@ -1852,7 +2053,7 @@ export class LayoutInstance {
         const leftOfGraph = new Map<string, Set<string>>();
         const aboveGraph = new Map<string, Set<string>>();
 
-        relativeOrientationConstraints.forEach((c: RelativeOrientationConstraint) => {
+        relativeOrientationConstraints.forEach((c: RelativeOrientationConstraint, specIndex: number) => {
 
             let directions = c.directions;
             let selector = c.selector;
@@ -1864,8 +2065,8 @@ export class LayoutInstance {
                 this.recordSelectorError(selector, 'orientation selector', error);
                 return; // Skip this orientation constraint
             }
-            if (!this.checkSelectorArity(selectorRes, selector, 'binary', 'orientation selector')) {
-                return; // Skip — unary selector in binary position
+            if (!this.acceptSelectorResult(selectorRes, selector, 'orientation selector', 'binary', 'orientation', specIndex, c)) {
+                return; // Skip this constraint only — every other one still applies
             }
             let selectedTuples: string[][] = selectorRes.selectedTwoples();
 
@@ -2190,7 +2391,7 @@ export class LayoutInstance {
         // Use normalized key (sorted node IDs) since alignment is symmetric
         const generatedAlignments = new Set<string>();
 
-        alignConstraints.forEach((c: AlignConstraint) => {
+        alignConstraints.forEach((c: AlignConstraint, specIndex: number) => {
             let direction = c.direction;
             let selector = c.selector;
 
@@ -2201,8 +2402,8 @@ export class LayoutInstance {
                 this.recordSelectorError(selector, 'align selector', error);
                 return; // Skip this align constraint
             }
-            if (!this.checkSelectorArity(selectorRes, selector, 'binary', 'align selector')) {
-                return; // Skip — unary selector in binary position
+            if (!this.acceptSelectorResult(selectorRes, selector, 'align selector', 'binary', 'align', specIndex, c)) {
+                return; // Skip this constraint only — every other one still applies
             }
             let selectedTuples: string[][] = selectorRes.selectedTwoples();
 
@@ -2662,12 +2863,12 @@ export class LayoutInstance {
         // (matching `sat_size` in the Lean mechanization: ∀ a ∈ S, b.width = w
         // ∧ b.height = h).
         let sizeDirectives = this._layoutSpec.directives.sizes;
-        sizeDirectives.forEach((sizeDirective) => {
+        sizeDirectives.forEach((sizeDirective, specIndex) => {
             let selectedNodes: string[];
             try {
                 const selectorRes = this.evaluator.evaluate(sizeDirective.selector, { instanceIndex: this.instanceNum });
-                if (!this.checkSelectorArity(selectorRes, sizeDirective.selector, 'unary', 'size selector')) {
-                    return; // Skip — binary selector in unary position
+                if (!this.acceptSelectorResult(selectorRes, sizeDirective.selector, 'size selector', 'unary', 'size', specIndex)) {
+                    return; // Skip this directive only
                 }
                 selectedNodes = selectorRes.selectedAtoms();
             } catch (error) {
@@ -2738,15 +2939,15 @@ export class LayoutInstance {
         const allNodeIdSet = new Set(allNodeIds);
         const rulesByNode: Record<string, AtomStyleRule[]> = {};
 
-        rules.forEach((rule) => {
+        rules.forEach((rule, specIndex) => {
             let matched: string[];
             if (!rule.selector) {
                 matched = allNodeIds; // no selector → applies to every atom
             } else {
                 try {
                     const selectorRes = this.evaluator.evaluate(rule.selector, { instanceIndex: this.instanceNum });
-                    if (!this.checkSelectorArity(selectorRes, rule.selector, 'unary', 'atomStyle selector')) {
-                        return; // Skip — binary selector in unary position
+                    if (!this.acceptSelectorResult(selectorRes, rule.selector, 'atomStyle selector', 'unary', 'atomStyle', specIndex)) {
+                        return; // Skip this rule only
                     }
                     matched = selectorRes.selectedAtoms();
                 } catch (error) {
@@ -2819,12 +3020,12 @@ export class LayoutInstance {
 
         // Apply icon directives first
         let iconDirectives = this._layoutSpec.directives.icons;
-        iconDirectives.forEach((iconDirective) => {
+        iconDirectives.forEach((iconDirective, specIndex) => {
             let selected: string[];
             try {
                 const selectorRes = this.evaluator.evaluate(iconDirective.selector, { instanceIndex: this.instanceNum });
-                if (!this.checkSelectorArity(selectorRes, iconDirective.selector, 'unary', 'icon selector')) {
-                    return; // Skip — binary selector in unary position
+                if (!this.acceptSelectorResult(selectorRes, iconDirective.selector, 'icon selector', 'unary', 'icon', specIndex)) {
+                    return; // Skip this directive only
                 }
                 selected = selectorRes.selectedAtoms();
             } catch (error) {
@@ -3116,8 +3317,12 @@ export class LayoutInstance {
         // Draw-qualified directives need groups to resolve their endpoints, and
         // groups don't exist yet at this point — they run in a second pass
         // (addDrawInferredEdges) after generateGroups().
-        let inferredEdges = this._layoutSpec.directives.inferredEdges.filter(he => !he.draw);
-        inferredEdges.forEach((he) => {
+        // Iterate the full list and skip `draw` directives inline, so specIndex stays
+        // a position in directives.inferredEdges rather than in a filtered copy.
+        this._layoutSpec.directives.inferredEdges.forEach((he, specIndex) => {
+            if (he.draw) {
+                return;
+            }
 
             let res;
             try {
@@ -3125,6 +3330,9 @@ export class LayoutInstance {
             } catch (error) {
                 this.recordSelectorError(he.selector, 'inferredEdge selector', error);
                 return; // Skip this inferred edge
+            }
+            if (!this.acceptSelectorResult(res, he.selector, 'inferredEdge selector', 'any', 'inferredEdge', specIndex)) {
+                return; // Skip this directive only — every other one still applies
             }
 
             let selectedTuples: string[][] = res.selectedTuplesAll();
@@ -3173,8 +3381,12 @@ export class LayoutInstance {
     private addDrawInferredEdges(g: Graph, groups: LayoutGroup[]) {
 
         const inferredEdgePrefix = "_inferred_";
-        const drawDirectives = this._layoutSpec.directives.inferredEdges.filter(he => he.draw);
-        drawDirectives.forEach((he) => {
+        // Iterate the full list and skip non-`draw` directives inline, so specIndex
+        // stays a position in directives.inferredEdges rather than in a filtered copy.
+        this._layoutSpec.directives.inferredEdges.forEach((he, specIndex) => {
+            if (!he.draw) {
+                return;
+            }
 
             const draw = he.draw!;
 
@@ -3223,6 +3435,9 @@ export class LayoutInstance {
             } catch (error) {
                 this.recordSelectorError(he.selector, 'inferredEdge selector', error);
                 return; // Skip this inferred edge
+            }
+            if (!this.acceptSelectorResult(res, he.selector, 'inferredEdge selector', 'any', 'inferredEdge', specIndex)) {
+                return; // Skip this directive only — every other one still applies
             }
 
             // `draw` also supports unary selectors: the single atom feeds both

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { EdgeWithMetadata, NodeWithMetadata, WebColaLayout, WebColaTranslator, NodePositionHint, TransformInfo, LayoutState, WebColaLayoutOptions, WebColaRenderTransitionMode } from './webcolatranslator';
 import { InstanceLayout, isAlignmentConstraint, isInstanceLayout, isLeftConstraint, isTopConstraint, LayoutNode, ColorSource } from '../../layout/interfaces';
+import type { LayoutWarning } from '../../layout/error-state';
 import type { GridRouter, Group, Layout, Node, Link } from 'webcola';
 import { IInputDataInstance, ITuple, IAtom } from '../../data-instance/interfaces';
 import { MAIN_LABEL_FONT_SIZE, SECONDARY_FONT_SIZE, LABEL_LINE_HEIGHT_RATIO, resolveAttrFontSize } from '../../layout/text-extent';
@@ -116,6 +117,14 @@ export class WebColaCnDGraph extends HTMLElementBase {
   private container!: any;
   private currentLayout!: WebColaLayout;
   private colaLayout!: Layout;
+  /** Signature of the warnings currently on screen. See renderLayoutWarnings. */
+  private currentWarningSignature: string | null = null;
+  /**
+   * Signature of the warning set the user dismissed, or null if they haven't.
+   * Compared against each render's signature so a dismissal survives re-renders
+   * of the *same* warnings but does not suppress new ones.
+   */
+  private dismissedWarningSignature: string | null = null;
   private readonly lineFunction: d3.Line<{ x: number; y: number }>;
   /**
    * Snapshot of the seed positions the most-recent policy resolved
@@ -834,6 +843,7 @@ export class WebColaCnDGraph extends HTMLElementBase {
     this.attachShadow({ mode: 'open' });
     this.initializeDOM();
     this.initializeD3();
+    this.setupLayoutWarningsToggle();
 
     // TODO: I'd like to make this better.
     this.lineFunction = d3.line()
@@ -1405,6 +1415,17 @@ export class WebColaCnDGraph extends HTMLElementBase {
       <div id="loading" role="status" aria-live="polite" aria-atomic="true">
         <span class="loading-dot" aria-hidden="true"></span>
         <span id="loading-progress">Computing layout...</span>
+      </div>
+      <div id="layout-warnings" hidden>
+        <div id="layout-warnings-bar">
+          <button id="layout-warnings-badge" type="button" aria-expanded="false" aria-controls="layout-warnings-panel">
+            <span aria-hidden="true">&#9888;</span>
+            <span id="layout-warnings-count"></span>
+            <span id="layout-warnings-caret" aria-hidden="true">&#9656;</span>
+          </button>
+          <button id="layout-warnings-dismiss" type="button" title="Dismiss" aria-label="Dismiss selector warnings">&#215;</button>
+        </div>
+        <div id="layout-warnings-panel" role="region" aria-label="Selector warnings" hidden></div>
       </div>
       <svg id="svg">
         <defs>
@@ -2144,6 +2165,13 @@ export class WebColaCnDGraph extends HTMLElementBase {
     // then race the new render's (the wedged-overlay / never-routed-edges /
     // never-revealed-morph failures).
     this.teardownInflightRender();
+
+    // Surface the advisory warnings this layout carries. Done before the solve
+    // rather than after because the badge describes the *spec*, not the geometry,
+    // so it stays accurate even if this render is later superseded or fails —
+    // but strictly after teardown, which must observe the prior render's state
+    // untouched.
+    this.renderLayoutWarnings(instanceLayout.warnings ?? []);
 
     // Claim the render generation. A superseded render can be torn down at
     // entry only if its solver already exists — a competitor arriving while
@@ -9953,6 +9981,129 @@ export class WebColaCnDGraph extends HTMLElementBase {
         animation: loading-pulse 1s ease-in-out infinite;
       }
 
+      /* Selector warnings: a collapsed summary bar, with detail on demand.
+         An unresolved name yields an empty set rather than an error, so the
+         diagram still renders looking perfectly fine — this bar is the only thing
+         saying a constraint silently did nothing. Collapsed rather than expanded
+         because these are advisory and, on an animated trace, one fires per
+         frame; dismissable because a warning you have already read and decided
+         to live with should not keep shouting. */
+      #layout-warnings {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 1001;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 6px;
+        max-width: min(80%, 420px);
+      }
+
+      #layout-warnings[hidden] {
+        display: none;
+      }
+
+      #layout-warnings-bar {
+        display: flex;
+        align-items: stretch;
+        background: var(--cnd-warning-bg, #fef3c7);
+        border: 1px solid var(--cnd-warning-border, #f59e0b);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+
+      #layout-warnings-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        flex: 1;
+        padding: 4px 10px;
+        background: none;
+        border: none;
+        color: var(--cnd-warning-text, #92400e);
+        font: inherit;
+        font-size: 12px;
+        line-height: 1.6;
+        text-align: left;
+        cursor: pointer;
+      }
+
+      #layout-warnings-badge:hover,
+      #layout-warnings-dismiss:hover {
+        background: var(--cnd-warning-bg-hover, #fde68a);
+      }
+
+      #layout-warnings-badge:focus-visible,
+      #layout-warnings-dismiss:focus-visible {
+        outline: 2px solid var(--cnd-warning-border, #f59e0b);
+        outline-offset: -2px;
+      }
+
+      #layout-warnings-caret {
+        margin-left: auto;
+        font-size: 10px;
+        transition: transform 120ms ease;
+      }
+
+      #layout-warnings-badge[aria-expanded="true"] #layout-warnings-caret {
+        transform: rotate(90deg);
+      }
+
+      #layout-warnings-dismiss {
+        padding: 0 9px;
+        background: none;
+        border: none;
+        border-left: 1px solid var(--cnd-warning-border, #f59e0b);
+        color: var(--cnd-warning-text, #92400e);
+        font: inherit;
+        font-size: 15px;
+        line-height: 1;
+        cursor: pointer;
+      }
+
+      #layout-warnings-panel {
+        max-height: 260px;
+        overflow-y: auto;
+        padding: 8px 10px;
+        background: var(--cnd-panel-bg, rgba(255, 255, 255, 0.97));
+        border: 1px solid var(--cnd-warning-border, #f59e0b);
+        border-radius: 6px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+        color: var(--cnd-loading-text, #374151);
+        font-size: 12px;
+        text-align: left;
+      }
+
+      #layout-warnings-panel[hidden] {
+        display: none;
+      }
+
+      .layout-warning-item + .layout-warning-item {
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px solid var(--cnd-panel-border, rgba(0, 0, 0, 0.12));
+      }
+
+      .layout-warning-label {
+        font-weight: 600;
+      }
+
+      .layout-warning-item code {
+        padding: 0 3px;
+        background: var(--cnd-code-bg, rgba(0, 0, 0, 0.06));
+        border-radius: 3px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+
+      .layout-warning-message {
+        margin-top: 2px;
+      }
+
+      .layout-warning-item[title] {
+        cursor: help;
+      }
+
       #loading-progress {
         overflow: hidden;
         text-overflow: ellipsis;
@@ -10529,6 +10680,124 @@ export class WebColaCnDGraph extends HTMLElementBase {
     this.hideLoading();
     error.style.display = 'block';
     error.textContent = message;
+  }
+
+  /**
+   * Renders the advisory-warning badge for the layout being drawn, and emits
+   * `layout-warnings` so hosts with richer UI can route them elsewhere.
+   *
+   * These ride on the layout rather than arriving through a host callback because
+   * every host — the docs site, the demos, spytial-py, spytial-rust — calls
+   * `generateLayout` itself and hands this element only the resulting layout.
+   * Anything needing extra host wiring would reach nobody.
+   *
+   * The badge is rebuilt per render, so on an animated trace it reflects the
+   * current frame instead of accumulating across frames.
+   */
+  private renderLayoutWarnings(warnings: LayoutWarning[]): void {
+    const container = this.root.querySelector('#layout-warnings') as HTMLElement | null;
+    const badge = this.root.querySelector('#layout-warnings-badge') as HTMLElement | null;
+    const count = this.root.querySelector('#layout-warnings-count') as HTMLElement | null;
+    const panel = this.root.querySelector('#layout-warnings-panel') as HTMLElement | null;
+    if (!container || !badge || !count || !panel) {
+      return; // Template not rendered yet (or overridden by a subclass)
+    }
+
+    if (warnings.length === 0) {
+      container.hidden = true;
+      panel.hidden = true;
+      badge.setAttribute('aria-expanded', 'false');
+      panel.replaceChildren();
+      this.dismissedWarningSignature = null;
+      return;
+    }
+
+    // A dismissal applies to the warnings that were on screen when it happened.
+    // Re-showing an identical set every frame of a trace would make the dismiss
+    // button useless; staying hidden after the warnings *change* would hide new
+    // information. Keying on the set itself gets both.
+    const signature = warnings
+      .map(w => `${w.code}|${w.specType ?? ''}|${w.specIndex ?? ''}|${w.name ?? w.selector}`)
+      .join('\n');
+    if (this.dismissedWarningSignature === signature) {
+      container.hidden = true;
+      return;
+    }
+    this.dismissedWarningSignature = null;
+
+    count.textContent = `${warnings.length} selector ${warnings.length === 1 ? 'warning' : 'warnings'}`;
+    badge.setAttribute('title', 'Click for detail');
+    this.currentWarningSignature = signature;
+
+    // Built with DOM calls rather than innerHTML: every field below is authored
+    // data (selector text, an instance's own names) and must not be parsed as markup.
+    panel.replaceChildren(...warnings.map(w => {
+      const item = document.createElement('div');
+      item.className = 'layout-warning-item';
+
+      const label = document.createElement('div');
+      label.className = 'layout-warning-label';
+      label.textContent = w.label ?? `${w.specType ?? 'spec'}[${w.specIndex ?? 0}]`;
+      item.appendChild(label);
+
+      const message = document.createElement('div');
+      message.className = 'layout-warning-message';
+      message.textContent = w.message;
+      item.appendChild(message);
+
+      // The suggestion is available on hover, not as visible text. It is only a
+      // guess: simple-graph-query takes the nearest name within one or two edits,
+      // over atom ids as well as types and relations, so it can propose something
+      // meaningless in selector position. Putting it behind a hover keeps it
+      // reachable without letting a guess read like a diagnosis. It remains on
+      // `LayoutWarning.suggestion` for programmatic consumers either way.
+      if (w.suggestion) {
+        item.title = `Did you mean '${w.suggestion}'?`;
+      }
+
+      const where = document.createElement('div');
+      where.className = 'layout-warning-message';
+      where.append(`${w.context}: `);
+      const selector = document.createElement('code');
+      selector.textContent = w.selector;
+      where.appendChild(selector);
+      item.appendChild(where);
+
+      return item;
+    }));
+
+    // Preserve the open/closed state across re-renders — on an animated trace the
+    // badge re-renders every frame, and a panel that snapped shut each time would
+    // be unreadable.
+    panel.hidden = badge.getAttribute('aria-expanded') !== 'true';
+    container.hidden = false;
+
+    this.dispatchEvent(new CustomEvent('layout-warnings', {
+      detail: { warnings },
+      bubbles: true
+    }));
+  }
+
+  /** Wires the warning bar's expand/collapse and dismiss controls. Called once, at setup. */
+  private setupLayoutWarningsToggle(): void {
+    const container = this.root.querySelector('#layout-warnings') as HTMLElement | null;
+    const badge = this.root.querySelector('#layout-warnings-badge') as HTMLElement | null;
+    const panel = this.root.querySelector('#layout-warnings-panel') as HTMLElement | null;
+    const dismiss = this.root.querySelector('#layout-warnings-dismiss') as HTMLElement | null;
+    if (!container || !badge || !panel || !dismiss) {
+      return;
+    }
+    badge.addEventListener('click', () => {
+      const willExpand = badge.getAttribute('aria-expanded') !== 'true';
+      badge.setAttribute('aria-expanded', String(willExpand));
+      panel.hidden = !willExpand;
+    });
+    dismiss.addEventListener('click', () => {
+      this.dismissedWarningSignature = this.currentWarningSignature;
+      container.hidden = true;
+      panel.hidden = true;
+      badge.setAttribute('aria-expanded', 'false');
+    });
   }
 
   // =========================================

--- a/tests/selector-warnings.test.ts
+++ b/tests/selector-warnings.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
+
+/**
+ * Tests that simple-graph-query's unresolved-name diagnostics reach the user.
+ *
+ * From sgq 3.0 on, a name matching nothing in the instance evaluates to the empty
+ * relation and raises a warning rather than throwing. That is the right call —
+ * an instance carries only *populated* types and relations, so a legitimately
+ * empty sig is indistinguishable from a typo — but it means an empty set
+ * satisfies predicates vacuously and a mistyped selector produces exactly the
+ * same *value* as one that legitimately matched nothing. The diagnostic is the
+ * only thing separating them, so it has to survive all the way to the surface.
+ */
+
+function createEvaluator(instance: JSONDataInstance): SGraphQueryEvaluator {
+    const evaluator = new SGraphQueryEvaluator();
+    evaluator.initialize({ sourceData: instance });
+    return evaluator;
+}
+
+const graphData: IJsonDataInstance = {
+    atoms: [
+        { id: 'A', type: 'Node', label: 'A' },
+        { id: 'B', type: 'Node', label: 'B' },
+        { id: 'C', type: 'Node', label: 'C' },
+    ],
+    relations: [
+        {
+            id: 'next',
+            name: 'next',
+            types: ['Node', 'Node'],
+            tuples: [
+                { atoms: ['A', 'B'], types: ['Node', 'Node'] },
+                { atoms: ['B', 'C'], types: ['Node', 'Node'] },
+            ],
+        },
+        {
+            id: 'peer',
+            name: 'peer',
+            types: ['Node', 'Node'],
+            tuples: [
+                { atoms: ['A', 'C'], types: ['Node', 'Node'] },
+            ],
+        },
+    ],
+};
+
+describe('Selector warnings', () => {
+    // ── Evaluator level ───────────────────────────────────────────
+
+    describe('SGraphQueryEvaluator diagnostics', () => {
+        it('reports an unresolved name, with a suggestion', () => {
+            const evaluator = createEvaluator(new JSONDataInstance(graphData));
+            const result = evaluator.evaluate('nxt');
+
+            const diagnostics = result.getDiagnostics?.() ?? [];
+            expect(diagnostics.length).toBe(1);
+            expect(diagnostics[0].kind).toBe('unresolved-name');
+            expect(diagnostics[0].name).toBe('nxt');
+            expect(diagnostics[0].suggestion).toBe('next');
+        });
+
+        it('raises nothing for a name that resolves', () => {
+            const evaluator = createEvaluator(new JSONDataInstance(graphData));
+            const result = evaluator.evaluate('next');
+
+            expect(result.getDiagnostics?.() ?? []).toHaveLength(0);
+        });
+
+        /**
+         * The regression that matters most. `evaluate` memoizes by expression, so if
+         * diagnostics were held anywhere but on the cached result object, the warning
+         * would appear on the first evaluation and silently vanish on every hit after
+         * — which is precisely the failure this feature exists to prevent. A single
+         * render evaluates the same selector many times over (isAttributeField
+         * re-evaluates its selector once per graph edge), so nearly every evaluation
+         * after the first is a cache hit.
+         */
+        it('replays diagnostics on a cache hit', () => {
+            const evaluator = createEvaluator(new JSONDataInstance(graphData));
+
+            const first = evaluator.evaluate('nxt').getDiagnostics?.() ?? [];
+            const second = evaluator.evaluate('nxt').getDiagnostics?.() ?? [];
+            const third = evaluator.evaluate('nxt').getDiagnostics?.() ?? [];
+
+            expect(first).toHaveLength(1);
+            expect(second).toHaveLength(1);
+            expect(third).toHaveLength(1);
+            expect(second[0].name).toBe('nxt');
+        });
+
+        it('does not leak diagnostics between different expressions', () => {
+            const evaluator = createEvaluator(new JSONDataInstance(graphData));
+
+            evaluator.evaluate('nxt');
+            const clean = evaluator.evaluate('next').getDiagnostics?.() ?? [];
+
+            expect(clean).toHaveLength(0);
+        });
+    });
+
+    // ── Layout level ──────────────────────────────────────────────
+
+    describe('generateLayout warnings', () => {
+        it('attributes an unresolved name to the constraint that used it', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: nxt
+      directions: [above]
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+            const { warnings } = layoutInstance.generateLayout(instance);
+
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0].code).toBe('unresolved-name');
+            expect(warnings[0].severity).toBe('warning');
+            expect(warnings[0].selector).toBe('nxt');
+            expect(warnings[0].context).toBe('orientation selector');
+            expect(warnings[0].specType).toBe('orientation');
+            expect(warnings[0].specIndex).toBe(0);
+            expect(warnings[0].name).toBe('nxt');
+            expect(warnings[0].suggestion).toBe('next');
+            // Our own wording, not sgq's pass-through: the name that missed and the
+            // consequence, with the suggestion kept out of the sentence.
+            expect(warnings[0].message).toBe(
+                "'nxt' did not match any type, relation, or atom. "
+                + 'This constraint does not apply to anything.'
+            );
+            // Constraints carry toHTML(), so the label names the actual constraint —
+            // reduced to plain text, since it is rendered and logged as text.
+            expect(warnings[0].label).toContain('nxt');
+            expect(warnings[0].label).not.toContain('<code>');
+        });
+
+        it('calls a directive a directive, not a constraint', () => {
+            const spec = parseLayoutSpec(`
+directives:
+  - atomStyle:
+      selector: Nod
+      fillStyle:
+        color: red
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+            const { warnings } = layoutInstance.generateLayout(instance);
+
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0].specType).toBe('atomStyle');
+            expect(warnings[0].message).toContain('This directive does not apply to anything.');
+        });
+
+        it('indexes each constraint within its own section', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: next
+      directions: [above]
+  - orientation:
+      selector: nxt
+      directions: [left]
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+            const { warnings } = layoutInstance.generateLayout(instance);
+
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0].specIndex).toBe(1);
+        });
+
+        it('emits one warning per name, not one per evaluation', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: nxt
+      directions: [above]
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+            const { warnings } = layoutInstance.generateLayout(instance);
+
+            expect(warnings).toHaveLength(1);
+        });
+
+        it('reports two different constraints with the same typo separately', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: nxt
+      directions: [above]
+  - align:
+      selector: nxt
+      direction: horizontal
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+            const { warnings } = layoutInstance.generateLayout(instance);
+
+            expect(warnings).toHaveLength(2);
+            expect(warnings.map(w => w.specType).sort()).toEqual(['align', 'orientation']);
+        });
+
+        it('reports nothing when every selector resolves', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: next
+      directions: [above]
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+            const { warnings } = layoutInstance.generateLayout(instance);
+
+            expect(warnings).toHaveLength(0);
+        });
+
+        it('carries warnings on the layout, so the diagram element sees them', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: nxt
+      directions: [above]
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+            const { layout } = layoutInstance.generateLayout(instance);
+
+            expect(layout.warnings).toHaveLength(1);
+            expect(layout.warnings![0].name).toBe('nxt');
+        });
+
+        it('resets warnings between renders rather than accumulating', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: nxt
+      directions: [above]
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+
+            layoutInstance.generateLayout(instance);
+            layoutInstance.generateLayout(instance);
+            const { warnings } = layoutInstance.generateLayout(instance);
+
+            // An animated trace re-renders per frame; the badge must show the current
+            // frame's state, not a list that grows without bound.
+            expect(warnings).toHaveLength(1);
+        });
+    });
+
+    // ── One bad selector must not take the others down ────────────
+
+    describe('a failing selector is isolated to its own constraint', () => {
+        /**
+         * `evaluator.evaluate()` does not throw on a malformed selector — sgq returns
+         * an error *result*, and the throw only happens later inside selectedTwoples().
+         * At several sites that extractor sat outside the try/catch, so one bad
+         * selector escaped the local handler and killed the whole layout.
+         */
+        it('does not abort the layout, and keeps the other constraints', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - orientation:
+      selector: "next +"
+      directions: [above]
+  - orientation:
+      selector: next
+      directions: [left]
+  - align:
+      selector: peer
+      direction: horizontal
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+
+            const result = layoutInstance.generateLayout(instance);
+
+            expect(result.layout.nodes.length).toBe(3);
+            const badSelector = result.selectorErrors.find(e => e.selector === 'next +');
+            expect(badSelector).toBeDefined();
+            expect(badSelector!.context).toBe('orientation selector');
+
+            // The two good constraints still produced geometry.
+            expect(result.layout.constraints.length).toBeGreaterThan(0);
+        });
+
+        it('leaves a group with a bad selector without dropping the rest', () => {
+            const spec = parseLayoutSpec(`
+constraints:
+  - group:
+      selector: "next +"
+      name: broken
+  - orientation:
+      selector: next
+      directions: [above]
+`);
+            const instance = new JSONDataInstance(graphData);
+            const layoutInstance = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+
+            const result = layoutInstance.generateLayout(instance);
+
+            expect(result.layout.nodes.length).toBe(3);
+            expect(result.layout.groups).toHaveLength(0);
+            expect(result.selectorErrors.some(e => e.context === 'groupBySelector selector')).toBe(true);
+        });
+    });
+});

--- a/tests/webcola-teardown.test.ts
+++ b/tests/webcola-teardown.test.ts
@@ -243,6 +243,9 @@ describe('WebColaCnDGraph overlapping renders', () => {
         const fakeThis: any = {
           renderGeneration: 0,
           teardownInflightRender: vi.fn(() => order.push('teardown')),
+          // Runs between teardown and transition-mode resolution; stubbed so the
+          // ordering assertions below still see exactly two entries.
+          renderLayoutWarnings: vi.fn(),
           resolveTransitionMode: vi.fn(() => { order.push('resolveTransitionMode'); return 'replace'; }),
           hasValidTransform: () => false,
           applyViewportRenderPolicy: vi.fn(),

--- a/webcola-demo/alloy-demo.html
+++ b/webcola-demo/alloy-demo.html
@@ -658,15 +658,16 @@
                 layoutResult = layoutInstance.generateLayout(instanceForLayout);
                 currentInstanceLayout = layoutResult.layout;
 
-                // 1. Check for selector errors first - early out if present
+                // 1. Report selector errors, but keep rendering. A broken selector drops
+                // only its own constraint; every other one still applied, so the diagram
+                // is worth showing. (This used to set `unsat` and bail, which left the
+                // user with a blank diagram and — since showSelectorErrors was never
+                // defined — no explanation.)
                 if (layoutResult.selectorErrors && layoutResult.selectorErrors.length > 0) {
                     console.warn('Selector errors:', layoutResult.selectorErrors);
                     if (window.showSelectorErrors) {
                         window.showSelectorErrors(layoutResult.selectorErrors);
                     }
-                    const webcolaGraphElement = document.getElementById('graph-container');
-                    webcolaGraphElement.setAttribute('unsat', '');
-                    return;
                 }
 
                 // 2. Standard IIS/constraint error handling

--- a/webcola-demo/dot-demo.html
+++ b/webcola-demo/dot-demo.html
@@ -575,15 +575,16 @@
             const layoutResult = layoutInstance.generateLayout(cachedInstance);
             currentInstanceLayout = layoutResult.layout;
 
-            // Handle selector errors
+            // Report selector errors, but keep rendering. A broken selector drops only
+            // its own constraint; every other one still applied, so the diagram is worth
+            // showing. (This used to set `unsat` and bail, which left the user with a
+            // blank diagram and — since showSelectorErrors was never defined — no
+            // explanation.)
             if (layoutResult.selectorErrors && layoutResult.selectorErrors.length > 0) {
                 console.warn('Selector errors:', layoutResult.selectorErrors);
                 if (window.showSelectorErrors) {
                     window.showSelectorErrors(layoutResult.selectorErrors);
                 }
-                const webcolaGraphElement = document.getElementById('graph-container');
-                webcolaGraphElement.setAttribute('unsat', '');
-                return;
             }
 
             // Handle constraint errors

--- a/webcola-demo/json-demo.html
+++ b/webcola-demo/json-demo.html
@@ -473,15 +473,16 @@
             const layoutResult = layoutInstance.generateLayout(instanceForLayout);
             currentInstanceLayout = layoutResult.layout;
 
-            // 1. Check for selector errors first - early out if present
+            // 1. Report selector errors, but keep rendering. A broken selector drops
+            // only its own constraint; every other one still applied, so the diagram
+            // is worth showing. (This used to set `unsat` and bail, which left the
+            // user with a blank diagram and — since showSelectorErrors was never
+            // defined — no explanation.)
             if (layoutResult.selectorErrors && layoutResult.selectorErrors.length > 0) {
                 console.warn('Selector errors:', layoutResult.selectorErrors);
                 if (window.showSelectorErrors) {
                     window.showSelectorErrors(layoutResult.selectorErrors);
                 }
-                const webcolaGraphElement = document.getElementById('graph-container');
-                webcolaGraphElement.setAttribute('unsat', '');
-                return;
             }
 
             // 2. Standard IIS/constraint error handling


### PR DESCRIPTION
Closes part of #510. Bumps `simple-graph-query` to `^3.0.0` and gives its diagnostics a route to the user.

## Why

In 3.0 a name matching nothing evaluates to the **empty relation** and raises a warning rather than throwing. That is the right call — an instance carries only *populated* types and relations, so a legitimately empty sig is byte-for-byte indistinguishable from a typo, and a sig can empty out mid-trace.

It also makes surfacing them load-bearing. An empty set satisfies predicates **vacuously** — `no Playr` is `true`, `Playr in Player` is `true` — so a mistyped selector produces the same *value* as one that legitimately matched nothing. The diagnostic is the only thing separating them. Bump without surfacing and typos become invisible.

No query migration was needed here. The only `@:` uses in this repo (`site/getting-started.md`) compare `@:` against `@:`, never against a bare identifier.

## Diagnostics ride on the result, not on the evaluator

`evaluate` memoizes by expression, so a drain-once channel on the evaluator would report on the first call and go silent on every hit after — the exact failure this feature exists to prevent. The LRU caches the *wrapped result*, so holding diagnostics as a field on `SGQEvaluatorResult` makes cache hits replay them for free.

This bites within a single render, not just across frames: `isAttributeField` re-evaluates its selector once per graph edge, so nearly every evaluation after the first is a cache hit. There is a regression test that evaluates the same bad selector three times and asserts the warning survives.

`IEvaluatorResult.getDiagnostics?()` is optional, so the SQL, Forge and three layout result classes need no change.

## Fixes a pre-existing abort: one bad selector killed the whole layout

Found while wiring this up; it is live on `main` and independent of the bump.

`evaluator.evaluate()` never throws on a malformed selector — sgq returns an error *result*, and the throw happens later inside `selectedTwoples()` / `selectedAtoms()` / `selectedTuplesAll()`. At six sites those extractors sat **outside** the try/catch:

```ts
try { selectorRes = this.evaluator.evaluate(selector, {...}); }
catch (error) { this.recordSelectorError(...); return; }
if (!this.checkSelectorArity(selectorRes, selector, 'binary', 'orientation selector')) return;
let selectedTuples = selectorRes.selectedTwoples();   // <- outside the try; throws
```

`checkSelectorArity` did not stop it either: `maxArity()` reports `0` for an error result, and arity `0` reads as "no results, nothing to validate".

Orientation, align and cyclic landed in `generateLayout`'s catch, which rethrows anything that is not a `MissingNodeConstraintError`. `generateGroups`, `addinferredEdges` and `addDrawInferredEdges` are called outside that try entirely and propagated straight out.

A new `acceptSelectorResult()` collects diagnostics, checks `isError`, and checks arity in one call. A broken selector now drops only its own constraint; every other one still applies.

## Attribution

Each warning carries `specType` + `specIndex` and a label — a constraint's own `toHTML()`, reduced to plain text so consumers do not see a literal `<code>` tag.

The index is a position in the **parsed** array, not a YAML line: `parseLayoutSpec` uses js-yaml (which discards positions), dedupes, and merges `size`/`hideAtom` across both sections. Deterministic and stable, enough to name an item; not enough to anchor an editor marker. Exact YAML anchoring would stamp positions at parse time with the eemeli `yaml` parser already used by `spec-editor/core/code-positioning.ts` — left for whenever the editor wants inline markers.

## Surface

Every host — the docs site, the demos, spytial-py, spytial-rust — calls `generateLayout` itself and hands the element only the layout, so anything needing extra host wiring would reach nobody. Warnings therefore ride on `InstanceLayout`, following the precedent of `conflictingConstraints`/`overlappingNodes`.

The element renders a collapsed `⚠ 2 selector warnings ▸` bar, expandable on click and dismissable. Dismissal is keyed to the warning *set*, so it survives re-renders of the same warnings but does not suppress new ones — otherwise it would be useless on an animated trace. A `layout-warnings` event fires for hosts with their own UI.

Messages are composed here rather than passed through from sgq, whose text must stand alone for any consumer and re-explains empty-set semantics we already show:

```
'pear' did not match any type, relation, or atom. This constraint does not apply to anything.
'Nod'  did not match any type, relation, or atom. This directive does not apply to anything.
```

Constraint vs. directive comes from a table mirroring the spec-editor registry's `kind` — note `size` and `hideAtom` are authored under `constraints:` even though the parser files them under `directives`.

The suggestion is deliberately **not** visible text. `suggestName` takes the nearest name within `name.length <= 4 ? 1 : 2` edits over atom ids as well as types and relations, so it can propose something meaningless in selector position. It is available on hover and on `LayoutWarning.suggestion`.

## What is deliberately unchanged

- `selectorErrors` stays errors-only, so the demos, `selector-arity-validation.test.ts` and `ErrorMessageModal`'s `selector-error` branch keep their meaning. Two arrays, not one widened array.
- The React `ErrorMessageModal` path. `ErrorStateManager` holds a single `SystemError`, so routing warnings through it would let a warning displace a live UNSAT error.

## Demos

All three no longer set `unsat` and bail on `selectorErrors`. That early-out is why one bad selector rendered a blank diagram — and the `window.showSelectorErrors` it guarded on was never defined anywhere in the repo.

## Two test changes worth review

Both were real signals, not noise:

1. `webcola-teardown.test.ts` caught that I had placed `renderLayoutWarnings` **before** `teardownInflightRender()`, violating the documented "teardown first" invariant. Moved after teardown; the test gains a stub for the new collaborator.
2. `acceptSelectorResult` guards `isError` with a `typeof` check. Hand-rolled stubs in `layout-instance.test.ts` implement only the extractors they use, and third-party evaluators may too — skipping the check for those leaves them exactly as they behaved before rather than failing on a missing method.

## Verification

- 2043 tests across 144 files pass. 14 are new in `tests/selector-warnings.test.ts`; **11 fail without the fix** (verified by stashing `src/`).
- Typecheck holds at the 73-error baseline — identical count before and after.
- `npm run build:all` exits 0.
- Browser, `webcola-demo/json-demo.html`: a spec with one misspelled selector plus two good constraints renders all three nodes with four constraints applied, shows the collapsed bar, and reports the warning on **all three** re-renders — confirming the cache path, which is the one failure mode that looks like success on a single pass.

## Out of scope (per #510)

Re-vendoring the downstream bundles, and the 13 authored query sites in spytial-py (9) and spytial-rust (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
