### PR TITLE
feat(warnings): surface deprecated spec forms on the diagram and in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ That's the entire core pipeline. Where `jsonPayload` and `yamlSpec` come from is
 | Layer                | Highlights                                                                            |
 |----------------------|---------------------------------------------------------------------------------------|
 | **Data instances**   | `JSONDataInstance`, `AlloyDataInstance`, `DotDataInstance`, `PyretDataInstance`, `TlaDataInstance`, plus the `IDataInstance` interface for custom adapters. |
-| **Spec language**    | YAML constraints (`orientation`, `align`, `cyclic`, `group`, `size`, `hideAtom`) and directives (`atomColor`, `edgeColor`, `icon`, `attribute`, `tag`, `inferredEdge`, `flag`, …). |
+| **Spec language**    | YAML constraints (`orientation`, `align`, `cyclic`, `group`, `size`, `hideAtom`) and directives (`atomStyle`, `edgeStyle`, `icon`, `attribute`, `tag`, `inferredEdge`, `flag`, …). |
 | **Selector engine**  | `SGraphQueryEvaluator` (Forge-style relational expressions) plus optional Forge / SQL evaluators. |
 | **Layout solver**    | `LayoutInstance` + `QualitativeConstraintValidator` — qualitative spatial constraints with IIS reporting. |
 | **Renderers**        | `<webcola-cnd-graph>` (visual), `<spytial-explorer>` (a11y + spatial REPL; opt-in via `spytial-core/explorer` since 4.0.0), `AccessibleTranslator` (semantic HTML / alt-text). |

--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -213,7 +213,9 @@ For a binary selector with tuples `(a, b), (a, c), (a, d)`, the group is keyed b
 
 ---
 
-### Group Constraint (by Field)
+### Group Constraint (by Field) — *legacy*
+
+> **Deprecated:** prefer [group by selector](#group-constraint-by-selector) above. The field form still groups exactly as before, but it raises a deprecation warning. To migrate, give a binary selector whose first column is the group key and whose second is the members (plus the `name` that form requires). Over `worksIn: Employee -> Department`, `field: worksIn` with `groupOn: 1` / `addToGroup: 0` keys on Department, so it becomes `selector: ~worksIn`.
 
 Groups elements based on a relational field (tuple-based grouping).
 

--- a/site/directives.md
+++ b/site/directives.md
@@ -703,19 +703,29 @@ Creates edges that don't exist in your data but are **computed from a selector e
     name: <edge-label>           # Required
     selector: <binary-selector>  # Required
     draw: <end> -> <end>         # Optional: what each end attaches to
-    color: <color>               # Optional (default: #000000)
-    style: <line-style>          # Optional (default: solid)
-    weight: <number>             # Optional
+    lineStyle:                   # Optional: the drawn line
+      color: <color>
+      pattern: <solid|dashed|dotted>
+      weight: <number>
+      highlight: <color>
+    textStyle:                   # Optional: the edge label
+      size: <small|normal|large>
+      color: <color>
 ```
+
+> **The flat inline `color` / `style` / `weight` / `highlight` are the legacy form** and still parse (`style`→`pattern`), with a deprecation warning. Use the `lineStyle` block — the same one `edgeStyle` and group connectors take.
 
 | Field | Required | Type | Default | Description |
 |-------|----------|------|---------|-------------|
 | `name` | Yes | string | — | Label displayed on the edge |
 | `selector` | Yes | string | — | Binary selector returning (source, target) pairs (unary allowed with `draw`) |
 | `draw` | No | string | — | `<end> -> <end>`, each end `_` (the atom, the default) or a group-constraint name (attach to the hull of that constraint's group keyed by this end's atom) |
-| `color` | No | string | `#000000` | CSS color |
-| `style` | No | string | `solid` | `solid`, `dashed`, or `dotted` |
-| `weight` | No | number | — | Line thickness in pixels |
+| `lineStyle.color` | No | string | `#000000` | CSS color of the line |
+| `lineStyle.pattern` | No | string | `solid` | `solid`, `dashed`, or `dotted` |
+| `lineStyle.weight` | No | number | — | Line thickness in pixels |
+| `lineStyle.highlight` | No | string | — | CSS color drawn as a wider, translucent underlay beneath the line |
+| `textStyle.size` | No | string | — | `small`, `normal`, or `large` |
+| `textStyle.color` | No | string | — | CSS color of the edge label |
 
 ### Group endpoints (`draw`)
 
@@ -734,16 +744,13 @@ The group name must match a `group` constraint (checked at parse time). A keyed 
 - inferredEdge:
     name: "reachable"
     selector: "^parent"
-    color: gray
-    style: dotted
+    lineStyle: { color: gray, pattern: dotted }
 
 # Highlight computed relationships
 - inferredEdge:
     name: "sibling"
     selector: "~parent.parent - iden"
-    color: purple
-    style: dashed
-    weight: 2
+    lineStyle: { color: purple, pattern: dashed, weight: 2 }
 
 # Group-to-group: one dashed edge per `connected` pair, drawn hull to hull
 # (assumes a group constraint named regions keyed by Region atoms)
@@ -777,7 +784,7 @@ The group name must match a `group` constraint (checked at parse time). A keyed 
 constraints:
   - orientation: { selector: parent, directions: [above] }
 directives:
-  - inferredEdge: { name: "reachable", selector: "^parent", color: gray, style: dotted }
+  - inferredEdge: { name: "reachable", selector: "^parent", lineStyle: { color: gray, pattern: dotted } }
 </template>
 </div>
 

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -74,11 +74,11 @@ directives:
 - attribute: { field: nid }
 - hideAtom:  { selector: NoneType + int }
 - hideAtom:  { selector: str }
-- atomColor: { selector: "{x: Node | @num:(x.nid) = 0}", value: red }
-- atomColor: { selector: "{x: Node | @num:(x.nid) = 1}", value: blue }
-- atomColor: { selector: "{x: Node | (@num:(x.nid) > 1)}", value: black }
-- edgeColor: { field: hi, value: green }
-- edgeColor: { field: lo, value: orange }
+- atomStyle: { selector: "{x: Node | @num:(x.nid) = 0}", borderStyle: { color: red } }
+- atomStyle: { selector: "{x: Node | @num:(x.nid) = 1}", borderStyle: { color: blue } }
+- atomStyle: { selector: "{x: Node | (@num:(x.nid) > 1)}", borderStyle: { color: black } }
+- edgeStyle: { field: hi, lineStyle: { color: green } }
+- edgeStyle: { field: lo, lineStyle: { color: orange } }
 </template>
 
 Compilers can vectorize loops you never wrote. IDEs can finish functions before you do. Agents can refactor your codebase from a sentence. And yet, when you want to inspect the value your program just produced, you still use the REPL as if nothing has changed in fifty years: type a variable name, get text back, squint. Here is Python showing you a binary decision diagram:
@@ -183,11 +183,11 @@ constraints:
 - orientation: { selector: "{x, y : Node | x->y in lo and (@num:(y.nid) > 1)}", directions: [left] }
 - orientation: { selector: "{x, y : Node | x->y in hi and (@num:(y.nid) > 1)}", directions: [right] }
 directives:
-- atomColor: { selector: "{x: Node | @num:(x.nid) = 0}", value: red }
-- atomColor: { selector: "{x: Node | @num:(x.nid) = 1}", value: blue }
-- atomColor: { selector: "{x: Node | (@num:(x.nid) > 1)}", value: black }
-- edgeColor: { field: hi, value: green }
-- edgeColor: { field: lo, value: orange }
+- atomStyle: { selector: "{x: Node | @num:(x.nid) = 0}", borderStyle: { color: red } }
+- atomStyle: { selector: "{x: Node | @num:(x.nid) = 1}", borderStyle: { color: blue } }
+- atomStyle: { selector: "{x: Node | (@num:(x.nid) > 1)}", borderStyle: { color: black } }
+- edgeStyle: { field: hi, lineStyle: { color: green } }
+- edgeStyle: { field: lo, lineStyle: { color: orange } }
 ```
 
 <div class="step-pair">
@@ -247,7 +247,7 @@ constraints:
   - orientation: { selector: left,  directions: [below, left]  }
   - orientation: { selector: right, directions: [below, right] }
 directives:
-  - atomColor: { selector: Node, value: "#4a90d9" }
+  - atomStyle: { selector: Node, borderStyle: { color: "#4a90d9" } }
 </template>
 </div>
 

--- a/site/json-data.md
+++ b/site/json-data.md
@@ -157,9 +157,9 @@ constraints:
 directives:
   - attribute:
       field: age
-  - atomColor:
+  - atomStyle:
       selector: Person
-      value: "#4a90d9"
+      borderStyle: { color: "#4a90d9" }
   - flag: hideDisconnectedBuiltIns
 ```
 
@@ -196,7 +196,7 @@ constraints:
   - orientation: { selector: parent, directions: [above] }
 directives:
   - attribute: { field: age }
-  - atomColor: { selector: Person, value: "#4a90d9" }
+  - atomStyle: { selector: Person, borderStyle: { color: "#4a90d9" } }
   - flag: hideDisconnectedBuiltIns
 </template>
 </div>

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -45,7 +45,7 @@ Save the following as `demo.html`, then open it in a browser:
       constraints:
         - orientation: { selector: parent, directions: [above] }
       directives:
-        - atomColor: { selector: Node, value: "#4a90d9" }
+        - atomStyle: { selector: Node, borderStyle: { color: "#4a90d9" } }
         - flag: hideDisconnectedBuiltIns
     `;
 
@@ -91,7 +91,7 @@ The four numbered comments map directly to the [pipeline stages](pipeline.md). I
 constraints:
   - orientation: { selector: parent, directions: [above] }
 directives:
-  - atomColor: { selector: Node, value: "#4a90d9" }
+  - atomStyle: { selector: Node, borderStyle: { color: "#4a90d9" } }
   - flag: hideDisconnectedBuiltIns
 </template>
 </div>

--- a/site/selectors.md
+++ b/site/selectors.md
@@ -32,7 +32,7 @@ The key concept to understand is **arity** — how many "columns" a selector ret
 
 A **unary selector** returns a *set of atoms*. It answers the question: **"which nodes?"**
 
-Used by: `atomColor`, `align`, `hideAtom`, `icon`, `size`, `group` (by selector)
+Used by: `atomStyle`, `align`, `hideAtom`, `icon`, `size`, `group` (by selector)
 
 ```yaml
 # All Node atoms
@@ -93,9 +93,9 @@ constraints:
 
 directives:
   # Unary selector: color all nodes
-  - atomColor:
+  - atomStyle:
       selector: Node
-      value: "#4a90d9"
+      borderStyle: { color: "#4a90d9" }
 
   # Show key as attribute instead of edge
   - attribute:
@@ -105,8 +105,7 @@ directives:
   - inferredEdge:
       name: "descendant"
       selector: "^(left + right)"
-      color: gray
-      style: dotted
+      lineStyle: { color: gray, pattern: dotted }
 
   - flag: hideDisconnectedBuiltIns
 ```
@@ -154,9 +153,9 @@ constraints:
   - orientation: { selector: right, directions: [below, right] }
   - align:       { selector: "Node - left.Node - right.Node",  direction: horizontal }
 directives:
-  - atomColor:    { selector: Node, value: "#4a90d9" }
+  - atomStyle:    { selector: Node, borderStyle: { color: "#4a90d9" } }
   - attribute:    { field: key }
-  - inferredEdge: { name: "descendant", selector: "^(left + right)", color: gray, style: dotted }
+  - inferredEdge: { name: "descendant", selector: "^(left + right)", lineStyle: { color: gray, pattern: dotted } }
   - flag: hideDisconnectedBuiltIns
 </template>
 </div>

--- a/site/yaml-reference.md
+++ b/site/yaml-reference.md
@@ -34,8 +34,8 @@ Both sections are optional. An empty specification is valid.
 
 | Directive | Purpose | Required Fields |
 |-----------|---------|-----------------|
-| [`atomColor`](directives.md#atom-color) | Color nodes | `selector`, `value` |
-| [`edgeColor`](directives.md#edge-styling) | Style edges | `field`, `value` |
+| [`atomStyle`](directives.md#atom-styling) | Style nodes (fill, border, label) | `selector` |
+| [`edgeStyle`](directives.md#edge-styling) | Style edges (line, label) | `field` |
 | [`icon`](directives.md#icons) | Assign icons to nodes | `selector`, `path` |
 | [`size`](directives.md#size-directive) | Set node dimensions | `selector` |
 | [`projection`](directives.md#projection) | Project over a type | `sig` |
@@ -52,7 +52,7 @@ Both sections are optional. An empty specification is valid.
 
 Selectors use [Forge](https://forge-fm.org/docs/building-models/constraints/formulas-and-expressions/) relational syntax. [AlaSQL](https://alasql.org/) is also supported as an alternative. See the full [Selector Syntax](selectors.md) guide.
 
-**Unary selectors** return a set of atoms — used by `atomColor`, `align`, `hideAtom`, `icon`, `group`, `size`:
+**Unary selectors** return a set of atoms — used by `atomStyle`, `align`, `hideAtom`, `icon`, `group`, `size`:
 
 ```yaml
 selector: Node                        # All Node atoms
@@ -96,14 +96,13 @@ constraints:
 
 directives:
   # Visual styling
-  - atomColor:
+  - atomStyle:
       selector: Person
-      value: "#4a90d9"
+      borderStyle: { color: "#4a90d9" }
 
-  - edgeColor:
+  - edgeStyle:
       field: error
-      value: red
-      style: dashed
+      lineStyle: { color: red, pattern: dashed }
 
   - attribute:
       field: age

--- a/src/components/NoCodeView/shims.ts
+++ b/src/components/NoCodeView/shims.ts
@@ -177,7 +177,8 @@ const KNOWN_TOP_LEVEL_KEYS = ['constraints', 'directives'];
  * Validate a Spytial spec YAML string and return detailed results: YAML syntax
  * is checked first, then unrecognized top-level keys and constraint/directive
  * types are flagged as warnings, then the spec is parsed with the authoritative
- * `parseLayoutSpec` to surface structural errors.
+ * `parseLayoutSpec` to surface structural errors — and its own warnings about
+ * deprecated forms, which join the ones found here.
  *
  * @param yamlString - YAML to validate
  * @public
@@ -249,7 +250,15 @@ export function validateSpytialSpec(yamlString: string): SpytialValidationResult
   }
 
   try {
-    parseLayoutSpec(yamlString);
+    // The parse is authoritative for errors, and it also reports the spec's use
+    // of deprecated forms (atomColor, edgeColor, group-by-field, inferredEdge's
+    // inline line styling). Those are warnings in exactly this sense — the spec
+    // parses and renders, but rests on something that is going away — so they
+    // join the ones collected above rather than being dropped on the floor.
+    const spec = parseLayoutSpec(yamlString);
+    for (const warning of spec.warnings ?? []) {
+      result.warnings.push(warning.message.replace(/^\[spytial\]\s*/, ''));
+    }
   } catch (error) {
     result.isValid = false;
     result.error = `Spytial spec error: ${(error as Error).message}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,12 @@ export const version = '1.0.0';
 // (npm) or load dist/components/react-component-integration.global.js (CDN),
 // which also exposes the window.mount* API.
 export { ErrorStateManager } from './layout/error-state';
-export type { SystemError, SelectorErrorDetail } from './layout/error-state';
+// LayoutWarning is exported because consumers *receive* it — it rides on
+// `InstanceLayout.warnings` and on the `layout-warnings` event — and until now
+// there was no name to import for it. The exports map blocks a deep import of
+// the declaration, so the only way to annotate one was an indexed access into
+// InstanceLayout.
+export type { SystemError, SelectorErrorDetail, LayoutWarning } from './layout/error-state';
 
 // REPL expression parser (React-free; kept for Pyret hosts using the global)
 export { PyretExpressionParser } from './components/ReplInterface/parsers/PyretExpressionParser';

--- a/src/layout/error-state.ts
+++ b/src/layout/error-state.ts
@@ -35,6 +35,13 @@ export interface SelectorErrorDetail {
  * warning is the only thing distinguishing a typo from a real empty result —
  * which is why these must reach the user rather than being dropped.
  *
+ * The other source is the spec parse itself: `parseLayoutSpec` raises a
+ * `'deprecated'` {@link ParseWarning} for a legacy form (`atomColor`,
+ * `edgeColor`, group-by-field, `inferredEdge`'s inline line styling), and
+ * `LayoutInstance` forwards those onto the layout as warnings too. Same reason:
+ * the spec works, quietly, on a form that is going away — and the console is
+ * not somewhere a diagram's author looks.
+ *
  * Carried on {@link CounterfactualLayoutResult} and on `InstanceLayout` beside
  * `selectorErrors`, never merged into it: `selectorErrors` stays errors-only so
  * existing consumers keep their meaning.
@@ -42,12 +49,16 @@ export interface SelectorErrorDetail {
 export interface LayoutWarning {
   severity: 'warning' | 'error';
   /** Machine-readable category, so consumers can filter without matching prose. */
-  code: 'unresolved-name' | 'selector-arity' | 'evaluation-failed' | (string & {});
+  code: 'unresolved-name' | 'selector-arity' | 'evaluation-failed' | 'deprecated' | (string & {});
   /** Human-readable explanation, including what the consequence was. */
   message: string;
-  /** The selector expression this warning is about. */
-  selector: string;
-  /** Where the selector was being used, e.g. `'orientation selector'`. */
+  /**
+   * The selector expression this warning is about. Absent when the warning is
+   * not about a selector at all — a `'deprecated'` warning is raised while
+   * *parsing* the spec, before any selector is evaluated.
+   */
+  selector?: string;
+  /** Where the warning came from, e.g. `'orientation selector'`, `'spec'`. */
   context: string;
   /**
    * Registry type key of the owning spec item — `'orientation'`, `'atomStyle'`.

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -389,12 +389,43 @@ export class LayoutInstance {
      * per evaluation.
      */
     private recordWarning(warning: LayoutWarning): void {
-        const key = `${warning.code}|${warning.specType ?? ''}|${warning.specIndex ?? ''}|${warning.name ?? warning.selector}`;
+        const key = `${warning.code}|${warning.specType ?? ''}|${warning.specIndex ?? ''}|${warning.name ?? warning.selector ?? warning.message}`;
         if (this.warningKeys.has(key)) {
             return;
         }
         this.warningKeys.add(key);
         this.warnings.push(warning);
+    }
+
+    /**
+     * Forwards the warnings `parseLayoutSpec` raised about the spec itself —
+     * today, use of a deprecated form — onto this render's warning list.
+     *
+     * They are the same kind of thing the selector warnings are: the diagram
+     * drew, nothing failed, but something in the spec deserves the author's
+     * attention. The parse writes them to `console.warn` as well, which reaches
+     * whoever opens devtools and nobody else; riding on the layout puts them on
+     * the same badge as everything else, in front of the person editing the spec.
+     *
+     * Re-run per `generateLayout` call rather than once in the constructor, since
+     * `this.warnings` is cleared each render (an animated trace reports its own
+     * frame). The spec does not change between frames, so this replays the same
+     * list — which is what should happen: the deprecation is still true.
+     */
+    private recordSpecParseWarnings(): void {
+        for (const w of this._layoutSpec.warnings ?? []) {
+            this.recordWarning({
+                severity: 'warning',
+                code: w.code,
+                // The `[spytial]` prefix marks the source in a console shared with
+                // the host page. On our own badge it is noise.
+                message: w.message.replace(/^\[spytial\]\s*/, ''),
+                // Where it came from: the spec text, not any one evaluation.
+                context: 'spec',
+                specType: w.specType,
+                label: w.specType ?? 'spec'
+            });
+        }
     }
 
     /**
@@ -1383,6 +1414,9 @@ export class LayoutInstance {
         this.selectorErrors = [];
         this.warnings = [];
         this.warningKeys.clear();
+        // Spec-level warnings (deprecated forms) first, so they read before the
+        // per-item selector warnings this render is about to collect.
+        this.recordSpecParseWarnings();
         // Reset hidden-node tracking at the start of each layout generation
         this.hiddenNodeSelectors = new Map();
         this.hiddenNodeConflicts = new Map();

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -204,11 +204,16 @@ export class GroupBySelector extends ConstraintOperation{
 }
 
 
-/*
-
-    TODO: Deprecate.
-
-*/
+/**
+ * Grouping by a relational field: `groupOn` and `addToGroup` index into each
+ * tuple of `field` to pick the group key and its members.
+ *
+ * @deprecated Use {@link GroupBySelector} instead — a binary selector whose
+ * first column is the key and whose second is the members says the same thing
+ * without the tuple indices. Retained for backwards compatibility: it still
+ * parses and groups exactly as before, behind a deprecation warning raised by
+ * {@link parseLayoutSpec}.
+ */
 export class GroupByField  {
     // And applies to selects the thing to group ON
     field : string;

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -477,6 +477,13 @@ function assertValidSizeParams(size: Record<string, unknown>, context: string): 
 export interface ParseWarning {
     code: 'deprecated' | (string & {});
     message: string;
+    /**
+     * The spec form the warning is about, named as the YAML key an author would
+     * recognise (`'atomColor'`, `'edgeColor'`, `'inferredEdge'`, `'group'`).
+     * Lets a consumer label the warning without parsing the prose — `LayoutInstance`
+     * uses it to attribute the deprecation when it forwards these onto the layout.
+     */
+    specType?: string;
 }
 
 export interface LayoutSpec {
@@ -578,7 +585,7 @@ export function parseLayoutSpec(s: string): LayoutSpec {
 
     if (constraints && Array.isArray(constraints)) {
         try {
-          let constraintsParsed = parseConstraints(constraints);
+          let constraintsParsed = parseConstraints(constraints, warnings);
           layoutSpec.constraints = constraintsParsed;
           
           // Also extract size and hideAtom from constraints
@@ -756,10 +763,17 @@ function removeDuplicateGroupByFieldConstraints(constraints: GroupByField[]): Gr
  * @returns List of CnD constraints
  * @throws Error if there are inconsistencies in the constraints.
  */
-function parseConstraints(constraints: unknown[]):   ConstraintsBlock
+function parseConstraints(constraints: unknown[], warnings: ParseWarning[] = []):   ConstraintsBlock
 {
     // Type assertion since we expect specific structure from YAML
     const rawConstraints = constraints as Record<string, any>[];
+
+    // Same dual emission as parseDirectives: console for back-compat, and the
+    // consumable accumulator that rides out on the spec.
+    const deprecate = (specType: string, message: string): void => {
+        console.warn(message);
+        warnings.push({ code: 'deprecated', message, specType });
+    };
 
     // Pre-process: determine negation from "hold: never" field
     const typedConstraints = rawConstraints.map((c): Record<string, any> & { _negated: boolean } => {
@@ -836,8 +850,19 @@ function parseConstraints(constraints: unknown[]):   ConstraintsBlock
     relativeOrientationConstraints = removeDuplicateRelativeOrientationConstraints(relativeOrientationConstraints);
 
 
-    let byfield: GroupByField[] = typedConstraints.filter(c => c.group)
-        .filter(c => c.group.field)
+    // group-by-field (`field` + `groupOn` + `addToGroup`) is the deprecated flat
+    // form of grouping. It still parses and groups exactly as before; the
+    // supported form is a group-by-selector over a binary relation.
+    const rawByField = typedConstraints.filter(c => c.group).filter(c => c.group.field);
+    if (rawByField.length > 0) {
+        deprecate(
+            'group',
+            "[spytial] group's 'field'/'groupOn'/'addToGroup' are deprecated and will be " +
+            "removed in a future major; use a group with a binary 'selector' instead — " +
+            "its first column is the group key, its second the members."
+        );
+    }
+    let byfield: GroupByField[] = rawByField
         .map(c => {
 
             // If not, we parse from the CORE constraint
@@ -953,9 +978,9 @@ function parseDirectives(directives: unknown[], warnings: ParseWarning[] = []): 
 
     // Emit a deprecation both to the console (back-compat: several tests assert
     // this) and to the consumable `warnings` accumulator (rides out on the spec).
-    const deprecate = (message: string): void => {
+    const deprecate = (specType: string, message: string): void => {
         console.warn(message);
-        warnings.push({ code: 'deprecated', message });
+        warnings.push({ code: 'deprecated', message, specType });
     };
 
     // CURRENTLY NO SUGAR HERE!
@@ -979,6 +1004,7 @@ function parseDirectives(directives: unknown[], warnings: ParseWarning[] = []): 
     const rawAtomColors = typedDirectives.filter(d => d.atomColor);
     if (rawAtomColors.length > 0) {
         deprecate(
+            'atomColor',
             "[spytial] 'atomColor' is deprecated and will be removed in a future major; " +
             "use 'atomStyle' with a 'borderStyle' block (value→borderStyle.color), " +
             "or a 'fillStyle' block for a real interior fill."
@@ -1009,6 +1035,7 @@ function parseDirectives(directives: unknown[], warnings: ParseWarning[] = []): 
     const rawEdgeColors = typedDirectives.filter(d => d.edgeColor);
     if (rawEdgeColors.length > 0) {
         deprecate(
+            'edgeColor',
             "[spytial] 'edgeColor' is deprecated and will be removed in a future major; " +
             "use 'edgeStyle' with a 'lineStyle' block " +
             "(value→lineStyle.color, style→lineStyle.pattern, weight→lineStyle.weight, highlight→lineStyle.highlight)."
@@ -1061,6 +1088,7 @@ function parseDirectives(directives: unknown[], warnings: ParseWarning[] = []): 
     });
     if (usedLegacyInferredInline) {
         deprecate(
+            'inferredEdge',
             "[spytial] inferredEdge's inline 'color'/'style'/'weight'/'highlight' are deprecated; " +
             "use a 'lineStyle' block (color, pattern, weight, highlight) instead."
         );

--- a/src/spec-editor/core/diagnostics.ts
+++ b/src/spec-editor/core/diagnostics.ts
@@ -59,18 +59,34 @@ const CONSTRAINT_STRUCTURAL_KEYS: readonly string[] = ['hold'];
 /**
  * Per-type keys the engine accepts but the registry does not expose as builder
  * fields, so the unknown-key check must not report them as typos:
- *  - `inferredEdge` still parses the deprecated flat `color`/`style`/`weight`/
- *    `highlight` (its own deprecation warning covers them).
  *  - `edgeColor` is the deprecated flat form; `edgeColorToEdgeStyleRule` reads
- *    these extras beyond the fields the registry lists.
+ *    these extras beyond the fields the registry lists. The type itself is
+ *    marked deprecated, so its own diagnostic already covers them.
  *
  * NOTE: this mirrors the engine parser (`layoutspec.ts` + the style-spec
  * parsers). If a directive gains an inner key there, add it here (or as a real
  * registry field) or valid specs will draw a spurious warning.
  */
 const EXTRA_ACCEPTED_KEYS_BY_TYPE: Readonly<Record<string, readonly string[]>> = {
-  inferredEdge: ['color', 'style', 'weight', 'highlight'],
   edgeColor: ['highlight', 'showLabel', 'hidden', 'filter'],
+};
+
+/**
+ * Per-type keys the engine still parses but has deprecated, mapped to what
+ * replaces each. These are neither unknown (the diagram honours them) nor fine
+ * (they are going away), so they get their own `'deprecated'` diagnostic rather
+ * than an "unknown field" warning or — as before — silence.
+ *
+ * Mirrors the engine's own parse-time deprecations in `layoutspec.ts`, which
+ * warn about the same keys on the diagram surface. Keep the two in step.
+ */
+const DEPRECATED_KEYS_BY_TYPE: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  inferredEdge: {
+    color: 'lineStyle.color',
+    style: 'lineStyle.pattern',
+    weight: 'lineStyle.weight',
+    highlight: 'lineStyle.highlight',
+  },
 };
 
 /** Levenshtein edit distance (case-insensitive at the call site). */
@@ -155,6 +171,8 @@ function checkUnknownKeys(item: SpecItem, def: ItemDefinition): Diagnostic[] {
     for (const k of CONSTRAINT_STRUCTURAL_KEYS) allowed.add(k);
   }
   for (const k of EXTRA_ACCEPTED_KEYS_BY_TYPE[item.type] ?? []) allowed.add(k);
+  const deprecatedKeys = DEPRECATED_KEYS_BY_TYPE[item.type] ?? {};
+  for (const k of Object.keys(deprecatedKeys)) allowed.add(k);
 
   // Prefer the raw parsed body when present: a custom `fromYamlNode` (group /
   // flag) copies only recognized keys into `params`, so a typo like `naem` would
@@ -163,6 +181,17 @@ function checkUnknownKeys(item: SpecItem, def: ItemDefinition): Diagnostic[] {
   // items (which only ever hold known fields).
   const topLevel = isRecord(item.sourceBody) ? item.sourceBody : item.params;
   for (const key of Object.keys(topLevel)) {
+    const replacement = deprecatedKeys[key];
+    if (replacement !== undefined) {
+      out.push({
+        severity: 'warning',
+        code: 'deprecated',
+        message: `"${key}" on ${def.label} is deprecated. Use "${replacement}" instead.`,
+        itemId: item.id,
+        source: 'structure',
+      });
+      continue;
+    }
     if (allowed.has(key)) continue;
     out.push(unknownKeyDiagnostic(key, fieldKeys, def.label, item.id));
   }

--- a/src/spec-editor/core/diagnostics.ts
+++ b/src/spec-editor/core/diagnostics.ts
@@ -79,15 +79,20 @@ const EXTRA_ACCEPTED_KEYS_BY_TYPE: Readonly<Record<string, readonly string[]>> =
  *
  * Mirrors the engine's own parse-time deprecations in `layoutspec.ts`, which
  * warn about the same keys on the diagram surface. Keep the two in step.
+ *
+ * A Map, not an object literal, because both levels are keyed by strings that
+ * come from the spec: an object literal would answer `deprecatedKeys['toString']`
+ * with something inherited from `Object.prototype`, and a spec key named after
+ * any prototype member would draw a nonsense deprecation.
  */
-const DEPRECATED_KEYS_BY_TYPE: Readonly<Record<string, Readonly<Record<string, string>>>> = {
-  inferredEdge: {
-    color: 'lineStyle.color',
-    style: 'lineStyle.pattern',
-    weight: 'lineStyle.weight',
-    highlight: 'lineStyle.highlight',
-  },
-};
+const DEPRECATED_KEYS_BY_TYPE: ReadonlyMap<string, ReadonlyMap<string, string>> = new Map([
+  ['inferredEdge', new Map([
+    ['color', 'lineStyle.color'],
+    ['style', 'lineStyle.pattern'],
+    ['weight', 'lineStyle.weight'],
+    ['highlight', 'lineStyle.highlight'],
+  ])],
+]);
 
 /** Levenshtein edit distance (case-insensitive at the call site). */
 function editDistance(a: string, b: string): number {
@@ -171,8 +176,8 @@ function checkUnknownKeys(item: SpecItem, def: ItemDefinition): Diagnostic[] {
     for (const k of CONSTRAINT_STRUCTURAL_KEYS) allowed.add(k);
   }
   for (const k of EXTRA_ACCEPTED_KEYS_BY_TYPE[item.type] ?? []) allowed.add(k);
-  const deprecatedKeys = DEPRECATED_KEYS_BY_TYPE[item.type] ?? {};
-  for (const k of Object.keys(deprecatedKeys)) allowed.add(k);
+  // Not added to `allowed`: the loop below reports them before it consults it.
+  const deprecatedKeys = DEPRECATED_KEYS_BY_TYPE.get(item.type);
 
   // Prefer the raw parsed body when present: a custom `fromYamlNode` (group /
   // flag) copies only recognized keys into `params`, so a typo like `naem` would
@@ -181,7 +186,7 @@ function checkUnknownKeys(item: SpecItem, def: ItemDefinition): Diagnostic[] {
   // items (which only ever hold known fields).
   const topLevel = isRecord(item.sourceBody) ? item.sourceBody : item.params;
   for (const key of Object.keys(topLevel)) {
-    const replacement = deprecatedKeys[key];
+    const replacement = deprecatedKeys?.get(key);
     if (replacement !== undefined) {
       out.push({
         severity: 'warning',

--- a/src/spec-editor/ui/BuilderView.tsx
+++ b/src/spec-editor/ui/BuilderView.tsx
@@ -19,8 +19,8 @@
  * labelled with their YAML key and a "preserved as written" note — they survive
  * round-trips untouched.
  *
- * Diagnostics that belong to the item rather than to one of its fields — a
- * deprecated type (`atomColor`) or a deprecated key (`inferredEdge`'s inline
+ * Diagnostics that belong to a registered item rather than to one of its fields
+ * — a deprecated type (`atomColor`) or a deprecated key (`inferredEdge`'s inline
  * `color`) — are listed at the top of the expanded panel, since the per-field
  * renderer has nowhere to put them.
  *
@@ -371,10 +371,11 @@ const Row: React.FC<RowProps> = ({
   );
   const severity = topSeverity(itemDiagnostics);
 
-  // Diagnostics about the item as a whole rather than one of its fields —
-  // a deprecated type or key, an unknown type, a `def.validate()` result.
-  // `FieldRenderer` buckets by `fieldKey` and so cannot show these; without
-  // this list they were a severity dot with no readable message anywhere.
+  // Diagnostics about the item as a whole rather than one of its fields — a
+  // deprecated type or key, a `def.validate()` result. `FieldRenderer` buckets
+  // by `fieldKey` and so cannot show these; without this list they were a
+  // severity dot with no readable message anywhere. (Unknown *types* are not
+  // among them: those items return above, before this panel exists.)
   const itemLevelDiagnostics = useMemo(
     () => itemDiagnostics.filter((d) => d.fieldKey === undefined),
     [itemDiagnostics],

--- a/src/spec-editor/ui/BuilderView.tsx
+++ b/src/spec-editor/ui/BuilderView.tsx
@@ -1,9 +1,11 @@
 /**
  * {@link BuilderView} — the compact, schema-driven row list of the spec editor.
  *
- * Each constraint/directive is a single compact row: a kind badge, the type
- * label, a live `summary(params)`, a diagnostic dot when the item has issues,
- * and an overflow menu (duplicate · delete · move up/down · add comment).
+ * Each constraint/directive is a single compact row: the type label, a live
+ * `summary(params)`, a diagnostic dot when the item has issues, and an overflow
+ * menu (duplicate · delete · move up/down · add comment). No per-row kind badge
+ * — the rows already sit under a "Constraints" or "Directives" heading, so a
+ * C/D stamp on every one of them only repeated it.
  * Clicking a row expands it inline (accordion: exactly one open at a time, Esc
  * collapses) into the generated form rendered by {@link FieldRenderer} from the
  * registry definition, plus a "negate" toggle for types that support `hold` and
@@ -383,9 +385,6 @@ const Row: React.FC<RowProps> = ({
     return (
       <li className="spytial-ed-row spytial-ed-row--unknown">
         <div className="spytial-ed-row-main">
-          <span className="spytial-ed-badge spytial-ed-badge--unknown">
-            {item.kind === 'constraint' ? 'C' : 'D'}
-          </span>
           <span className="spytial-ed-row-type">{item.type}</span>
           <span className="spytial-ed-row-summary spytial-ed-row-summary--muted">
             preserved as written
@@ -422,12 +421,6 @@ const Row: React.FC<RowProps> = ({
           disabled={disabled}
           onClick={() => onToggleExpand(item.id)}
         >
-          <span
-            className={`spytial-ed-badge spytial-ed-badge--${item.kind}`}
-            aria-hidden="true"
-          >
-            {item.kind === 'constraint' ? 'C' : 'D'}
-          </span>
           <span className="spytial-ed-row-type">{def.label}</span>
           {negated ? (
             <span

--- a/src/spec-editor/ui/BuilderView.tsx
+++ b/src/spec-editor/ui/BuilderView.tsx
@@ -17,6 +17,11 @@
  * labelled with their YAML key and a "preserved as written" note — they survive
  * round-trips untouched.
  *
+ * Diagnostics that belong to the item rather than to one of its fields — a
+ * deprecated type (`atomColor`) or a deprecated key (`inferredEdge`'s inline
+ * `color`) — are listed at the top of the expanded panel, since the per-field
+ * renderer has nowhere to put them.
+ *
  * This component is domain-blind about completion/synthesis: the parent passes a
  * `selectorProps(item, field)` callback that composes the real sources.
  */
@@ -364,6 +369,15 @@ const Row: React.FC<RowProps> = ({
   );
   const severity = topSeverity(itemDiagnostics);
 
+  // Diagnostics about the item as a whole rather than one of its fields —
+  // a deprecated type or key, an unknown type, a `def.validate()` result.
+  // `FieldRenderer` buckets by `fieldKey` and so cannot show these; without
+  // this list they were a severity dot with no readable message anywhere.
+  const itemLevelDiagnostics = useMemo(
+    () => itemDiagnostics.filter((d) => d.fieldKey === undefined),
+    [itemDiagnostics],
+  );
+
   // Unknown / unregistered types render read-only ("preserved as written").
   if (!def) {
     return (
@@ -462,6 +476,20 @@ const Row: React.FC<RowProps> = ({
             }
           }}
         >
+          {itemLevelDiagnostics.length > 0 ? (
+            <ul className="spytial-ed-diagnostics spytial-ed-diagnostics--item">
+              {itemLevelDiagnostics.map((d, i) => (
+                <li
+                  key={i}
+                  className={`spytial-ed-diagnostic spytial-ed-diagnostic--${d.severity}`}
+                >
+                  <span className="spytial-ed-diagnostic-dot" aria-hidden="true" />
+                  <span className="spytial-ed-diagnostic-msg">{d.message}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
           <FieldRenderer
             fields={visibleFields(def.fields)}
             values={item.params}

--- a/src/spec-editor/ui/spec-editor.css
+++ b/src/spec-editor/ui/spec-editor.css
@@ -740,6 +740,23 @@
   text-overflow: ellipsis;
 }
 
+/* Item-level diagnostics (deprecated type/key, unknown type, validate()) sit at
+   the top of an expanded row rather than under a control. They get the full
+   panel width, so — unlike the one-line field diagnostics — they wrap instead
+   of truncating: the message names the replacement to move to, which is the
+   part that would be cut off. */
+.spytial-ed-diagnostics--item {
+  gap: 0.2em;
+}
+.spytial-ed-diagnostics--item .spytial-ed-diagnostic {
+  white-space: normal;
+  overflow: visible;
+}
+.spytial-ed-diagnostics--item .spytial-ed-diagnostic-msg {
+  overflow: visible;
+  text-overflow: clip;
+}
+
 .spytial-ed-diagnostic-dot {
   flex: 0 0 auto;
   inline-size: 0.5em;

--- a/src/spec-editor/ui/spec-editor.css
+++ b/src/spec-editor/ui/spec-editor.css
@@ -1185,34 +1185,6 @@
     calc(var(--spytial-ed-gap, 8px) * 0.75);
 }
 
-/* kind badge as an inked stamp: outlined, mono, square */
-.spytial-ed-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: 1.5em;
-  block-size: 1.5em;
-  flex: 0 0 auto;
-  font-family: var(--spytial-ed-chrome-font);
-  font-size: 0.72em;
-  font-weight: 700;
-  border-radius: var(--spytial-ed-radius-sm, 2px);
-  background: transparent;
-}
-
-.spytial-ed-badge--constraint {
-  color: var(--spytial-ed-accent, #b5431a);
-  border: 1px solid var(--spytial-ed-accent, #b5431a);
-}
-.spytial-ed-badge--directive {
-  color: var(--spytial-ed-syn-type, #0e6b6b);
-  border: 1px solid var(--spytial-ed-syn-type, #0e6b6b);
-}
-.spytial-ed-badge--unknown {
-  color: var(--spytial-ed-text-muted, #6e6553);
-  border: 1px dashed var(--spytial-ed-text-muted, #6e6553);
-}
-
 .spytial-ed-row-type {
   font-family: var(--spytial-ed-chrome-font);
   font-size: 0.88em;

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -1423,9 +1423,9 @@ export class WebColaCnDGraph extends HTMLElementBase {
             <span id="layout-warnings-count"></span>
             <span id="layout-warnings-caret" aria-hidden="true">&#9656;</span>
           </button>
-          <button id="layout-warnings-dismiss" type="button" title="Dismiss" aria-label="Dismiss selector warnings">&#215;</button>
+          <button id="layout-warnings-dismiss" type="button" title="Dismiss" aria-label="Dismiss spec warnings">&#215;</button>
         </div>
-        <div id="layout-warnings-panel" role="region" aria-label="Selector warnings" hidden></div>
+        <div id="layout-warnings-panel" role="region" aria-label="Spec warnings" hidden></div>
       </div>
       <svg id="svg">
         <defs>
@@ -10693,6 +10693,10 @@ export class WebColaCnDGraph extends HTMLElementBase {
    *
    * The badge is rebuilt per render, so on an animated trace it reflects the
    * current frame instead of accumulating across frames.
+   *
+   * The list mixes two kinds: per-item selector diagnostics, and deprecation
+   * notices `parseLayoutSpec` raised about the spec's own forms. A deprecation
+   * carries no selector, so its detail row is the label and message only.
    */
   private renderLayoutWarnings(warnings: LayoutWarning[]): void {
     const container = this.root.querySelector('#layout-warnings') as HTMLElement | null;
@@ -10717,7 +10721,7 @@ export class WebColaCnDGraph extends HTMLElementBase {
     // button useless; staying hidden after the warnings *change* would hide new
     // information. Keying on the set itself gets both.
     const signature = warnings
-      .map(w => `${w.code}|${w.specType ?? ''}|${w.specIndex ?? ''}|${w.name ?? w.selector}`)
+      .map(w => `${w.code}|${w.specType ?? ''}|${w.specIndex ?? ''}|${w.name ?? w.selector ?? w.message}`)
       .join('\n');
     if (this.dismissedWarningSignature === signature) {
       container.hidden = true;
@@ -10725,7 +10729,9 @@ export class WebColaCnDGraph extends HTMLElementBase {
     }
     this.dismissedWarningSignature = null;
 
-    count.textContent = `${warnings.length} selector ${warnings.length === 1 ? 'warning' : 'warnings'}`;
+    // "spec", not "selector": the list now mixes selector diagnostics with
+    // deprecation notices raised while parsing the spec.
+    count.textContent = `${warnings.length} spec ${warnings.length === 1 ? 'warning' : 'warnings'}`;
     badge.setAttribute('title', 'Click for detail');
     this.currentWarningSignature = signature;
 
@@ -10755,13 +10761,18 @@ export class WebColaCnDGraph extends HTMLElementBase {
         item.title = `Did you mean '${w.suggestion}'?`;
       }
 
-      const where = document.createElement('div');
-      where.className = 'layout-warning-message';
-      where.append(`${w.context}: `);
-      const selector = document.createElement('code');
-      selector.textContent = w.selector;
-      where.appendChild(selector);
-      item.appendChild(where);
+      // Where it came from — only for warnings that are about a selector. A
+      // deprecation has none (it is raised at parse time), and the label already
+      // names the directive, so the row would be an empty `<code>`.
+      if (w.selector) {
+        const where = document.createElement('div');
+        where.className = 'layout-warning-message';
+        where.append(`${w.context}: `);
+        const selector = document.createElement('code');
+        selector.textContent = w.selector;
+        where.appendChild(selector);
+        item.appendChild(where);
+      }
 
       return item;
     }));

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -10720,8 +10720,14 @@ export class WebColaCnDGraph extends HTMLElementBase {
     // Re-showing an identical set every frame of a trace would make the dismiss
     // button useless; staying hidden after the warnings *change* would hide new
     // information. Keying on the set itself gets both.
+    //
+    // Sorted, so the key is genuinely the set and not the order it arrived in:
+    // warnings are collected as the render walks the instance, and two frames
+    // holding the same warnings can collect them in a different order. Without
+    // the sort, that reads as a change and the badge reappears after dismissal.
     const signature = warnings
       .map(w => `${w.code}|${w.specType ?? ''}|${w.specIndex ?? ''}|${w.name ?? w.selector ?? w.message}`)
+      .sort()
       .join('\n');
     if (this.dismissedWarningSignature === signature) {
       container.hidden = true;

--- a/tests/deprecation-warnings.test.ts
+++ b/tests/deprecation-warnings.test.ts
@@ -4,6 +4,7 @@ import { parseLayoutSpec } from '../src/layout/layoutspec';
 import { LayoutInstance } from '../src/layout/layoutinstance';
 import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
 import { validateItem, newId, type SpecItem } from '../src/spec-editor';
+import { validateSpytialSpec } from '../src/components/NoCodeView';
 
 /**
  * Tests that using a deprecated spec form is *visible* — on the diagram, the
@@ -185,6 +186,31 @@ describe('Deprecation warnings', () => {
                 "directives:\n  - atomStyle: { selector: Node, fillStyle: { color: '#ff0000' } }",
             );
             expect(warnings).toEqual([]);
+        });
+    });
+
+    // ── Spec validation API ────────────────────────────────────────
+
+    describe('validateSpytialSpec', () => {
+        it('reports a deprecated form among its warnings, without failing', () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const result = validateSpytialSpec(
+                "directives:\n  - atomColor: { selector: Node, value: '#ff0000' }",
+            );
+            warn.mockRestore();
+
+            expect(result.isValid).toBe(true);
+            expect(result.error).toBe(null);
+            expect(result.warnings).toContainEqual(expect.stringContaining('atomColor'));
+            // The console prefix is not part of a returned message.
+            expect(result.warnings.some((w) => w.startsWith('[spytial]'))).toBe(false);
+        });
+
+        it('stays quiet for a spec on the supported forms', () => {
+            const result = validateSpytialSpec(
+                "directives:\n  - atomStyle: { selector: Node, fillStyle: { color: '#ff0000' } }",
+            );
+            expect(result.warnings).toHaveLength(0);
         });
     });
 

--- a/tests/deprecation-warnings.test.ts
+++ b/tests/deprecation-warnings.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
+import { validateItem, newId, type SpecItem } from '../src/spec-editor';
+
+/**
+ * Tests that using a deprecated spec form is *visible* — on the diagram, the
+ * same badge selector warnings use, and in the spec editor.
+ *
+ * The parse has always warned about `atomColor`, `edgeColor`, group-by-field and
+ * `inferredEdge`'s inline line styling, but only to `console.warn` and to a
+ * field on the parse result. Neither reaches the person editing the spec: the
+ * console is a place you have to already suspect something to look, and the
+ * hosts that read the result (spytial-py, spytial-rust, the docs site) hand the
+ * diagram element only the layout. So a spec sitting on a form that is being
+ * removed rendered exactly like one that isn't.
+ */
+
+function createEvaluator(instance: JSONDataInstance): SGraphQueryEvaluator {
+    const evaluator = new SGraphQueryEvaluator();
+    evaluator.initialize({ sourceData: instance });
+    return evaluator;
+}
+
+const graphData: IJsonDataInstance = {
+    atoms: [
+        { id: 'A', type: 'Node', label: 'A' },
+        { id: 'B', type: 'Node', label: 'B' },
+    ],
+    relations: [
+        {
+            id: 'next',
+            name: 'next',
+            types: ['Node', 'Node'],
+            tuples: [{ atoms: ['A', 'B'], types: ['Node', 'Node'] }],
+        },
+    ],
+};
+
+/** Parse with `console.warn` silenced (the parse writes there too, for back-compat). */
+function parseQuietly(yaml: string) {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+        return parseLayoutSpec(yaml);
+    } finally {
+        warn.mockRestore();
+    }
+}
+
+function layoutWarningsFor(yaml: string) {
+    const spec = parseQuietly(yaml);
+    const instance = new JSONDataInstance(graphData);
+    const li = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+    return li.generateLayout(instance).warnings;
+}
+
+function item(type: string, params: Record<string, unknown>, kind: 'constraint' | 'directive'): SpecItem {
+    return { id: newId(), kind, type, params };
+}
+
+describe('Deprecation warnings', () => {
+    // ── Parse level: every deprecated form names itself ────────────
+
+    describe('parseLayoutSpec attributes each deprecation to a spec form', () => {
+        const cases: Array<[string, string]> = [
+            ['atomColor', "directives:\n  - atomColor: { selector: Node, value: '#ff0000' }"],
+            ['edgeColor', "directives:\n  - edgeColor: { field: next, value: '#111111' }"],
+            [
+                'inferredEdge',
+                "directives:\n  - inferredEdge: { name: n, selector: next, color: '#00ff00' }",
+            ],
+            [
+                'group',
+                'constraints:\n  - group: { field: next, groupOn: 0, addToGroup: 1 }',
+            ],
+        ];
+
+        for (const [specType, yaml] of cases) {
+            it(`reports ${specType} with a machine-readable specType`, () => {
+                const warnings = (parseQuietly(yaml).warnings ?? []).filter(
+                    (w) => w.code === 'deprecated',
+                );
+                expect(warnings).toHaveLength(1);
+                expect(warnings[0].specType).toBe(specType);
+                // The message names the replacement, not just the problem.
+                expect(warnings[0].message.length).toBeGreaterThan(0);
+            });
+        }
+
+        it('names the replacement for group-by-field', () => {
+            const warnings = parseQuietly(
+                'constraints:\n  - group: { field: next, groupOn: 0, addToGroup: 1 }',
+            ).warnings!;
+            expect(warnings[0].message).toMatch(/selector/);
+        });
+
+        it('leaves a spec on the supported forms clean', () => {
+            const spec = parseQuietly(
+                "directives:\n  - atomStyle: { selector: Node, fillStyle: { color: '#ff0000' } }\n" +
+                'constraints:\n  - group: { selector: next, name: g }',
+            );
+            expect(spec.warnings).toEqual([]);
+        });
+    });
+
+    // ── Diagram: the deprecation rides out on the layout ────────────
+
+    describe('generateLayout forwards parse deprecations onto the layout', () => {
+        it('carries the deprecation as a layout warning, labelled by form', () => {
+            const warnings = layoutWarningsFor(
+                "directives:\n  - atomColor: { selector: Node, value: '#ff0000' }",
+            );
+
+            const deprecations = warnings.filter((w) => w.code === 'deprecated');
+            expect(deprecations).toHaveLength(1);
+            expect(deprecations[0].severity).toBe('warning');
+            expect(deprecations[0].specType).toBe('atomColor');
+            expect(deprecations[0].label).toBe('atomColor');
+            expect(deprecations[0].message).toMatch(/atomColor/);
+            // Not about a selector — it was raised before anything was evaluated.
+            expect(deprecations[0].selector).toBeUndefined();
+        });
+
+        it('reaches the diagram element by riding on the layout itself', () => {
+            const spec = parseQuietly(
+                "directives:\n  - atomColor: { selector: Node, value: '#ff0000' }",
+            );
+            const instance = new JSONDataInstance(graphData);
+            const li = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+
+            const { layout } = li.generateLayout(instance);
+            expect(layout.warnings?.some((w) => w.code === 'deprecated')).toBe(true);
+        });
+
+        it('reports one warning per deprecated form, not per use of it', () => {
+            const warnings = layoutWarningsFor(
+                "directives:\n" +
+                "  - atomColor: { selector: A, value: '#ff0000' }\n" +
+                "  - atomColor: { selector: B, value: '#00ff00' }",
+            );
+            expect(warnings.filter((w) => w.code === 'deprecated')).toHaveLength(1);
+        });
+
+        it('reports each deprecated form separately', () => {
+            const warnings = layoutWarningsFor(
+                "directives:\n" +
+                "  - atomColor: { selector: Node, value: '#ff0000' }\n" +
+                "  - edgeColor: { field: next, value: '#111111' }",
+            );
+            expect(
+                warnings.filter((w) => w.code === 'deprecated').map((w) => w.specType).sort(),
+            ).toEqual(['atomColor', 'edgeColor']);
+        });
+
+        it('keeps reporting on every render — the spec is still deprecated', () => {
+            const spec = parseQuietly(
+                "directives:\n  - atomColor: { selector: Node, value: '#ff0000' }",
+            );
+            const instance = new JSONDataInstance(graphData);
+            const li = new LayoutInstance(spec, createEvaluator(instance), 0, true);
+
+            const first = li.generateLayout(instance).warnings;
+            const second = li.generateLayout(instance).warnings;
+            // Same list each frame: replayed, not accumulated (a trace would
+            // otherwise grow one copy per frame).
+            expect(second.filter((w) => w.code === 'deprecated')).toHaveLength(1);
+            expect(second.length).toBe(first.length);
+        });
+
+        it('sits alongside selector warnings rather than replacing them', () => {
+            const warnings = layoutWarningsFor(
+                "directives:\n  - atomColor: { selector: Node, value: '#ff0000' }\n" +
+                'constraints:\n  - orientation: { selector: nxt, directions: [left] }',
+            );
+            expect(warnings.map((w) => w.code).sort()).toEqual([
+                'deprecated',
+                'unresolved-name',
+            ]);
+        });
+
+        it('says nothing for a spec on the supported forms', () => {
+            const warnings = layoutWarningsFor(
+                "directives:\n  - atomStyle: { selector: Node, fillStyle: { color: '#ff0000' } }",
+            );
+            expect(warnings).toEqual([]);
+        });
+    });
+
+    // ── Spec editor: the same fact, in the builder ─────────────────
+
+    describe('spec editor diagnostics', () => {
+        it('flags a deprecated type and names its replacement', () => {
+            const diags = validateItem(
+                item('atomColor', { selector: 'Node', value: '#ff0000' }, 'directive'),
+            );
+            const deprecated = diags.filter((d) => d.code === 'deprecated');
+            expect(deprecated).toHaveLength(1);
+            expect(deprecated[0].severity).toBe('warning');
+            expect(deprecated[0].message).toMatch(/atomStyle/);
+        });
+
+        it('flags a deprecated *key* on a supported type, naming its replacement', () => {
+            const diags = validateItem(
+                item('inferredEdge', { name: 'e', selector: 'next', color: '#f00' }, 'directive'),
+            );
+            const deprecated = diags.filter((d) => d.code === 'deprecated');
+            expect(deprecated).toHaveLength(1);
+            expect(deprecated[0].message).toMatch(/lineStyle\.color/);
+            // Item-level, not field-level: `color` is not a builder field, so a
+            // field-scoped diagnostic would render against a control that does
+            // not exist.
+            expect(deprecated[0].fieldKey).toBeUndefined();
+        });
+
+        it('does not call a deprecated key unknown', () => {
+            const diags = validateItem(
+                item(
+                    'inferredEdge',
+                    { name: 'e', selector: 'next', color: '#f00', style: 'dashed', weight: 2 },
+                    'directive',
+                ),
+            );
+            expect(diags.filter((d) => d.code === 'unknown-key')).toHaveLength(0);
+            expect(diags.filter((d) => d.code === 'deprecated')).toHaveLength(3);
+        });
+
+        it('leaves the supported form of the same directive clean', () => {
+            const diags = validateItem(
+                item(
+                    'inferredEdge',
+                    { name: 'e', selector: 'next', lineStyle: { color: '#f00' } },
+                    'directive',
+                ),
+            );
+            expect(diags).toHaveLength(0);
+        });
+    });
+});

--- a/tests/deprecation-warnings.test.ts
+++ b/tests/deprecation-warnings.test.ts
@@ -226,6 +226,19 @@ describe('Deprecation warnings', () => {
             expect(diags.filter((d) => d.code === 'deprecated')).toHaveLength(3);
         });
 
+        it('does not mistake a prototype member for a deprecated key', () => {
+            // The deprecated-key table is looked up with a key straight out of
+            // the spec. Backed by an object literal, `table['toString']` answers
+            // with something off Object.prototype — so a spec key named after
+            // any prototype member drew a nonsense deprecation naming a native
+            // function, and swallowed the unknown-key warning it should have got.
+            const diags = validateItem(
+                item('orientation', { selector: 'p', directions: ['left'], toString: 'x' }, 'constraint'),
+            );
+            expect(diags.filter((d) => d.code === 'deprecated')).toHaveLength(0);
+            expect(diags.filter((d) => d.code === 'unknown-key')).toHaveLength(1);
+        });
+
         it('leaves the supported form of the same directive clean', () => {
             const diags = validateItem(
                 item(

--- a/tests/layout-warnings-render.test.ts
+++ b/tests/layout-warnings-render.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
+import type { LayoutWarning } from '../src/layout/error-state';
+
+/**
+ * Rendering tests for the warning badge, exercised through the prototype with a
+ * fake `this` (the same shape `webcola-teardown.test.ts` uses) so no d3/WebCola
+ * is needed.
+ *
+ * The badge now carries two kinds of warning: per-item selector diagnostics, and
+ * deprecation notices raised while parsing the spec. A deprecation has no
+ * selector — it is raised before anything is evaluated — which is the case these
+ * tests are here for: the detail row that prints `context: <selector>` must be
+ * skipped rather than rendering an empty `<code>`, and the dedup/dismissal
+ * signature must fall back to something that still tells two of them apart.
+ *
+ * The fixture is hand-built rather than taken from `initializeDOM` (which needs
+ * d3), but it cannot silently drift: it carries the ids the implementation
+ * queries, so renaming one makes `renderLayoutWarnings` bail early and these
+ * assertions fail.
+ */
+
+const proto = WebColaCnDGraph.prototype as any;
+
+/** The warning-badge subtree of the element's shadow DOM. */
+function fixture() {
+  const root = document.createElement('div');
+  root.innerHTML = `
+    <div id="layout-warnings" hidden>
+      <div id="layout-warnings-bar">
+        <button id="layout-warnings-badge" type="button" aria-expanded="false" aria-controls="layout-warnings-panel">
+          <span id="layout-warnings-count"></span>
+        </button>
+        <button id="layout-warnings-dismiss" type="button"></button>
+      </div>
+      <div id="layout-warnings-panel" hidden></div>
+    </div>`;
+  const fakeThis: any = {
+    root,
+    dismissedWarningSignature: null,
+    currentWarningSignature: null,
+    dispatchEvent: vi.fn(),
+  };
+  return { root, fakeThis };
+}
+
+const deprecation: LayoutWarning = {
+  severity: 'warning',
+  code: 'deprecated',
+  message: "'atomColor' is deprecated; use 'atomStyle' with a 'borderStyle' block.",
+  context: 'spec',
+  specType: 'atomColor',
+  label: 'atomColor',
+};
+
+const unresolved: LayoutWarning = {
+  severity: 'warning',
+  code: 'unresolved-name',
+  message: "'nxt' did not match any type, relation, or atom.",
+  selector: 'nxt',
+  context: 'orientation selector',
+  specType: 'orientation',
+  specIndex: 0,
+  label: 'OrientationConstraint · nxt',
+  name: 'nxt',
+};
+
+const render = (fakeThis: any, warnings: LayoutWarning[]) =>
+  proto.renderLayoutWarnings.call(fakeThis, warnings);
+
+const items = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll('.layout-warning-item')) as HTMLElement[];
+
+describe('renderLayoutWarnings', () => {
+  it('renders a deprecation without a selector row', () => {
+    const { root, fakeThis } = fixture();
+
+    render(fakeThis, [deprecation]);
+
+    const [item] = items(root);
+    expect(item.querySelector('.layout-warning-label')!.textContent).toBe('atomColor');
+    expect(item.textContent).toContain('atomStyle');
+    // No selector to point at, so no `context: <selector>` row — and in
+    // particular no empty <code> element.
+    expect(item.querySelectorAll('code')).toHaveLength(0);
+    expect(item.textContent).not.toContain('spec:');
+  });
+
+  it('still renders the selector row for a selector warning', () => {
+    const { root, fakeThis } = fixture();
+
+    render(fakeThis, [unresolved]);
+
+    const [item] = items(root);
+    expect(item.querySelector('code')!.textContent).toBe('nxt');
+    expect(item.textContent).toContain('orientation selector');
+  });
+
+  it('counts both kinds together, and says "spec" rather than "selector"', () => {
+    const { root, fakeThis } = fixture();
+
+    render(fakeThis, [deprecation, unresolved]);
+
+    expect(root.querySelector('#layout-warnings-count')!.textContent).toBe('2 spec warnings');
+    expect(items(root)).toHaveLength(2);
+    expect((root.querySelector('#layout-warnings') as HTMLElement).hidden).toBe(false);
+  });
+
+  it('singularizes the count', () => {
+    const { root, fakeThis } = fixture();
+    render(fakeThis, [deprecation]);
+    expect(root.querySelector('#layout-warnings-count')!.textContent).toBe('1 spec warning');
+  });
+
+  it('hides the badge when there is nothing to report', () => {
+    const { root, fakeThis } = fixture();
+
+    render(fakeThis, [deprecation]);
+    render(fakeThis, []);
+
+    expect((root.querySelector('#layout-warnings') as HTMLElement).hidden).toBe(true);
+    expect(items(root)).toHaveLength(0);
+  });
+
+  it('emits layout-warnings so a host with richer UI can route them', () => {
+    const { fakeThis } = fixture();
+
+    render(fakeThis, [deprecation]);
+
+    expect(fakeThis.dispatchEvent).toHaveBeenCalledTimes(1);
+    const event = fakeThis.dispatchEvent.mock.calls[0][0] as CustomEvent;
+    expect(event.type).toBe('layout-warnings');
+    expect(event.detail.warnings).toEqual([deprecation]);
+  });
+
+  describe('dismissal', () => {
+    it('keeps an identical set hidden across re-renders', () => {
+      const { root, fakeThis } = fixture();
+      render(fakeThis, [deprecation]);
+
+      fakeThis.dismissedWarningSignature = fakeThis.currentWarningSignature;
+      render(fakeThis, [deprecation]);
+
+      expect((root.querySelector('#layout-warnings') as HTMLElement).hidden).toBe(true);
+    });
+
+    it('tells two selectorless warnings apart, so a new one still shows', () => {
+      // Both are deprecations of the same form with no selector and no name —
+      // the fields the signature normally keys on. Only the message separates
+      // them, so a signature that ignored it would leave the second warning
+      // suppressed by the first one's dismissal.
+      const { root, fakeThis } = fixture();
+      render(fakeThis, [deprecation]);
+      fakeThis.dismissedWarningSignature = fakeThis.currentWarningSignature;
+
+      render(fakeThis, [{ ...deprecation, message: "'edgeColor' is deprecated." }]);
+
+      expect((root.querySelector('#layout-warnings') as HTMLElement).hidden).toBe(false);
+    });
+  });
+});

--- a/tests/layout-warnings-render.test.ts
+++ b/tests/layout-warnings-render.test.ts
@@ -144,6 +144,20 @@ describe('renderLayoutWarnings', () => {
       expect((root.querySelector('#layout-warnings') as HTMLElement).hidden).toBe(true);
     });
 
+    it('holds when the same warnings arrive in a different order', () => {
+      // The key is the set, not the arrival order: warnings are collected as the
+      // render walks the instance, and two frames carrying the same warnings can
+      // collect them in a different order. That must not read as a change and
+      // undo the dismissal.
+      const { root, fakeThis } = fixture();
+      render(fakeThis, [deprecation, unresolved]);
+      fakeThis.dismissedWarningSignature = fakeThis.currentWarningSignature;
+
+      render(fakeThis, [unresolved, deprecation]);
+
+      expect((root.querySelector('#layout-warnings') as HTMLElement).hidden).toBe(true);
+    });
+
     it('tells two selectorless warnings apart, so a new one still shows', () => {
       // Both are deprecations of the same form with no selector and no name —
       // the fields the signature normally keys on. Only the message separates

--- a/tests/spec-editor-registry-diagnostics.test.ts
+++ b/tests/spec-editor-registry-diagnostics.test.ts
@@ -229,9 +229,10 @@ describe('diagnostics — unknown keys (typo detection)', () => {
     expect(diags).toHaveLength(0);
   });
 
-  it('does not flag inferredEdge deprecated inline line keys', () => {
-    // color/style/weight/highlight are still parsed (deprecation-warned
-    // elsewhere), so they are not "unknown".
+  it('calls inferredEdge inline line keys deprecated, not unknown', () => {
+    // color/style/weight/highlight are still parsed, so they are not "unknown" —
+    // but they are on their way out, so they get a `deprecated` diagnostic
+    // naming the block that replaces each.
     const diags = validateItem(
       item(
         'inferredEdge',
@@ -240,6 +241,10 @@ describe('diagnostics — unknown keys (typo detection)', () => {
       ),
     );
     expect(diags.filter((d) => /Unknown field/.test(d.message))).toHaveLength(0);
+    expect(diags.filter((d) => d.code === 'deprecated')).toHaveLength(3);
+    expect(diags.find((d) => d.message.includes('"style"'))!.message).toMatch(
+      /lineStyle\.pattern/,
+    );
   });
 
   it('does not flag `filter` on attribute/hideField (a real field)', () => {


### PR DESCRIPTION
Using a deprecated form — `atomColor`, `edgeColor`, group-by-field, `inferredEdge`'s inline line styling — has warned since each was deprecated, but only to `console.warn` and to a field on the parse result. Neither reaches the person editing the spec: the console is somewhere you have to already suspect something to look, and the hosts that read the parse result (spytial-py, spytial-rust, the docs site) hand the diagram element only the layout. A spec sitting on a form that is being removed rendered exactly like one that isn't.

## Deprecations ride out on the layout, like selector warnings

`LayoutInstance` now forwards `LayoutSpec.warnings` onto `InstanceLayout.warnings`, so they land on the badge #510 built and on the `layout-warnings` event with no host wiring — the same argument that put selector warnings there.

- `ParseWarning` gains `specType` (`'atomColor'`, `'group'`, …) so a consumer can label the warning without matching prose.
- `LayoutWarning.selector` becomes optional: a deprecation is raised at parse time, before anything is evaluated. The panel's "where" row is skipped when it is absent, and the dedup/dismissal keys fall back to the message.
- The badge reads **"N spec warnings"**, not "N selector warnings" — the list now mixes both kinds.
- The `[spytial]` prefix is stripped on the way to the badge. It marks the source in a console shared with the host page; on our own surface it is noise.

Replayed per render rather than recorded once in the constructor, since `warnings` is cleared each frame — an animated trace reports its own frame, and the deprecation is still true on every one of them.

## group-by-field warns too

`group: { field, groupOn, addToGroup }` was already marked deprecated in the spec-editor registry and hidden from its add menu, but the parser never said so and `docs/YAML_SPECIFICATION.md` did not mention it. Both now do, with the migration named: a binary selector whose first column is the group key.

## Two silent spots in the no-code editor

- **Item-level diagnostics** (deprecated type, deprecated key, unknown type, `validate()` results) rendered as a severity dot with the message shown *nowhere* — `FieldRenderer` buckets by `fieldKey` and drops anything without one. They now list at the top of the expanded row, wrapping rather than truncating: the replacement to move to is the part that would be cut off.
- **`inferredEdge`'s inline `color`/`style`/`weight`/`highlight`** sat on a silent allow-list, commented "its own deprecation warning covers them" — which meant the console. They now get a `deprecated` diagnostic naming the replacement block (`"style" on Inferred edge is deprecated. Use "lineStyle.pattern" instead.`), kept item-level because none of them is a builder field.

## The docs were teaching the form we now flag

The site renders live diagrams from the CDN bundle, so once deprecations reach the badge, every example built on a legacy form shows a warning — starting with the quickstart, the first thing an integrator copies. Migrated the copy-paste paths (quickstart, getting-started, json-data, selectors, yaml-reference, and the README's directive list): `atomColor` → `atomStyle` with `value` under `borderStyle.color`, the border-preserving mapping the desugaring already uses, so every diagram renders identically; `edgeColor` → `edgeStyle` with a `lineStyle` block.

`site/directives.md`'s **inferredEdge** section was documenting the inline `color`/`style`/`weight` as *the* schema with no legacy note — stale rather than deliberate, and now contradicting the warning we raise. Its schema block, field table and examples move to `lineStyle`/`textStyle`, and it gains the same "legacy form" note the `atomColor` and `edgeColor` sections carry.

Left alone: the `edgeColor` section itself, which documents both forms on purpose. Its one live diagram still warns — on that page, that is the point. Verified by parsing every `<template class="spec">` on the site: all parse, and that demo is the only remaining deprecation.

## Also here

- **A test for the badge's deprecation path.** `renderLayoutWarnings` gained a branch with no coverage: no selector means the `context: <selector>` row must be skipped rather than rendering an empty `<code>`, and the dismissal signature must still tell two selectorless warnings apart. Driven through the prototype with a fake `this` (the `webcola-teardown.test.ts` shape), no d3 involved.
- **`GroupByField`'s `/* TODO: Deprecate. */`** becomes a real `@deprecated` note — this PR does the deprecating.
- **The builder's per-row C/D badge is gone** (`59528f2`). Unrelated to the warnings work, folded in here rather than opening a second PR for two files. The rows already sit under a "Constraints"/"Directives" heading with their own add button, so the stamp repeated per row what the header said once, and pushed the type label off the left edge. The unrelated `.spytial-ed-diagnostic-badge` is untouched.

## Reviewer notes

- **Visible change for legacy specs.** One that renders clean today will now raise the badge on every render. That is the point of the change, and the badge is dismissible, but it is worth knowing before this ships.
- Verified in the browser on both surfaces: the diagram badge showed an `atomColor` deprecation and an unresolved-name warning together; the builder showed both the type-level and key-level messages.
- 2079 tests pass (17 new in `tests/deprecation-warnings.test.ts` covering parse → layout → editor, 8 in `tests/layout-warnings-render.test.ts` covering the badge). Typecheck holds at the 73-error baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
