### PR TITLE
test(z3-oracle): align degenerate negated-group semantics with validator

### DIFF
--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -481,6 +481,14 @@ function buildModel(
 
         if (altExprs.length > 0) {
             solver.add(ctx.Or(...altExprs));
+        } else {
+            // Every group from this source is degenerate: with fewer than 2
+            // members or 0 non-members, ¬group is false (a rectangle around
+            // the members excluding all non-members always exists). The
+            // validator pushes the merged inclusion disjunction unconditionally,
+            // so these cases surface as an EMPTY disjunction → UNSAT. Mirror
+            // that here rather than silently dropping the constraint.
+            solver.add(ctx.Bool.val(false));
         }
     }
 

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -585,6 +585,37 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
             ), { numRuns: 25, timeout: TIMEOUT });
         });
 
+        // ── Degenerate negated groups ──────────────────────────────────
+        // ¬group is false when the group has 0 non-members (a rectangle around
+        // everything always exists) or fewer than 2 members (non-overlap keeps
+        // every non-member out of a single member's box). The validator pushes
+        // the merged inclusion disjunction unconditionally, so an all-degenerate
+        // source yields an EMPTY disjunction → UNSAT; the oracle asserts false
+        // for the same case.
+
+        it('negated group covering all nodes — UNSAT (Z3 cross-check)', async () => {
+            const layout = parseConstraintSpec('{!G: a1, a2, a3}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(false);
+        });
+
+        it('negated group with a single member — UNSAT (Z3 cross-check)', async () => {
+            const layout = parseConstraintSpec('a1 <x b, {!G: a1}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(false);
+        });
+
+        it('degenerate group does not poison a same-source non-degenerate one — SAT (Z3 cross-check)', async () => {
+            // {!A} alone would be UNSAT, but same-source merging means only ONE
+            // group must be violated, and {!B} can be (a1 inside span(a2, a3)).
+            const layout = parseConstraintSpec('{!A: a1}, {!B: a2, a3}');
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(true);
+        });
+
         it('groups + ordering disjunctions on 6 nodes', async () => {
             const gbf = new GroupByField('type', 0, 1, 'type');
             const arbLayout = arbNodePool(6).chain(nodes => {


### PR DESCRIPTION
## What

Fixes a latent semantic divergence between the production validator and the Z3 test oracle for degenerate negated groups, and adds deterministic cross-checks so the equivalence suite would catch it.

- `tests/helpers/z3-oracle.ts`: when a source constraint's negated groups produce **zero** alternatives (every group has fewer than 2 members or 0 non-members), the oracle now asserts `false` instead of silently dropping the constraint.
- `tests/z3-equivalence.test.ts`: three new deterministic `(Z3 cross-check)` tests:
  - negated group covering all nodes → UNSAT
  - negated group with a single member → UNSAT
  - degenerate group merged with a same-source non-degenerate one → SAT (the degenerate group must drop out of the merged disjunction, not poison it)

## Why

The validator (`addGroupBoundingBoxDisjunctions`, negated-groups section) pushes the merged inclusion disjunction **unconditionally**; when all same-source groups are degenerate the disjunction is empty, and `presolveDisjunctions` reports it as UNSAT via a dedicated empty-disjunction error path. The oracle only added `Or(...altExprs)` when alternatives existed, so the same layouts were trivially SAT on the oracle side. No existing test generated these shapes (the randomized ones always use ≥2 members on larger node pools), so the suite never disagreed.

UNSAT is the intended semantics, on three grounds:

1. **Paper/Lean semantics**: `group(s, n)` is an existential over a boundary rectangle (members inside, non-members strictly outside), and negation is pure `¬modelsC`. With 0 non-members the exclusion clause is vacuous, so the positive group holds in every layout and its negation in none. With 1 member, pairwise non-overlap (which the oracle model itself asserts) makes the member's own bbox always a valid boundary — same conclusion.
2. **Production behavior is deliberate**: the validator's empty-disjunction path names exactly this case ("NOT GROUP with all nodes as members") and builds a proper `PositionalConstraintError` rather than crashing.
3. **Reachable in practice**: a negated GroupBy directive whose selector matches the whole universe (or a single atom) produces these shapes, and surfacing the contradiction matches how Spytial handles other unsatisfiable directives (e.g. hideAtom vs constraint, #479).

Note the merge subtlety the third test guards: a degenerate negated group only forces UNSAT when **every** group from its source is degenerate; otherwise it contributes nothing to the "at least one group fails" disjunction.

## Testing

Full suite passes on Node 22: `npx vitest run tests/z3-equivalence.test.ts` — 48/48 (including the 3 new tests) in ~20s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)