### PR TITLE
test(z3-oracle): diagnose OOM-poisoned solver-oracle runs

### DIFF
--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -33,7 +33,81 @@ const MIN_PADDING = 15;
 let Z3Context: any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let z3Ctx: any;
+// Full init() result ({ Context, Z3, em, ... }) — kept for diagnostics:
+// Z3.get_estimated_alloc_size() reports Z3's own allocator usage inside the
+// fixed-size Emscripten heap, which HEAPU8.length cannot show.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let z3Api: any;
 let z3Initialized = false;
+
+// ─── Diagnostics ─────────────────────────────────────────────────────────
+//
+// The WASM build of Z3 has a FIXED 2 GiB heap (no ALLOW_MEMORY_GROWTH).
+// When malloc exhausts it, Emscripten abort()s and the whole module is dead:
+// the in-flight solver.check() promise never settles (the pthread dies
+// without rejecting it) and every later call into Z3 — including AST
+// construction in buildModel — throws RuntimeError immediately. Without the
+// bookkeeping below, that surfaces as one 120s test timeout followed by a
+// cascade of instant, meaningless "disagreements" on trivially-SAT inputs
+// (observed in CI run 30188347391 attempt 1). Track allocator growth and
+// mark the runtime as dead on the first abort so every subsequent failure
+// names the real cause instead of fabricating counterexamples.
+
+export class Z3OracleError extends Error {}
+
+let solveCount = 0;
+let lastSolveMs = -1;
+let poisonedBy: string | null = null;
+
+export interface OracleStats {
+    /** Total solver.check() calls since the module was (re)initialized. */
+    solveCount: number;
+    /** Wall time of the most recent completed check, in ms (-1 if none). */
+    lastSolveMs: number;
+    /** Z3's estimate of its allocated bytes (-1 if unavailable/dead). */
+    estimatedAllocBytes: number;
+    /** Total Emscripten heap size in bytes (-1 if unavailable/dead). */
+    heapBytes: number;
+    /** Set once the WASM runtime aborts; all results after this are garbage. */
+    poisonedBy: string | null;
+}
+
+export function oracleStats(): OracleStats {
+    let estimatedAllocBytes = -1;
+    let heapBytes = -1;
+    try {
+        estimatedAllocBytes = Number(z3Api.Z3.get_estimated_alloc_size());
+        heapBytes = z3Api.em.HEAPU8.length;
+    } catch {
+        // Runtime dead or not initialized — stats stay at -1.
+    }
+    return { solveCount, lastSolveMs, estimatedAllocBytes, heapBytes, poisonedBy };
+}
+
+export function describeOracleStats(): string {
+    const s = oracleStats();
+    const mb = (b: number) => b < 0 ? '?' : (b / (1024 * 1024)).toFixed(1);
+    return `solve #${s.solveCount}, z3 alloc ≈ ${mb(s.estimatedAllocBytes)} MB / heap ${mb(s.heapBytes)} MB`;
+}
+
+function assertNotPoisoned(): void {
+    if (poisonedBy) {
+        throw new Z3OracleError(
+            `Z3 WASM runtime is dead; this and every later oracle result is meaningless. ` +
+            `Root cause: ${poisonedBy}`
+        );
+    }
+}
+
+function poison(context: string, e: unknown): void {
+    poisonedBy = `${context}: ${e} (${describeOracleStats()})`;
+    // eslint-disable-next-line no-console
+    console.error(`[z3-oracle] RUNTIME DEAD — ${poisonedBy}`);
+}
+
+function looksLikeRuntimeDeath(e: unknown): boolean {
+    return e instanceof WebAssembly.RuntimeError || /Aborted|abort\(|OOM|unreachable/i.test(String(e));
+}
 
 // ─── Initialization ──────────────────────────────────────────────────────
 
@@ -48,23 +122,32 @@ export async function isZ3Available(): Promise<boolean> {
 
 export async function initZ3(): Promise<void> {
     if (z3Initialized) return;
-    const { Context } = await init();
-    Z3Context = Context;
+    z3Api = await init();
+    Z3Context = z3Api.Context;
     z3Ctx = new Z3Context('oracle');
     z3Initialized = true;
+    // A fresh init() instantiates a new WASM module, so prior death is cured.
+    solveCount = 0;
+    lastSolveMs = -1;
+    poisonedBy = null;
 }
 
 export function shutdownZ3(): void {
     z3Initialized = false;
     z3Ctx = null;
     Z3Context = null;
+    z3Api = null;
 }
 
 /** Create a fresh Z3 context, discarding accumulated WASM memory from prior solves. */
 export async function resetZ3(): Promise<void> {
     if (!Z3Context) {
-        const { Context } = await init();
-        Z3Context = Context;
+        z3Api = await init();
+        Z3Context = z3Api.Context;
+        // Fresh WASM module (see initZ3).
+        solveCount = 0;
+        lastSolveMs = -1;
+        poisonedBy = null;
     }
     z3Ctx = new Z3Context('oracle');
     z3Initialized = true;
@@ -384,14 +467,65 @@ function compileDisjunction(disj: DisjunctiveConstraint, vars: VarMap, ctx: any)
 
 // ─── Solving ────────────────────────────────────────────────────────────
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function checkedSolve(solver: any, what: string): Promise<boolean> {
+    solveCount++;
+    const solveNo = solveCount;
+    const started = Date.now();
+    let result: string;
+    try {
+        result = await solver.check();
+    } catch (e) {
+        if (looksLikeRuntimeDeath(e)) {
+            poison(`${what} solve #${solveNo} threw after ${Date.now() - started}ms`, e);
+        }
+        throw new Z3OracleError(`Z3 ${what} solve #${solveNo} threw after ${Date.now() - started}ms: ${e}`);
+    }
+    lastSolveMs = Date.now() - started;
+    if (result !== 'sat' && result !== 'unsat') {
+        // NEVER map 'unknown' to UNSAT: that fabricates validator/oracle
+        // disagreements out of solver limitations (timeout, interrupt, memout).
+        let reason = 'reason unavailable';
+        try {
+            reason = solver.reasonUnknown();
+        } catch {
+            // Runtime may be dead; keep the placeholder.
+        }
+        const detail = `Z3 ${what} solve #${solveNo} returned '${result}' (${reason}) after ${lastSolveMs}ms — ${describeOracleStats()}`;
+        // eslint-disable-next-line no-console
+        console.error(`[z3-oracle] ${detail}`);
+        throw new Z3OracleError(detail);
+    }
+    return result === 'sat';
+}
+
+function buildModelChecked(
+    layout: InstanceLayout,
+    what: string,
+    constraintOverride?: LayoutConstraint[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): { solver: any; vars: VarMap } {
+    try {
+        return buildModel(layout, constraintOverride);
+    } catch (e) {
+        // Once the runtime has aborted, even AST construction throws — this is
+        // the path that produced instant bogus "counterexamples" in CI.
+        if (looksLikeRuntimeDeath(e)) {
+            poison(`${what} buildModel threw`, e);
+        }
+        throw e;
+    }
+}
+
 /**
  * Solve an InstanceLayout using Z3.
- * Returns true if SAT, false if UNSAT.
+ * Returns true if SAT, false if UNSAT; throws Z3OracleError on 'unknown'
+ * or when the WASM runtime has died (never a silent wrong answer).
  */
 export async function solveZ3(layout: InstanceLayout): Promise<boolean> {
-    const { solver } = buildModel(layout);
-    const result = await solver.check();
-    return result === 'sat';
+    assertNotPoisoned();
+    const { solver } = buildModelChecked(layout, 'solveZ3');
+    return checkedSolve(solver, 'solveZ3');
 }
 
 /**
@@ -402,7 +536,7 @@ export async function verifyFeasibleSubset(
     layout: InstanceLayout,
     subset: LayoutConstraint[],
 ): Promise<boolean> {
-    const { solver } = buildModel(layout, subset);
-    const result = await solver.check();
-    return result === 'sat';
+    assertNotPoisoned();
+    const { solver } = buildModelChecked(layout, 'verifyFeasibleSubset', subset);
+    return checkedSolve(solver, 'verifyFeasibleSubset');
 }

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -8,7 +8,7 @@
  * Z3 runs as a WASM module — no system binary required.
  */
 
-import { describe, it, expect, afterAll, vi } from 'vitest';
+import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
 
 vi.setConfig({ testTimeout: 120_000 });
 import * as fc from 'fast-check';
@@ -25,6 +25,8 @@ import {
     shutdownZ3,
     solveZ3,
     verifyFeasibleSubset,
+    oracleStats,
+    describeOracleStats,
 } from './helpers/z3-oracle';
 import {
     cloneLayout,
@@ -60,7 +62,19 @@ async function checkAgainstOracle(layout: InstanceLayout): Promise<{
     const validator = new QualitativeConstraintValidator(layoutV);
     const error = validator.validateConstraints();
     const validatorSat = error === null;
-    const oracleSat = await solveZ3(layout);
+    let oracleSat: boolean;
+    try {
+        oracleSat = await solveZ3(layout);
+    } catch (e) {
+        // Log the real cause directly: fast-check wraps predicate errors and
+        // the reporter can drop the cause chain, leaving only a meaningless
+        // shrunk counterexample in CI output (see run 30188347391 attempt 1).
+        console.error(
+            `[z3-oracle] oracle threw (validator said ${validatorSat ? 'SAT' : 'UNSAT'}): ${e}\n` +
+            `  ${describeLayout(layout)}`
+        );
+        throw e;
+    }
     return { validatorSat, oracleSat };
 }
 
@@ -70,10 +84,14 @@ function assertAgreement(
     oracleSat: boolean,
 ): void {
     if (validatorSat !== oracleSat) {
-        throw new Error(
+        const detail =
             `Disagreement! Validator=${validatorSat ? 'SAT' : 'UNSAT'}, ` +
-            `Z3=${oracleSat ? 'SAT' : 'UNSAT'}\n  ${describeLayout(layout)}`
-        );
+            `Z3=${oracleSat ? 'SAT' : 'UNSAT'} ` +
+            `(z3 solve took ${oracleStats().lastSolveMs}ms; ${describeOracleStats()})\n` +
+            `  ${describeLayout(layout)}`;
+        // Also log directly — see checkAgainstOracle for why.
+        console.error(`[z3-oracle] ${detail}`);
+        throw new Error(detail);
     }
 }
 
@@ -83,6 +101,15 @@ const available = await isZ3Available();
 
 afterAll(() => {
     if (available) shutdownZ3();
+});
+
+// One line per test tracking Z3's allocator inside its FIXED 2 GiB WASM heap.
+// Cleanup of Z3 ASTs is FinalizationRegistry-driven (JS GC), so allocation
+// can ratchet up across the suite; when it crosses 2 GiB the runtime aborts
+// and poisons everything after it. This log turns "flaky OOM" into a curve.
+afterEach((ctx) => {
+    if (!available) return;
+    console.log(`[z3-oracle] after "${ctx.task.name}": ${describeOracleStats()}`);
 });
 
 describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
@@ -675,10 +702,18 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
                     const error = validator.validateConstraints();
 
                     if (error && isPositionalConstraintError(error) && error.maximalFeasibleSubset) {
-                        const mfsFeasible = await verifyFeasibleSubset(
-                            layout,
-                            error.maximalFeasibleSubset,
-                        );
+                        let mfsFeasible: boolean;
+                        try {
+                            mfsFeasible = await verifyFeasibleSubset(
+                                layout,
+                                error.maximalFeasibleSubset,
+                            );
+                        } catch (e) {
+                            console.error(
+                                `[z3-oracle] MFS verification threw: ${e}\n  ${describeLayout(layout)}`
+                            );
+                            throw e;
+                        }
                         if (!mfsFeasible) {
                             throw new Error(
                                 `MFS is NOT feasible according to Z3!\n` +


### PR DESCRIPTION
## What & why

The `solver-oracle` job failed on [run 30188347391](https://github.com/sidprasad/spytial-core/actions/runs/30188347391) (attempt 1) with a confusing signature: one property test timing out at 120s, then every remaining test failing **instantly** with trivially-SAT "counterexamples". The rerun passed, so it read as generic flakiness. It isn't — the attempt-1 stderr, two minutes before the first reported failure, shows the real cause:

```
Aborted(Cannot enlarge memory arrays to size 2220077056 bytes (OOM).
        ... current value 2147483648 ...)
Pthread 0x215891a8 sent an error!
```

The z3-solver WASM build has a **fixed 2 GiB heap**. When it runs out:

1. The abort kills a Z3 worker thread **without rejecting** the awaited `solver.check()` promise → the running test hangs until vitest's 120s timeout.
2. The Emscripten module is permanently dead afterwards → every later Z3 call, including AST construction in `buildModel`, throws `RuntimeError: Aborted` in milliseconds.
3. fast-check treats each instant throw as a property failure and shrinks it → a cascade of meaningless shrunk counterexamples.
4. The reporter prints only fast-check's `Property failed after 1 tests` wrapper — the cause chain is dropped, and nothing links the failures to the OOM two minutes earlier in stderr.

**Why memory fills up:** the suite runs ~1,000 solves against one long-lived context, and z3-solver frees Z3 ASTs via `FinalizationRegistry` — i.e. only when JS GC happens to run finalizers. Instrumented locally, allocation ratchets ~0.8 MB per solve (49 MB after 50 solves → 488 MB after 591), then drops to 40 MB when a GC pass finally fires. Whether a run OOMs is a race between GC timing and allocation rate (instance hardness), which is why it's seed- and machine-dependent.

## Changes

Diagnostics only — no behavior change on healthy runs beyond one log line per test:

- **Allocation curve**: after each test, log `Z3_get_estimated_alloc_size()` (Z3's own allocator usage inside the fixed heap — `HEAPU8.length` can't show it) plus cumulative solve count. A future OOM comes with the full ratchet leading up to it.
- **Poisoned-runtime detection**: the first abort marks the module dead (`RUNTIME DEAD` log with root cause); every subsequent oracle call fails fast with a `Z3OracleError` naming that original failure — one real failure plus clearly-labeled secondaries instead of fabricated disagreements.
- **`unknown` is a hard error**: `solveZ3`/`verifyFeasibleSubset` previously mapped `unknown` → UNSAT (`result === 'sat'`), which would report a solver limitation (memout/interrupt) as a false validator/oracle disagreement. Now throws with Z3's `reasonUnknown()`.
- **Direct logging of every discrepancy**: `checkAgainstOracle`/`assertAgreement` (and the MFS path) `console.error` the verdicts, solve timing, allocator stats, and layout description at the point of failure, independent of what the reporter keeps.

## Testing

- Full `tests/z3-equivalence.test.ts` suite green locally (33/33, ~16s) with the diagnostics active; the per-test log verified the ratchet-then-GC-drop curve described above.
- Typecheck at the 73-error pre-existing baseline.

## Follow-up (not in this PR)

Once the logging confirms the curve on CI, prevention is straightforward: periodic `resetZ3()` + a GC nudge between describe blocks, or splitting the suite across workers. Held back deliberately so the next occurrence is diagnosed, not masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
