### PR TITLE
test(z3-oracle): prevent WASM OOM, bail on first failure, widen coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,9 @@ jobs:
       - run: npm install
         if: steps.changes.outputs.run == 'true'
 
-      - run: npx vitest run tests/z3-equivalence.test.ts
+      # --bail=1: one confirmed validator/oracle discrepancy is enough signal;
+      # everything after it (especially after a Z3 WASM abort) is noise.
+      - run: npx vitest run --bail=1 tests/z3-equivalence.test.ts
         if: steps.changes.outputs.run == 'true'
 
       - name: Skip (no relevant changes)

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -60,7 +60,7 @@ let lastSolveMs = -1;
 let poisonedBy: string | null = null;
 
 export interface OracleStats {
-    /** Total solver.check() calls since the module was (re)initialized. */
+    /** Total solver.check() calls since the suite started (survives recycles). */
     solveCount: number;
     /** Wall time of the most recent completed check, in ms (-1 if none). */
     lastSolveMs: number;
@@ -68,6 +68,8 @@ export interface OracleStats {
     estimatedAllocBytes: number;
     /** Total Emscripten heap size in bytes (-1 if unavailable/dead). */
     heapBytes: number;
+    /** How many times the WASM module was proactively recycled (see below). */
+    recycles: number;
     /** Set once the WASM runtime aborts; all results after this are garbage. */
     poisonedBy: string | null;
 }
@@ -81,13 +83,13 @@ export function oracleStats(): OracleStats {
     } catch {
         // Runtime dead or not initialized — stats stay at -1.
     }
-    return { solveCount, lastSolveMs, estimatedAllocBytes, heapBytes, poisonedBy };
+    return { solveCount, lastSolveMs, estimatedAllocBytes, heapBytes, recycles: recycleCount, poisonedBy };
 }
 
 export function describeOracleStats(): string {
     const s = oracleStats();
     const mb = (b: number) => b < 0 ? '?' : (b / (1024 * 1024)).toFixed(1);
-    return `solve #${s.solveCount}, z3 alloc ≈ ${mb(s.estimatedAllocBytes)} MB / heap ${mb(s.heapBytes)} MB`;
+    return `solve #${s.solveCount}, z3 alloc ≈ ${mb(s.estimatedAllocBytes)} MB / heap ${mb(s.heapBytes)} MB, recycles ${s.recycles}`;
 }
 
 function assertNotPoisoned(): void {
@@ -109,6 +111,51 @@ function looksLikeRuntimeDeath(e: unknown): boolean {
     return e instanceof WebAssembly.RuntimeError || /Aborted|abort\(|OOM|unreachable/i.test(String(e));
 }
 
+// ─── OOM prevention ──────────────────────────────────────────────────────
+//
+// z3-solver frees Z3 ASTs via FinalizationRegistry — i.e. only when the JS GC
+// happens to run finalizers. Across a long suite (~1,000 solves) Z3's allocator
+// ratchets up ~0.8 MB/solve inside the fixed heap; whether a run OOMs is a race
+// between GC timing and allocation rate. Passing runs were observed peaking at
+// ~450–490 MB *estimated* alloc while the failing run hit the 2 GiB cliff
+// (fragmentation makes the real arena several times the estimate). Rather than
+// gamble on the GC, replace the whole WASM module once the estimate crosses
+// RECYCLE_ALLOC_BYTES: a fresh module starts from an empty heap, and the ~1s
+// init cost is paid at most a few times per run.
+
+const RECYCLE_ALLOC_BYTES = 256 * 1024 * 1024;
+let recycleCount = 0;
+
+async function recycleZ3(reason: string): Promise<void> {
+    // eslint-disable-next-line no-console
+    console.log(`[z3-oracle] recycling WASM module: ${reason}`);
+    terminateThreads();
+    z3Api = null;
+    Z3Context = null;
+    z3Ctx = null;
+    z3Initialized = false;
+    recycleCount++;
+    await freshModule();
+}
+
+async function maybeRecycle(): Promise<void> {
+    if (!z3Initialized) return;
+    const alloc = oracleStats().estimatedAllocBytes;
+    if (alloc >= RECYCLE_ALLOC_BYTES) {
+        const mb = (b: number) => (b / (1024 * 1024)).toFixed(1);
+        await recycleZ3(`alloc ${mb(alloc)} MB ≥ ${mb(RECYCLE_ALLOC_BYTES)} MB after ${solveCount} solves`);
+    }
+}
+
+/** Terminate the old module's pthread workers so it can be garbage-collected. */
+function terminateThreads(): void {
+    try {
+        z3Api?.em?.PThread?.terminateAllThreads?.();
+    } catch {
+        // Best effort — a dead runtime may throw here.
+    }
+}
+
 // ─── Initialization ──────────────────────────────────────────────────────
 
 export async function isZ3Available(): Promise<boolean> {
@@ -120,37 +167,26 @@ export async function isZ3Available(): Promise<boolean> {
     }
 }
 
-export async function initZ3(): Promise<void> {
-    if (z3Initialized) return;
+async function freshModule(): Promise<void> {
     z3Api = await init();
     Z3Context = z3Api.Context;
     z3Ctx = new Z3Context('oracle');
     z3Initialized = true;
     // A fresh init() instantiates a new WASM module, so prior death is cured.
-    solveCount = 0;
-    lastSolveMs = -1;
     poisonedBy = null;
 }
 
+export async function initZ3(): Promise<void> {
+    if (z3Initialized) return;
+    await freshModule();
+}
+
 export function shutdownZ3(): void {
+    terminateThreads();
     z3Initialized = false;
     z3Ctx = null;
     Z3Context = null;
     z3Api = null;
-}
-
-/** Create a fresh Z3 context, discarding accumulated WASM memory from prior solves. */
-export async function resetZ3(): Promise<void> {
-    if (!Z3Context) {
-        z3Api = await init();
-        Z3Context = z3Api.Context;
-        // Fresh WASM module (see initZ3).
-        solveCount = 0;
-        lastSolveMs = -1;
-        poisonedBy = null;
-    }
-    z3Ctx = new Z3Context('oracle');
-    z3Initialized = true;
 }
 
 // ─── ID sanitization ────────────────────────────────────────────────────
@@ -524,6 +560,7 @@ function buildModelChecked(
  */
 export async function solveZ3(layout: InstanceLayout): Promise<boolean> {
     assertNotPoisoned();
+    await maybeRecycle();
     const { solver } = buildModelChecked(layout, 'solveZ3');
     return checkedSolve(solver, 'solveZ3');
 }
@@ -537,6 +574,7 @@ export async function verifyFeasibleSubset(
     subset: LayoutConstraint[],
 ): Promise<boolean> {
     assertNotPoisoned();
+    await maybeRecycle();
     const { solver } = buildModelChecked(layout, 'verifyFeasibleSubset', subset);
     return checkedSolve(solver, 'verifyFeasibleSubset');
 }

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -55,6 +55,13 @@ let z3Initialized = false;
 
 export class Z3OracleError extends Error {}
 
+/**
+ * Z3 answered 'unknown' (or raised) while the WASM runtime stayed alive —
+ * resource ceiling, timeout, or cancellation. Unlike runtime death these are
+ * safe to retry once on a fresh module (see runSolve).
+ */
+class Z3UnknownError extends Z3OracleError {}
+
 let solveCount = 0;
 let lastSolveMs = -1;
 let poisonedBy: string | null = null;
@@ -113,17 +120,31 @@ function looksLikeRuntimeDeath(e: unknown): boolean {
 
 // ─── OOM prevention ──────────────────────────────────────────────────────
 //
-// z3-solver frees Z3 ASTs via FinalizationRegistry — i.e. only when the JS GC
-// happens to run finalizers. Across a long suite (~1,000 solves) Z3's allocator
-// ratchets up ~0.8 MB/solve inside the fixed heap; whether a run OOMs is a race
-// between GC timing and allocation rate. Passing runs were observed peaking at
-// ~450–490 MB *estimated* alloc while the failing run hit the 2 GiB cliff
-// (fragmentation makes the real arena several times the estimate). Rather than
-// gamble on the GC, replace the whole WASM module once the estimate crosses
-// RECYCLE_ALLOC_BYTES: a fresh module starts from an empty heap, and the ~1s
-// init cost is paid at most a few times per run.
+// Two distinct mechanisms can exhaust the fixed 2 GiB WASM heap:
+//
+// 1. GRADUAL RATCHET: z3-solver frees Z3 ASTs via FinalizationRegistry — i.e.
+//    only when the JS GC happens to run finalizers — so allocation climbs
+//    ~0.8 MB/solve across the suite (run 30188347391). Countered by recycling
+//    the whole module once the estimate crosses RECYCLE_ALLOC_BYTES.
+//
+// 2. SINGLE MONSTER SOLVE: one hard instance can allocate its way to the
+//    cliff mid-search regardless of a clean starting point. On CI run
+//    30227554187 a solve died with a native abort at only ~325 MB *estimated*
+//    alloc — the real arena hit 2 GiB at a ~6× fragmentation/overhead
+//    multiplier. Countered by Z3's own 'memory_max_size' ceiling (Z3 tracks
+//    exactly the counter we read here and returns a clean 'unknown' instead
+//    of letting malloc fail and kill the runtime), plus a 'timeout' so a
+//    grinder surfaces as 'unknown' before vitest's 120s test timeout.
+//
+// The numbers hang together: recycling at 128 MB guarantees ≥ 128 MB of
+// estimated headroom below the 256 MB ceiling for every solve, and the
+// ceiling caps worst-case real arena at ~6.3 × 256 MB ≈ 1.6 GiB < 2 GiB.
+// 45s timeout + one fresh-module retry (see runSolve) stays under the 120s
+// vitest limit. A recycle costs ~1s; expect a handful per run.
 
-const RECYCLE_ALLOC_BYTES = 256 * 1024 * 1024;
+const RECYCLE_ALLOC_BYTES = 128 * 1024 * 1024;
+const Z3_MEMORY_MAX_MB = 256;
+const Z3_TIMEOUT_MS = 45_000;
 let recycleCount = 0;
 
 async function recycleZ3(reason: string): Promise<void> {
@@ -169,6 +190,9 @@ export async function isZ3Available(): Promise<boolean> {
 
 async function freshModule(): Promise<void> {
     z3Api = await init();
+    // Resource ceilings are global per module, so re-apply after every init.
+    z3Api.Z3.global_param_set('memory_max_size', String(Z3_MEMORY_MAX_MB));
+    z3Api.Z3.global_param_set('timeout', String(Z3_TIMEOUT_MS));
     Z3Context = z3Api.Context;
     z3Ctx = new Z3Context('oracle');
     z3Initialized = true;
@@ -512,10 +536,14 @@ async function checkedSolve(solver: any, what: string): Promise<boolean> {
     try {
         result = await solver.check();
     } catch (e) {
+        const detail = `Z3 ${what} solve #${solveNo} threw after ${Date.now() - started}ms: ${e}`;
         if (looksLikeRuntimeDeath(e)) {
             poison(`${what} solve #${solveNo} threw after ${Date.now() - started}ms`, e);
+            throw new Z3OracleError(detail);
         }
-        throw new Z3OracleError(`Z3 ${what} solve #${solveNo} threw after ${Date.now() - started}ms: ${e}`);
+        // Z3 raised but the runtime survived (resource limits can surface as
+        // exceptions rather than 'unknown') — same retry semantics as 'unknown'.
+        throw new Z3UnknownError(detail);
     }
     lastSolveMs = Date.now() - started;
     if (result !== 'sat' && result !== 'unsat') {
@@ -530,7 +558,7 @@ async function checkedSolve(solver: any, what: string): Promise<boolean> {
         const detail = `Z3 ${what} solve #${solveNo} returned '${result}' (${reason}) after ${lastSolveMs}ms — ${describeOracleStats()}`;
         // eslint-disable-next-line no-console
         console.error(`[z3-oracle] ${detail}`);
-        throw new Z3OracleError(detail);
+        throw new Z3UnknownError(detail);
     }
     return result === 'sat';
 }
@@ -553,16 +581,47 @@ function buildModelChecked(
     }
 }
 
+async function attemptSolve(
+    layout: InstanceLayout,
+    what: string,
+    constraintOverride?: LayoutConstraint[],
+): Promise<boolean> {
+    const { solver } = buildModelChecked(layout, what, constraintOverride);
+    return checkedSolve(solver, what);
+}
+
+async function runSolve(
+    layout: InstanceLayout,
+    what: string,
+    constraintOverride?: LayoutConstraint[],
+): Promise<boolean> {
+    assertNotPoisoned();
+    await maybeRecycle();
+    try {
+        return await attemptSolve(layout, what, constraintOverride);
+    } catch (e) {
+        if (!(e instanceof Z3UnknownError) || poisonedBy) throw e;
+        // A clean 'unknown' (memory ceiling, timeout) from a part-filled heap
+        // and a context polluted by hundreds of prior solves' AST interning
+        // often solves instantly from a clean module — observed on CI run
+        // 30227554187, where a deterministic instance that solves in ms
+        // locally ground for 6s. Retry exactly once; a second 'unknown' is a
+        // genuinely pathological instance and should fail loudly.
+        // eslint-disable-next-line no-console
+        console.error(`[z3-oracle] retrying ${what} on a fresh module after: ${e}`);
+        await recycleZ3(`'unknown' during ${what}`);
+        return attemptSolve(layout, what, constraintOverride);
+    }
+}
+
 /**
  * Solve an InstanceLayout using Z3.
  * Returns true if SAT, false if UNSAT; throws Z3OracleError on 'unknown'
- * or when the WASM runtime has died (never a silent wrong answer).
+ * (after one fresh-module retry) or when the WASM runtime has died —
+ * never a silent wrong answer.
  */
 export async function solveZ3(layout: InstanceLayout): Promise<boolean> {
-    assertNotPoisoned();
-    await maybeRecycle();
-    const { solver } = buildModelChecked(layout, 'solveZ3');
-    return checkedSolve(solver, 'solveZ3');
+    return runSolve(layout, 'solveZ3');
 }
 
 /**
@@ -573,8 +632,5 @@ export async function verifyFeasibleSubset(
     layout: InstanceLayout,
     subset: LayoutConstraint[],
 ): Promise<boolean> {
-    assertNotPoisoned();
-    await maybeRecycle();
-    const { solver } = buildModelChecked(layout, 'verifyFeasibleSubset', subset);
-    return checkedSolve(solver, 'verifyFeasibleSubset');
+    return runSolve(layout, 'verifyFeasibleSubset', subset);
 }

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -30,6 +30,7 @@ import {
 } from './helpers/z3-oracle';
 import {
     cloneLayout,
+    describeConstraint,
     describeLayout,
     leftOf,
     aboveOf,
@@ -46,6 +47,7 @@ import {
     arbDisjunction,
     arbRichDisjunction,
     arbFullSystem,
+    arbMixedSystem,
     arbNegativeOrdering,
     arbMixedOrdering,
     arbGroup,
@@ -492,6 +494,97 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
             ), { numRuns: NUM_RUNS, timeout: TIMEOUT });
         });
 
+        it('random negated group with 4 members on 6 nodes (Z3 cross-check)', async () => {
+            const gbf = new GroupByField('type', 0, 1, 'type');
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(6).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 4 }),
+                        fc.shuffledSubarray(
+                            Array.from({ length: 6 }, (_, i) => i),
+                            { minLength: 4, maxLength: 4 },
+                        ),
+                    )
+                ),
+                async ([nodes, constraints, memberIndices]) => {
+                    const memberIds = memberIndices.map(i => nodes[i].id);
+                    const group: LayoutGroup = {
+                        name: 'NG0', nodeIds: memberIds,
+                        keyNodeId: memberIds[0], showLabel: true,
+                        sourceConstraint: gbf, negated: true,
+                    };
+                    const layout = buildLayout(nodes, constraints, undefined, [group]);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: 25, timeout: TIMEOUT });
+        });
+
+        // ── Multiple negated groups from ONE source constraint ─────────
+        // Both the validator and the oracle merge same-source negated groups
+        // into a single disjunction: at least ONE group must be violated
+        // (some non-member sits inside its members' span), not all of them.
+        // No prior test exercised this path with more than one group.
+
+        it('two same-source negated groups, either can be violated — SAT (Z3 cross-check)', async () => {
+            const layout = parseConstraintSpec('a1 <x a2, a3 <x a4, {!A: a1, a2}, {!B: a3, a4}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(true);
+        });
+
+        it('same-source negated groups need only ONE violated (Or, not And) — SAT (Z3 cross-check)', async () => {
+            // The total order a1 < a2 < a3 < a4 makes {!B} impossible to violate
+            // (nothing can sit between a3 and a4's span from the left), but a2 or
+            // a3 can still sit inside span(a1, a4), violating {!A}. Under Or
+            // semantics this is SAT; under (wrong) And semantics it would be UNSAT.
+            const layout = parseConstraintSpec('a1 <x a2, a2 <x a3, a3 <x a4, {!A: a1, a4}, {!B: a3, a4}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(true);
+        });
+
+        it('total horizontal order starves both negated groups — UNSAT (Z3 cross-check)', async () => {
+            const layout = parseConstraintSpec('a1 <x a2, a2 <x a3, a3 <x a4, {!A: a1, a2}, {!B: a3, a4}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(false);
+        });
+
+        it('random pair of same-source negated 2-member groups on 5 nodes (Z3 cross-check)', async () => {
+            const gbf = new GroupByField('type', 0, 1, 'type');
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(5).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 4 }),
+                        fc.shuffledSubarray(
+                            Array.from({ length: 5 }, (_, i) => i),
+                            { minLength: 2, maxLength: 2 },
+                        ),
+                        fc.shuffledSubarray(
+                            Array.from({ length: 5 }, (_, i) => i),
+                            { minLength: 2, maxLength: 2 },
+                        ),
+                    )
+                ),
+                async ([nodes, constraints, indicesA, indicesB]) => {
+                    const groups: LayoutGroup[] = [indicesA, indicesB].map((indices, g) => {
+                        const memberIds = indices.map(i => nodes[i].id);
+                        return {
+                            name: `NG${g}`, nodeIds: memberIds,
+                            keyNodeId: memberIds[0], showLabel: true,
+                            sourceConstraint: gbf, negated: true,
+                        };
+                    });
+                    const layout = buildLayout(nodes, constraints, undefined, groups);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: 25, timeout: TIMEOUT });
+        });
+
         it('groups + ordering disjunctions on 6 nodes', async () => {
             const gbf = new GroupByField('type', 0, 1, 'type');
             const arbLayout = arbNodePool(6).chain(nodes => {
@@ -512,6 +605,103 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
                 const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
                 assertAgreement(layout, validatorSat, oracleSat);
             }), { numRuns: NUM_RUNS, timeout: TIMEOUT });
+        });
+    });
+
+    // ─── Nested and overlapping groups ──────────────────────────────────
+    // Subgroup pairs (B ⊂ A) are allowed and skip group-to-group separation;
+    // partially overlapping pairs get `overlapping: true` stamped by the
+    // validator (on the SHARED group objects, so the oracle sees it too).
+    // Neither shape was covered before.
+
+    describe('Nested and overlapping groups', () => {
+
+        it('nested group (B inside A) — SAT (Z3 cross-check)', async () => {
+            const layout = parseConstraintSpec('a1 <x a2, {A: a1, a2, a3}, {B: a1, a2}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(true);
+        });
+
+        it('outsider trapped inside nested inner group — UNSAT (Z3 cross-check)', async () => {
+            const layout = parseConstraintSpec('a1 <x x, x <x a2, a1 <y x, x <y a2, {A: a1, a2, a3}, {B: a1, a2}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(false);
+        });
+
+        it('outsider left of all members escapes both nested groups — SAT (Z3 cross-check)', async () => {
+            const layout = parseConstraintSpec('x <x a1, x <x a2, x <x a3, {A: a1, a2, a3}, {B: a1, a2}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(true);
+        });
+
+        it('shared member trapped inside one of two overlapping groups — SAT (Z3 cross-check)', async () => {
+            const layout = parseConstraintSpec('a1 <x s, s <x a2, a1 <y s, s <y a2, {A: a1, a2, s}, {B: s, b1, b2}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(true);
+        });
+
+        it('random nested groups on 6 nodes (Z3 cross-check)', async () => {
+            const gbf = new GroupByField('type', 0, 1, 'type');
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(6).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.integer({ min: 3, max: 5 }),
+                        fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 4 }),
+                    )
+                ),
+                async ([nodes, outerSize, constraints]) => {
+                    const outerIds = nodes.slice(0, outerSize).map(n => n.id);
+                    const innerIds = outerIds.slice(0, 2);
+                    const groups: LayoutGroup[] = [
+                        {
+                            name: 'G0', nodeIds: outerIds,
+                            keyNodeId: outerIds[0], showLabel: true, sourceConstraint: gbf,
+                        },
+                        {
+                            name: 'G1', nodeIds: innerIds,
+                            keyNodeId: innerIds[0], showLabel: true, sourceConstraint: gbf,
+                        },
+                    ];
+                    const layout = buildLayout(nodes, constraints, undefined, groups);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: NUM_RUNS, timeout: TIMEOUT });
+        });
+
+        it('random partially-overlapping groups on 6 nodes (Z3 cross-check)', async () => {
+            const gbf = new GroupByField('type', 0, 1, 'type');
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(6).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 4 }),
+                    )
+                ),
+                async ([nodes, constraints]) => {
+                    // G0 = {0,1,2}, G1 = {2,3,4}: share node 2, neither subsumes.
+                    const g0Ids = nodes.slice(0, 3).map(n => n.id);
+                    const g1Ids = nodes.slice(2, 5).map(n => n.id);
+                    const groups: LayoutGroup[] = [
+                        {
+                            name: 'G0', nodeIds: g0Ids,
+                            keyNodeId: g0Ids[0], showLabel: true, sourceConstraint: gbf,
+                        },
+                        {
+                            name: 'G1', nodeIds: g1Ids,
+                            keyNodeId: g1Ids[0], showLabel: true, sourceConstraint: gbf,
+                        },
+                    ];
+                    const layout = buildLayout(nodes, constraints, undefined, groups);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: NUM_RUNS, timeout: TIMEOUT });
         });
     });
 
@@ -720,6 +910,54 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
                                 `  Layout: ${describeLayout(layout)}\n` +
                                 `  MFS size: ${error.maximalFeasibleSubset.length}`
                             );
+                        }
+                    }
+                }
+            ), { numRuns: NUM_RUNS, timeout: TIMEOUT });
+        });
+
+        // On conjunctive-only systems the validator's model coincides with the
+        // oracle's subset model (nodes + non-overlap + the given constraints),
+        // and the MFS comes from the global greedy builder — so maximality is
+        // checkable: adding back ANY excluded constraint must be Z3-UNSAT.
+        // (With groups/disjunctions in play the subset model is a relaxation
+        // and a SAT verdict on an excluded constraint would prove nothing.)
+        it('MFS on conjunctive-only systems is feasible AND maximal per Z3', async () => {
+            await fc.assert(fc.asyncProperty(
+                arbMixedSystem(5, 8),
+                async (layout) => {
+                    const layoutV = cloneLayout(layout);
+                    const validator = new QualitativeConstraintValidator(layoutV);
+                    const error = validator.validateConstraints();
+                    if (!error || !isPositionalConstraintError(error) || !error.maximalFeasibleSubset) {
+                        return;
+                    }
+                    const mfs = error.maximalFeasibleSubset;
+                    // cloneLayout shares constraint object identity, so the
+                    // excluded set is computable from the original array
+                    // (the validator replaces layoutV.constraints, not ours).
+                    const mfsSet = new Set(mfs);
+                    const excluded = layout.constraints.filter(c => !mfsSet.has(c));
+
+                    const feasible = await verifyFeasibleSubset(layout, mfs);
+                    if (!feasible) {
+                        const detail =
+                            `MFS is NOT feasible according to Z3!\n` +
+                            `  MFS: ${mfs.map(describeConstraint).join(', ')}\n` +
+                            `  ${describeLayout(layout)}`;
+                        console.error(`[z3-oracle] ${detail}`);
+                        throw new Error(detail);
+                    }
+
+                    for (const c of excluded) {
+                        const stillFeasible = await verifyFeasibleSubset(layout, [...mfs, c]);
+                        if (stillFeasible) {
+                            const detail =
+                                `MFS is not maximal: adding back "${describeConstraint(c)}" is still feasible per Z3\n` +
+                                `  MFS: ${mfs.map(describeConstraint).join(', ')}\n` +
+                                `  ${describeLayout(layout)}`;
+                            console.error(`[z3-oracle] ${detail}`);
+                            throw new Error(detail);
                         }
                     }
                 }


### PR DESCRIPTION
Follow-up to #513, which added the diagnostics that explained the `solver-oracle` OOM flake ([run 30188347391](https://github.com/sidprasad/spytial-core/actions/runs/30188347391) attempt 1). This PR does the three remaining things: prevent the OOM, stop after the first real failure, and widen what the oracle actually cross-checks.

## 1. OOM prevention — two layers, because CI showed two death modes

**Gradual ratchet.** z3-solver frees Z3 ASTs via `FinalizationRegistry` — only when the JS GC happens to run finalizers — so allocation climbs ~0.8 MB/solve inside the fixed 2 GiB heap. The oracle now replaces the whole WASM module (terminate pthreads → fresh `init()`) whenever `Z3_get_estimated_alloc_size()` crosses **128 MB**, checked before each solve. ~1s per recycle, 7 per run on CI, allocation never ratchets again.

**Single monster solve.** This PR's own first CI run ([30227554187](https://github.com/sidprasad/spytial-core/actions/runs/30227554187)) proved recycling alone is not enough: one deterministic instance that solves in milliseconds locally ground for 6s on CI and then **native-aborted at only ~325 MB estimated alloc** — the real arena hit 2 GiB at a ~6× fragmentation/overhead multiplier, killing the runtime mid-solve exactly like the original flake (unsettled promise → 120s hang). Countermeasures:

- Z3's own `memory_max_size` ceiling at **256 MB** (Z3 tracks exactly the counter we already log, and returns a clean `unknown` instead of letting malloc fail and abort the runtime). Worst-case real arena ≈ 6.3 × 256 MB ≈ 1.6 GiB < 2 GiB.
- Z3 `timeout` at **45s**, so a grinder surfaces as `unknown` well before vitest's 120s.
- Clean `unknown`s (memory ceiling / timeout) **retry exactly once on a fresh module** — the CI monster was context-pollution-dependent search divergence (hundreds of prior solves' AST interning perturb the heuristics), so a clean module usually cures it. A second `unknown` fails loudly with `reasonUnknown()`. Native aborts still poison the runtime and never silently heal.

The misleading `resetZ3()` is removed (no callers): a new context on the same module does **not** reclaim the arena — that was the flaky mechanism, not a fix for it.

## 2. Fail-fast: `--bail=1` on the CI solver-oracle run

One confirmed validator/oracle discrepancy is enough signal. Everything after it — especially after a WASM abort — is noise (#513's poisoned-runtime cascade). Verified live on this PR's first run: the monster-solve failure stopped the job with **zero** cascade noise after it.

## 3. Coverage: 33 → 45 tests

- **MFS maximality, not just feasibility.** On conjunctive-only systems the validator's model coincides with the oracle's subset model and the MFS comes from the global greedy builder, so maximality is soundly checkable: adding back **any** excluded constraint must be Z3-UNSAT. (With groups/disjunctions the subset model is a relaxation and would prove nothing — the existing feasibility-only test keeps covering those.)
- **Nested (subgroup) and partially-overlapping groups** — deterministic cross-checks plus randomized properties. Neither shape had any oracle coverage; the `overlapping` flag path in both the validator and the oracle was dead code in tests.
- **Two same-source negated groups** — the merged-Or path (`negatedBySource`) had never run with more than one group. Includes a case that is SAT under the correct Or semantics but would be UNSAT under And semantics, plus a randomized pair property.
- **Randomized 4-member negated groups on 6 nodes** — extends the 2/3-member properties; largest M still on the FLAT encoding (`BBOX_THRESHOLD = 5`).

All 12 new tests agree between validator and Z3 — no divergences found.

## Testing

- `tests/z3-equivalence.test.ts`: 45/45 green locally (Node 22, ~25s, 7 recycles) and on CI ([run 30227872479](https://github.com/sidprasad/spytial-core/actions/runs/30227872479): 7 recycles, no retries needed).
- Typecheck at the 73-error pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
