### PR TITLE
perf(layout): lazy modal query state; Tarjan SCC for alignment classes

### DIFF
--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -432,71 +432,90 @@ class DifferenceConstraintGraph {
     }
 
     /**
+     * All strongly connected components of the graph (any-weight edges).
+     * In a consistent graph, mutual reachability is only possible through
+     * zero-weight alignment cycles (positive-weight cycles are rejected at
+     * insertion), so SCCs are exactly the alignment classes.
+     *
+     * Iterative Tarjan, O(V + E) — replaces the old per-node nested-BFS
+     * approach, which was O(V·(V+E)) and dominated computeAlignmentOrders
+     * (87ms of a 200-node chain's validation, with zero alignments present).
+     */
+    private tarjanSCCs(): string[][] {
+        const index = new Map<string, number>();
+        const lowlink = new Map<string, number>();
+        const onStack = new Set<string>();
+        const stack: string[] = [];
+        const components: string[][] = [];
+        let next = 0;
+
+        interface Frame { node: string; succs: string[]; i: number }
+
+        for (const root of this.nodes) {
+            if (index.has(root)) continue;
+            const frames: Frame[] = [];
+            const open = (n: string): void => {
+                index.set(n, next);
+                lowlink.set(n, next);
+                next++;
+                stack.push(n);
+                onStack.add(n);
+                frames.push({ node: n, succs: [...(this.adj.get(n)?.keys() ?? [])], i: 0 });
+            };
+            open(root);
+            while (frames.length > 0) {
+                const f = frames[frames.length - 1];
+                if (f.i < f.succs.length) {
+                    const s = f.succs[f.i++];
+                    if (!index.has(s)) {
+                        open(s);
+                    } else if (onStack.has(s)) {
+                        lowlink.set(f.node, Math.min(lowlink.get(f.node)!, index.get(s)!));
+                    }
+                } else {
+                    frames.pop();
+                    if (lowlink.get(f.node) === index.get(f.node)) {
+                        const comp: string[] = [];
+                        let m: string;
+                        do {
+                            m = stack.pop()!;
+                            onStack.delete(m);
+                            comp.push(m);
+                        } while (m !== f.node);
+                        components.push(comp);
+                    }
+                    const parent = frames[frames.length - 1];
+                    if (parent) {
+                        lowlink.set(parent.node, Math.min(lowlink.get(parent.node)!, lowlink.get(f.node)!));
+                    }
+                }
+            }
+        }
+        return components;
+    }
+
+    /**
      * Get alignment classes: groups of nodes connected by mutual zero-weight paths.
      * Returns a map from canonical representative to list of class members.
      * Classes with only one member are omitted.
      */
     getAlignmentClasses(): Map<string, string[]> {
-        // Find SCCs using Tarjan's or simpler approach: for each node, find its
-        // SCC by checking mutual reachability. For small graphs, nested BFS is fine.
         const classes = new Map<string, string[]>();
-        const assigned = new Set<string>();
-
-        for (const node of this.nodes) {
-            if (assigned.has(node)) continue;
-
-            // Find all nodes mutually reachable from this node (same SCC)
-            const forwardReachable = this.reachableSet(node);
-            const classMembers: string[] = [];
-
-            for (const candidate of forwardReachable) {
-                if (this.canReach(candidate, node)) {
-                    classMembers.push(candidate);
-                }
-            }
-
-            if (classMembers.length > 1) {
-                classMembers.sort(); // deterministic
-                const representative = classMembers[0];
-                classes.set(representative, classMembers);
-                for (const m of classMembers) assigned.add(m);
-            } else {
-                assigned.add(node);
+        for (const comp of this.tarjanSCCs()) {
+            if (comp.length > 1) {
+                comp.sort(); // deterministic
+                classes.set(comp[0], comp);
             }
         }
-
         return classes;
     }
 
     /** Get the alignment class (SCC) containing the given node. */
     getAlignmentClassOf(nodeId: string): string[] {
-        const forward = this.reachableSet(nodeId);
-        const members: string[] = [];
-        for (const candidate of forward) {
-            if (this.canReach(candidate, nodeId)) {
-                members.push(candidate);
-            }
+        for (const comp of this.tarjanSCCs()) {
+            if (comp.includes(nodeId)) return comp;
         }
-        return members;
-    }
-
-    /** Get all nodes reachable from `start` via any edges. */
-    private reachableSet(start: string): Set<string> {
-        const visited = new Set<string>();
-        const queue: string[] = [start];
-        visited.add(start);
-        while (queue.length > 0) {
-            const cur = queue.shift()!;
-            const succs = this.adj.get(cur);
-            if (!succs) continue;
-            for (const s of succs.keys()) {
-                if (!visited.has(s)) {
-                    visited.add(s);
-                    queue.push(s);
-                }
-            }
-        }
-        return visited;
+        return [nodeId];
     }
 
     /**
@@ -727,8 +746,13 @@ class QualitativeConstraintValidator implements IConstraintValidator {
             this.layout.constraints = this.layout.constraints.concat(chosenConstraints);
         }
 
-        // Phase 5b: Build modal query state (must/can/cannot)
-        this.buildModalQueryState();
+        // Phase 5b: Modal query state (must/can/cannot) is built LAZILY on the
+        // first modal query (ensureModalQueryState). It is pure post-solve
+        // analysis over the must-graph snapshots and this.allDisjunctions —
+        // both frozen from here on — and profiling showed it dominating
+        // validation wall time (e.g. 78% on a 200-node conjunctive chain)
+        // while its only consumers (layout-evaluator, spytial-explorer) query
+        // interactively after render, and often never.
 
         // Phase 6: Alignment orders
         const implicitConstraints = this.computeAlignmentOrders();
@@ -3073,12 +3097,28 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     // ─── Modal query computation ────────────────────────────────────────────
 
     /**
+     * Build modal state on first use. Safe to defer past validation because
+     * buildModalQueryState reads only the must-graph snapshots (taken before
+     * CDCL) and this.allDisjunctions (final after solveCDCL) — neither
+     * changes after validatePositionalConstraints returns. If validation
+     * failed (or never ran), the snapshots are null and modal queries keep
+     * their pre-existing behavior of returning empty/reflexive sets.
+     */
+    private modalStateBuilt = false;
+
+    private ensureModalQueryState(): void {
+        if (this.modalStateBuilt || !this.mustHGraph || !this.mustVGraph) return;
+        this.modalStateBuilt = true;
+        this.buildModalQueryState();
+    }
+
+    /**
      * Build the precomputed must-ordering pairs by:
      * 1. Starting with the conjunctive base (post-presolve snapshot)
      * 2. Strengthening via disjunction intersection: for each remaining disjunction,
      *    compute which orderings ALL alternatives agree on
      *
-     * Called once after successful validation (feasible layout).
+     * Called once, lazily, via ensureModalQueryState.
      */
     private buildModalQueryState(): void {
         if (!this.mustHGraph || !this.mustVGraph) return;
@@ -3115,17 +3155,20 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         return pairs;
     }
 
-    /** Collect alignment equivalence classes from a graph. */
+    /** Collect alignment equivalence classes from a graph (one SCC pass). */
     private collectAlignmentClasses(graph: DifferenceConstraintGraph, nodeIds: string[]): Map<string, Set<string>> {
         const classes = new Map<string, Set<string>>();
         const realSet = new Set(nodeIds);
-        for (const id of nodeIds) {
-            const members = graph.getAlignmentClassOf(id);
-            const filtered = new Set<string>();
-            for (const m of members) {
-                if (m !== id && realSet.has(m)) filtered.add(m);
+        for (const id of nodeIds) classes.set(id, new Set());
+        for (const [, members] of graph.getAlignmentClasses()) {
+            const real = members.filter(m => realSet.has(m));
+            for (const m of real) {
+                const set = classes.get(m);
+                if (!set) continue;
+                for (const other of real) {
+                    if (other !== m) set.add(other);
+                }
             }
-            classes.set(id, filtered);
         }
         return classes;
     }
@@ -3278,6 +3321,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * Derived from conjunctive entailment + disjunction intersection.
      */
     public getMust(nodeId: string, relation: 'leftOf' | 'rightOf' | 'above' | 'below'): Set<string> {
+        this.ensureModalQueryState();
         const realNodeIds = new Set(this.nodes.map(n => n.id));
         const result = new Set<string>();
         if (!this.mustHPairs || !this.mustVPairs) return result;
@@ -3307,6 +3351,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * because it also catches infeasibility via zero-weight path chains.
      */
     public getCannot(nodeId: string, relation: 'leftOf' | 'rightOf' | 'above' | 'below'): Set<string> {
+        this.ensureModalQueryState();
         const result = new Set<string>();
         result.add(nodeId); // reflexive exclusion
 
@@ -3353,6 +3398,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
 
     /** Alignment equivalence class — nodes that MUST be aligned with nodeId. */
     public getMustAligned(nodeId: string, axis: 'x' | 'y'): Set<string> {
+        this.ensureModalQueryState();
         const classes = axis === 'x' ? this.mustHAlignmentClasses : this.mustVAlignmentClasses;
         return classes?.get(nodeId) ?? new Set();
     }
@@ -3373,6 +3419,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      *    e.g. "A =x B" alone would report that A and B can also be y-aligned.
      */
     public getCannotAligned(nodeId: string, axis: 'x' | 'y'): Set<string> {
+        this.ensureModalQueryState();
         const result = new Set<string>();
         result.add(nodeId); // X is not "aligned with itself" in the query sense
         const graph = axis === 'x' ? this.mustHGraph : this.mustVGraph;

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -903,18 +903,15 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         const remaining: DisjunctiveConstraint[] = [];
 
         for (const disj of this.allDisjunctions) {
-            const regionPair = this.getDisjunctionRegionPair(disj);
-
-            // Already separated?
-            if (regionPair && this.areSeparated(regionPair[0], regionPair[1])) {
-                const satisfyingAlt = this.findSatisfyingAlternative(disj, regionPair);
-                if (satisfyingAlt !== null) {
-                    for (const constraint of disj.alternatives[satisfyingAlt]) {
-                        this.addedConstraints.push(constraint);
-                    }
-                    this.prunedByTransitivity++;
-                    continue;
+            // Already satisfied? An alternative fully implied by the current
+            // graphs can be committed without adding edges (already entailed).
+            const impliedAlt = this.findImpliedAlternative(disj);
+            if (impliedAlt !== null) {
+                for (const constraint of disj.alternatives[impliedAlt]) {
+                    this.addedConstraints.push(constraint);
                 }
+                this.prunedByTransitivity++;
+                continue;
             }
 
             // Prune infeasible alternatives
@@ -1287,13 +1284,6 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     // Geometric pruning helpers
     // ═══════════════════════════════════════════════════════════════════════════
 
-    private areSeparated(idA: string, idB: string): boolean {
-        return (
-            this.hGraph.isOrdered(idA, idB) || this.hGraph.isOrdered(idB, idA) ||
-            this.vGraph.isOrdered(idA, idB) || this.vGraph.isOrdered(idB, idA)
-        );
-    }
-
     /**
      * Check if an alternative is feasible:
      * 1. No cycle (transitivity check)
@@ -1397,20 +1387,24 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     // alignment conflicts are caught automatically by DifferenceConstraintGraph.addEdge
     // (which checks canReach for cycles through zero-weight alignment edges).
 
-    private getDisjunctionRegionPair(disj: DisjunctiveConstraint): [string, string] | null {
-        if (disj.alternatives.length === 0) return null;
-        const first = disj.alternatives[0][0];
-        if (isBoundingBoxConstraint(first)) return [first.node.id, `_group_${first.group.name}`];
-        if (isGroupBoundaryConstraint(first)) return [`_group_${first.groupA.name}`, `_group_${first.groupB.name}`];
-        if (isLeftConstraint(first)) return [first.left.id, first.right.id];
-        if (isTopConstraint(first)) return [first.top.id, first.bottom.id];
-        return null;
-    }
-
-    private findSatisfyingAlternative(disj: DisjunctiveConstraint, pair: [string, string]): number | null {
-        // Find an alternative whose constraints are all actually implied by
-        // the current ordering graphs (forward direction is ordered or alignment
-        // already holds).
+    /**
+     * Find an alternative whose constraints are ALL already implied by the
+     * current ordering graphs (forward direction is ordered or the alignment
+     * already holds). Only such an alternative may be committed WITHOUT adding
+     * its edges to the graphs — the facts are already entailed, so nothing can
+     * later contradict them undetected.
+     *
+     * There is deliberately NO "merely not contradicted" fallback here. The
+     * old fallback checked each constraint of an alternative against the
+     * graphs individually and committed the alternative without edges; the
+     * constraints could then contradict each other JOINTLY with the base
+     * (e.g. a negated-group tuple N1 <x N2 <x N0 against base N0 <x N1),
+     * producing a SAT verdict with an unsatisfiable committed constraint set.
+     * Caught by the Z3 committed-model cross-check in z3-equivalence.test.ts.
+     * Non-implied alternatives must go through the normal path, where commits
+     * add graph edges (addConjunctiveConstraint / tryAssign).
+     */
+    private findImpliedAlternative(disj: DisjunctiveConstraint): number | null {
         for (let i = 0; i < disj.alternatives.length; i++) {
             let allImplied = true;
             for (const constraint of disj.alternatives[i]) {
@@ -1427,32 +1421,6 @@ class QualitativeConstraintValidator implements IConstraintValidator {
                 if (!graph.isOrdered(edge.from, edge.to)) { allImplied = false; break; }
             }
             if (allImplied) return i;
-        }
-        // Fallback: if no alternative is fully implied, find one that's at least
-        // not contradicted. Must also check alignment conflicts — an ordering
-        // between aligned nodes is contradicted even if no reverse edge exists.
-        // With zero-weight alignment edges, isStrictlyOrdered catches this:
-        // ordering aligned nodes would create a negative cycle through the
-        // zero-weight alignment path.
-        for (let i = 0; i < disj.alternatives.length; i++) {
-            let feasible = true;
-            for (const constraint of disj.alternatives[i]) {
-                if (isAlignmentConstraint(constraint)) {
-                    const ac = constraint as AlignmentConstraint;
-                    const graph = ac.axis === 'x' ? this.hGraph : this.vGraph;
-                    // Alignment is contradicted if the nodes are strictly ordered
-                    if (graph.isStrictlyOrdered(ac.node1.id, ac.node2.id) || graph.isStrictlyOrdered(ac.node2.id, ac.node1.id)) {
-                        feasible = false; break;
-                    }
-                    continue;
-                }
-                const edge = this.constraintToEdge(constraint);
-                if (!edge) continue;
-                const graph = edge.axis === 'h' ? this.hGraph : this.vGraph;
-                // Contradicted by reverse ordering (including through alignment paths)?
-                if (graph.canReach(edge.to, edge.from)) { feasible = false; break; }
-            }
-            if (feasible) return i;
         }
         return null;
     }
@@ -2108,13 +2076,10 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         const pruned: DisjunctiveConstraint[] = [];
 
         for (const disj of this.allDisjunctions) {
-            const regionPair = this.getDisjunctionRegionPair(disj);
-            if (regionPair && this.areSeparated(regionPair[0], regionPair[1])) {
-                const satisfyingAlt = this.findSatisfyingAlternative(disj, regionPair);
-                if (satisfyingAlt !== null) {
-                    for (const c of disj.alternatives[satisfyingAlt]) this.addedConstraints.push(c);
-                    continue;
-                }
+            const impliedAlt = this.findImpliedAlternative(disj);
+            if (impliedAlt !== null) {
+                for (const c of disj.alternatives[impliedAlt]) this.addedConstraints.push(c);
+                continue;
             }
 
             const validAlternatives: LayoutConstraint[][] = [];
@@ -3396,19 +3361,33 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * Nodes that CANNOT be aligned with nodeId on the given axis.
      *
      * Feasibility check: adding alignment(X, Y) means zero-weight edges in both
-     * directions. This is infeasible if there's a strict ordering between them
-     * (isStrictlyOrdered in either direction), because the zero-weight cycle
-     * would contradict the positive-weight edge.
+     * directions. This is infeasible if:
+     * 1. There's a strict ordering between them (isStrictlyOrdered in either
+     *    direction) — the zero-weight cycle would contradict the positive-weight
+     *    edge; or
+     * 2. Merging their alignment classes on this axis would put two distinct
+     *    nodes that are aligned on the OTHER axis into the same class —
+     *    dual-axis alignment forces identical positions, i.e. node overlap.
+     *    This is the same rule the solver applies in isAlternativeFeasible
+     *    (classHasDualAxisOverlap); without it getCanAligned over-claims,
+     *    e.g. "A =x B" alone would report that A and B can also be y-aligned.
      */
     public getCannotAligned(nodeId: string, axis: 'x' | 'y'): Set<string> {
         const result = new Set<string>();
         result.add(nodeId); // X is not "aligned with itself" in the query sense
         const graph = axis === 'x' ? this.mustHGraph : this.mustVGraph;
+        const otherGraph = axis === 'x' ? this.mustVGraph : this.mustHGraph;
         if (!graph) return result;
 
         for (const n of this.nodes) {
             if (n.id === nodeId) continue;
             if (graph.isStrictlyOrdered(nodeId, n.id) || graph.isStrictlyOrdered(n.id, nodeId)) {
+                result.add(n.id);
+                continue;
+            }
+            if (otherGraph && QualitativeConstraintValidator.classHasDualAxisOverlap(
+                graph, otherGraph, nodeId, n.id, false,
+            )) {
                 result.add(n.id);
             }
         }

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -613,14 +613,53 @@ async function checkedSolve(solver: any, what: string): Promise<boolean> {
     return result === 'sat';
 }
 
+// ─── Modal propositions ─────────────────────────────────────────────────
+//
+// Atomic geometric propositions that can be conjoined onto the full model.
+// These are the building blocks for entailment cross-checks of the
+// validator's modal query API (getMust / getCannot / getCan / *Aligned):
+//   must P    ⟺  UNSAT(model ∧ ¬P)
+//   cannot P  ⟺  UNSAT(model ∧ P)
+//   can P     ⟺  SAT(model ∧ P)
+// `axis: 'x'` reads coordinates from the x vars and sizes from widths;
+// `axis: 'y'` from y vars and heights.
+export type OracleProp =
+    | { kind: 'coordLt'; axis: 'x' | 'y'; a: string; b: string }      // coord_a < coord_b
+    | { kind: 'coordGe'; axis: 'x' | 'y'; a: string; b: string }      // coord_a ≥ coord_b
+    | { kind: 'properBefore'; axis: 'x' | 'y'; a: string; b: string } // coord_a + size_a ≤ coord_b
+    | { kind: 'coordEq'; axis: 'x' | 'y'; a: string; b: string }      // coord_a = coord_b
+    | { kind: 'coordNeq'; axis: 'x' | 'y'; a: string; b: string };    // coord_a ≠ coord_b
+
+function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool {
+    const ctx = z3Ctx;
+    const coord = (id: string) => vars.get(varName(id, p.axis));
+    const size = (id: string): number => {
+        const n = layout.nodes.find(node => node.id === id);
+        if (!n) throw new Z3OracleError(`Unknown node in oracle proposition: ${id}`);
+        return p.axis === 'x' ? n.width : n.height;
+    };
+    switch (p.kind) {
+        case 'coordLt': return coord(p.a).lt(coord(p.b));
+        case 'coordGe': return coord(p.a).ge(coord(p.b));
+        case 'properBefore': return coord(p.a).add(size(p.a)).le(coord(p.b));
+        case 'coordEq': return coord(p.a).eq(coord(p.b));
+        case 'coordNeq': return ctx.Not(coord(p.a).eq(coord(p.b)));
+    }
+}
+
 function buildModelChecked(
     layout: InstanceLayout,
     what: string,
     constraintOverride?: LayoutConstraint[],
+    extraProps?: OracleProp[],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): { solver: any; vars: VarMap } {
     try {
-        return buildModel(layout, constraintOverride);
+        const built = buildModel(layout, constraintOverride);
+        for (const p of extraProps ?? []) {
+            built.solver.add(compileProp(p, layout, built.vars));
+        }
+        return built;
     } catch (e) {
         // Once the runtime has aborted, even AST construction throws — this is
         // the path that produced instant bogus "counterexamples" in CI.
@@ -635,8 +674,9 @@ async function attemptSolve(
     layout: InstanceLayout,
     what: string,
     constraintOverride?: LayoutConstraint[],
+    extraProps?: OracleProp[],
 ): Promise<boolean> {
-    const { solver } = buildModelChecked(layout, what, constraintOverride);
+    const { solver } = buildModelChecked(layout, what, constraintOverride, extraProps);
     return checkedSolve(solver, what);
 }
 
@@ -644,11 +684,12 @@ async function runSolve(
     layout: InstanceLayout,
     what: string,
     constraintOverride?: LayoutConstraint[],
+    extraProps?: OracleProp[],
 ): Promise<boolean> {
     assertNotPoisoned();
     await maybeRecycle();
     try {
-        return await attemptSolve(layout, what, constraintOverride);
+        return await attemptSolve(layout, what, constraintOverride, extraProps);
     } catch (e) {
         if (!(e instanceof Z3UnknownError) || poisonedBy) throw e;
         // A clean 'unknown' (memory ceiling, timeout) from a part-filled heap
@@ -660,7 +701,7 @@ async function runSolve(
         // eslint-disable-next-line no-console
         console.error(`[z3-oracle] retrying ${what} on a fresh module after: ${e}`);
         await recycleZ3(`'unknown' during ${what}`);
-        return attemptSolve(layout, what, constraintOverride);
+        return attemptSolve(layout, what, constraintOverride, extraProps);
     }
 }
 
@@ -683,4 +724,17 @@ export async function verifyFeasibleSubset(
     subset: LayoutConstraint[],
 ): Promise<boolean> {
     return runSolve(layout, 'verifyFeasibleSubset', subset);
+}
+
+/**
+ * Solve the FULL model (constraints, disjunctions, groups, non-overlap)
+ * conjoined with extra atomic propositions. This is the entailment probe
+ * for modal queries: `must P` holds iff solveZ3With(layout, [¬P]) is false;
+ * `can P` holds iff solveZ3With(layout, [P]) is true.
+ */
+export async function solveZ3With(
+    layout: InstanceLayout,
+    props: OracleProp[],
+): Promise<boolean> {
+    return runSolve(layout, 'solveZ3With', undefined, props);
 }

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -65,8 +65,19 @@ async function checkAgainstOracle(layout: InstanceLayout): Promise<{
     const error = validator.validateConstraints();
     const validatorSat = error === null;
     let oracleSat: boolean;
+    let committedSat = true;
     try {
         oracleSat = await solveZ3(layout);
+
+        // On SAT the validator has committed its chosen disjunct alternatives
+        // plus implicit alignment orders into layoutV.constraints. Boolean
+        // agreement alone would miss a solver that answers SAT while committing
+        // an inconsistent set — so verify the committed conjunctive system too.
+        // (Group bbox variables are unconstrained in this relaxed check, so it
+        // can only under-report inconsistency, never false-alarm.)
+        if (validatorSat) {
+            committedSat = await verifyFeasibleSubset(layoutV, layoutV.constraints);
+        }
     } catch (e) {
         // Log the real cause directly: fast-check wraps predicate errors and
         // the reporter can drop the cause chain, leaving only a meaningless
@@ -76,6 +87,13 @@ async function checkAgainstOracle(layout: InstanceLayout): Promise<{
             `  ${describeLayout(layout)}`
         );
         throw e;
+    }
+    if (!committedSat) {
+        const detail =
+            `Validator said SAT but its committed constraint set is UNSAT per Z3 ` +
+            `(${layoutV.constraints.length} constraints)\n  ${describeLayout(layout)}`;
+        console.error(`[z3-oracle] ${detail}`);
+        throw new Error(detail);
     }
     return { validatorSat, oracleSat };
 }

--- a/tests/z3-modal-equivalence.test.ts
+++ b/tests/z3-modal-equivalence.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Entailment cross-checks between the validator's modal query API
+ * (getMust / getCannot / getCan / getMustAligned / getCannotAligned)
+ * and the Z3 oracle.
+ *
+ * The modal contracts are exact claims over the ORIGINAL constraint program
+ * (all valid layouts, not the one the CDCL happened to commit):
+ *   getMust(X, rel)    — nodes in `rel` to X in ALL valid layouts
+ *   getCannot(X, rel)  — nodes in `rel` to X in NO valid layout
+ *   getCan(X, rel)     — complement of getCannot
+ * Z3 decides these directly on the full model:
+ *   must P    ⟺  UNSAT(model ∧ ¬P)
+ *   cannot P  ⟺  UNSAT(model ∧ P)
+ *
+ * Propositions:
+ *   - must "Y left of X" is probed with its weakest sound reading,
+ *     coord entailment: UNSAT(x_Y ≥ x_X).
+ *   - cannot/can "Y left of X" is probed as proper placement:
+ *     x_Y + w_Y ≤ x_X. The system is pure difference bounds (no upper
+ *     bounds), so a model with x_Y < x_X can always be stretched into one
+ *     with proper separation — "can be strictly before" ⟺ "can be
+ *     properly before" — which makes this probe exact, not conservative.
+ *
+ * Soundness (claimed must/cannot facts hold per Z3) is always asserted.
+ * Exactness of the can-side (no over-claimed "can") is asserted only where
+ * the theory guarantees the must-graph is complete: conjunctive systems,
+ * where reachability in the difference graph plus the dual-axis overlap
+ * rule exactly characterize entailment. With disjunctions the
+ * per-disjunction intersection strengthening misses joint entailment —
+ * see the KNOWN INCOMPLETENESS ledger at the bottom.
+ */
+
+import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 120_000 });
+import * as fc from 'fast-check';
+import { QualitativeConstraintValidator } from '../src/layout/qualitative-constraint-validator';
+import { InstanceLayout } from '../src/layout/interfaces';
+import {
+    isZ3Available,
+    shutdownZ3,
+    solveZ3With,
+    describeOracleStats,
+    OracleProp,
+} from './helpers/z3-oracle';
+import {
+    cloneLayout,
+    describeLayout,
+    parseConstraintSpec,
+} from './helpers/constraint-dsl';
+import {
+    arbNodePool,
+    arbConjunctive,
+    arbOrdering,
+    arbDisjunction,
+    buildLayout,
+} from './helpers/constraint-arbitraries';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+class ModalDisagreement extends Error {}
+
+function fail(layout: InstanceLayout, claim: string): never {
+    const detail = `Modal disagreement: ${claim}\n  ${describeLayout(layout)}`;
+    // Log directly — fast-check wraps predicate errors and the reporter can
+    // drop the cause chain (same rationale as in z3-equivalence.test.ts).
+    console.error(`[z3-oracle] ${detail}`);
+    throw new ModalDisagreement(detail);
+}
+
+/**
+ * Validate `layout`, then cross-check every modal claim against Z3.
+ * Returns false (checking nothing) when the layout is UNSAT — modal
+ * queries are only defined for feasible layouts.
+ *
+ * `canExactOrdering` / `canExactAlignment` additionally assert that the
+ * can-side does not over-claim (every ¬cannot is Z3-SAT), separately for
+ * ordering and alignment claims — the two have different completeness
+ * frontiers (see the KNOWN INCOMPLETENESS tests).
+ */
+async function checkModalAgainstOracle(
+    layout: InstanceLayout,
+    opts: { canExactOrdering: boolean; canExactAlignment: boolean },
+): Promise<boolean> {
+    const layoutV = cloneLayout(layout);
+    const validator = new QualitativeConstraintValidator(layoutV);
+    if (validator.validateConstraints() !== null) return false;
+
+    const ids = layout.nodes.map(n => n.id);
+
+    // ── Structural coherence (no Z3): mirror relations must agree ──────
+    for (const X of ids) {
+        expect(validator.getCannot(X, 'leftOf').has(X)).toBe(true); // reflexive
+        expect(validator.getCannot(X, 'above').has(X)).toBe(true);
+        for (const Y of ids) {
+            if (X === Y) continue;
+            expect(validator.getMust(X, 'leftOf').has(Y)).toBe(validator.getMust(Y, 'rightOf').has(X));
+            expect(validator.getMust(X, 'above').has(Y)).toBe(validator.getMust(Y, 'below').has(X));
+            expect(validator.getCannot(X, 'leftOf').has(Y)).toBe(validator.getCannot(Y, 'rightOf').has(X));
+            expect(validator.getCannot(X, 'above').has(Y)).toBe(validator.getCannot(Y, 'below').has(X));
+            expect(validator.getMustAligned(X, 'x').has(Y)).toBe(validator.getMustAligned(Y, 'x').has(X));
+            expect(validator.getMustAligned(X, 'y').has(Y)).toBe(validator.getMustAligned(Y, 'y').has(X));
+        }
+    }
+
+    // ── Entailment probes ──────────────────────────────────────────────
+    for (const axis of ['x', 'y'] as const) {
+        const rel = axis === 'x' ? 'leftOf' as const : 'above' as const;
+
+        for (const X of ids) {
+            const must = validator.getMust(X, rel);
+            const cannot = validator.getCannot(X, rel);
+            for (const Y of ids) {
+                if (Y === X) continue;
+
+                if (must.has(Y)) {
+                    // Claim: Y strictly before X on this axis in ALL models.
+                    const refuted: OracleProp = { kind: 'coordGe', axis, a: Y, b: X };
+                    if (await solveZ3With(layout, [refuted])) {
+                        fail(layout, `getMust(${X}, ${rel}) claims ${Y}, but Z3 found a model with ${axis}_${Y} ≥ ${axis}_${X}`);
+                    }
+                }
+
+                const placement: OracleProp = { kind: 'properBefore', axis, a: Y, b: X };
+                if (cannot.has(Y)) {
+                    // Claim: no model places Y properly before X.
+                    if (await solveZ3With(layout, [placement])) {
+                        fail(layout, `getCannot(${X}, ${rel}) claims ${Y}, but Z3 placed ${Y} properly before ${X} on ${axis}`);
+                    }
+                } else if (opts.canExactOrdering) {
+                    // Claim (via getCan = ¬getCannot): some model places Y properly before X.
+                    if (!(await solveZ3With(layout, [placement]))) {
+                        fail(layout, `getCan(${X}, ${rel}) claims ${Y}, but Z3 proved ${Y} can never be properly before ${X} on ${axis}`);
+                    }
+                }
+            }
+        }
+
+        // Alignment claims are symmetric — probe unordered pairs once.
+        for (let i = 0; i < ids.length; i++) {
+            const X = ids[i];
+            const mustA = validator.getMustAligned(X, axis);
+            const cannotA = validator.getCannotAligned(X, axis);
+            for (let j = i + 1; j < ids.length; j++) {
+                const Y = ids[j];
+
+                if (mustA.has(Y)) {
+                    const refuted: OracleProp = { kind: 'coordNeq', axis, a: X, b: Y };
+                    if (await solveZ3With(layout, [refuted])) {
+                        fail(layout, `getMustAligned(${X}, ${axis}) claims ${Y}, but Z3 found a model with ${axis}_${X} ≠ ${axis}_${Y}`);
+                    }
+                }
+
+                const aligned: OracleProp = { kind: 'coordEq', axis, a: X, b: Y };
+                if (cannotA.has(Y)) {
+                    if (await solveZ3With(layout, [aligned])) {
+                        fail(layout, `getCannotAligned(${X}, ${axis}) claims ${Y}, but Z3 aligned them`);
+                    }
+                } else if (opts.canExactAlignment) {
+                    if (!(await solveZ3With(layout, [aligned]))) {
+                        fail(layout, `getCanAligned(${X}, ${axis}) claims ${Y}, but Z3 proved alignment impossible`);
+                    }
+                }
+            }
+        }
+    }
+    return true;
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+const available = await isZ3Available();
+
+afterAll(() => {
+    if (available) shutdownZ3();
+});
+
+afterEach((ctx) => {
+    if (!available) return;
+    console.log(`[z3-oracle] after "${ctx.task.name}": ${describeOracleStats()}`);
+});
+
+describe.runIf(available)('Modal query entailment vs Z3', () => {
+
+    // ─── Deterministic cases (exhaustive pair probes) ───────────────────
+
+    it('transitive chain: modal queries exactly match Z3', async () => {
+        const layout = parseConstraintSpec('a <x b, b <x c');
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        // Spot-check the expected transitive facts surfaced at all.
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('c', 'leftOf').has('a')).toBe(true);
+        expect(v.getCannot('a', 'leftOf').has('c')).toBe(true);
+    });
+
+    it('alignment chain: aligned nodes cannot order, mustAligned is transitive', async () => {
+        const layout = parseConstraintSpec('a =x b, b =x c, a <y b');
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMustAligned('a', 'x').has('c')).toBe(true);
+        expect(v.getCannot('a', 'leftOf').has('b')).toBe(true);
+    });
+
+    it('disjunction with a common consequence yields a must fact', async () => {
+        // Both alternatives contain a <x b, so the intersection strengthening
+        // must surface must(a before b) even though the constraint is disjunctive.
+        // Alignment exactness is off: every alternative x-separates b and c, so
+        // b/c can never be x-aligned, but cannot-aligned facts are not derived
+        // from disjunction intersection (see KNOWN INCOMPLETENESS below).
+        const layout = parseConstraintSpec('[a <x b & b <x c | a <x b & c <x b]');
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: false })).toBe(true);
+
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('b', 'leftOf').has('a')).toBe(true);
+    });
+
+    it('group bounding-box disjunctions leave modal claims exact', async () => {
+        const layout = parseConstraintSpec('x <x a1, x <x a2, {A: a1, a2}');
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+    });
+
+    // ─── Randomized (fixed seed → deterministic in CI) ──────────────────
+
+    it('random conjunctive systems: modal queries exactly match Z3', async () => {
+        await fc.assert(fc.asyncProperty(
+            arbNodePool(4).chain(nodes =>
+                fc.tuple(
+                    fc.constant(nodes),
+                    fc.array(arbConjunctive(nodes), { minLength: 0, maxLength: 5 }),
+                )
+            ),
+            async ([nodes, constraints]) => {
+                const layout = buildLayout(nodes, constraints);
+                await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true });
+            }
+        ), { numRuns: 8, seed: 20260727, timeout: 120_000 });
+    });
+
+    it('random ordering + disjunction systems: modal claims are sound', async () => {
+        await fc.assert(fc.asyncProperty(
+            arbNodePool(4).chain(nodes =>
+                fc.tuple(
+                    fc.constant(nodes),
+                    fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 3 }),
+                    fc.array(arbDisjunction(nodes), { minLength: 1, maxLength: 2 }),
+                )
+            ),
+            async ([nodes, constraints, disjunctions]) => {
+                const layout = buildLayout(nodes, constraints, disjunctions);
+                // Soundness only: with disjunctions the can-side may over-claim
+                // (see KNOWN INCOMPLETENESS below).
+                await checkModalAgainstOracle(layout, { canExactOrdering: false, canExactAlignment: false });
+            }
+        ), { numRuns: 8, seed: 20260727, timeout: 120_000 });
+    });
+
+    // ─── Known incompleteness ledger ────────────────────────────────────
+    // Each specimen has a passing ground-truth test (Z3 proves the fact,
+    // and everything the validator DOES claim stays sound) and an it.fails
+    // test asserting the exact modal semantics. If an it.fails test starts
+    // PASSING, the validator learned that inference — delete the .fails
+    // modifier and fold the case into the exactness suites above.
+
+    // Specimen 1: joint entailment across two disjunctions. Any model
+    // violating a <x b must satisfy BOTH c <x d and d <x c — impossible —
+    // so a <x b is entailed jointly, and "b left of a" is impossible. The
+    // per-disjunction intersection strengthening cannot see this (each
+    // disjunction's alternatives share no common consequence).
+
+    it('joint-entailment ground truth: Z3 proves b can never be left of a', async () => {
+        const layout = parseConstraintSpec('[a <x b | c <x d], [a <x b | d <x c]');
+        expect(await solveZ3With(layout, [{ kind: 'properBefore', axis: 'x', a: 'b', b: 'a' }])).toBe(false);
+        // Soundness of what IS claimed still holds on this layout.
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: false, canExactAlignment: false })).toBe(true);
+    });
+
+    it.fails('joint entailment across two disjunctions is not captured (KNOWN INCOMPLETENESS)', async () => {
+        const layout = parseConstraintSpec('[a <x b | c <x d], [a <x b | d <x c]');
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getCannot('a', 'leftOf').has('b')).toBe(true);
+    });
+
+    // Specimen 2: disjunction-forced alignment impossibility. Every
+    // alternative of [a <x b | b <x a] separates a and b on x, so they can
+    // never be x-aligned — but cannot-aligned facts are derived only from
+    // the must graphs (strict orders + dual-axis overlap), not from
+    // disjunction intersection, so getCanAligned over-claims here.
+
+    it('disjunction-forced ground truth: Z3 proves a and b can never be x-aligned', async () => {
+        const layout = parseConstraintSpec('[a <x b | b <x a]');
+        expect(await solveZ3With(layout, [{ kind: 'coordEq', axis: 'x', a: 'a', b: 'b' }])).toBe(false);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: false })).toBe(true);
+    });
+
+    it.fails('disjunction-forced alignment impossibility is not captured (KNOWN INCOMPLETENESS)', async () => {
+        const layout = parseConstraintSpec('[a <x b | b <x a]');
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getCannotAligned('a', 'x').has('b')).toBe(true);
+    });
+});


### PR DESCRIPTION
## What

Step two of the correctness-anchored perf campaign (stacked on #517, whose entailment suite is the safety net for this change). Two changes, both semantics-preserving:

1. **Modal query state is built lazily.** `buildModalQueryState` (must/can/cannot precomputation) ran eagerly on every successful validation and dominated wall time — 78% of a 200-node chain's ~400ms. Its inputs (the must-graph snapshots taken before CDCL, and `this.allDisjunctions` after `solveCDCL`) are frozen once `validatePositionalConstraints` returns, so building on first query cannot change any answer. The consumers ([layout-evaluator](src/evaluators/layout/layout-evaluator.ts), [spytial-explorer](src/components/spytial-explorer/spytial-explorer.ts)) query interactively after render — and most renders never query at all. Failed validations keep the existing behavior (empty/reflexive sets).

2. **Alignment classes via iterative Tarjan SCC, O(V+E).** `getAlignmentClasses`/`getAlignmentClassOf` used a per-node nested BFS — O(V·(V+E)) — which cost `computeAlignmentOrders` 87ms on a 200-node chain *with zero alignments present*. In a consistent difference graph, mutual reachability is only possible through zero-weight cycles, so SCCs are exactly the alignment classes; one Tarjan pass replaces the quadratic scan. `collectAlignmentClasses` now derives all per-node sets from a single pass.

## Why it's safe

- The modal answers are entailment-verified: `tests/z3-modal-equivalence.test.ts` (from #517) triggers the lazy build through the public API and checks every claim against Z3 (`must P ⟺ UNSAT(model ∧ ¬P)`), with can-side exactness asserted on conjunctive systems.
- Tarjan output is normalized identically (sorted members, lexicographic representative, singletons omitted), so `topologicalSort`'s SCC-contraction fallback, `computeAlignmentOrders`, `detectNodeOverlaps`, and `classHasDualAxisOverlap` see byte-identical class structures.
- Full `npm run test:run` gate green; Z3 suites 58/58; validator/evaluator suites 272/272; no new typecheck errors.

## Benchmarks (Node 22, `benchmarks/validator-benchmark.bench.ts`)

| Scenario | main | after #517 | this PR |
|---|---|---|---|
| conjunctive chain N=200 | 374 ms | 387 ms | **2.7 ms** |
| independent 4-way disjunctions ×50 | 296 ms | 303 ms | **2.0 ms** |
| groups 5×5 + 25 free | 321 ms | 338 ms | **101 ms** |
| groups 10×5 + 50 free | 10.1 s | 10.1 s | **3.9 s** |
| chain + lateral disjunctions N=30 | 1.3 ms | 87 ms | **0.22 ms** |
| grid separation 4×4 | 68 ms | 69 ms | **3.0 ms** |

The #517 soundness fix's one regression (chain + lateral) is recovered 6× past the original baseline. UNSAT/error paths are unchanged. The remaining cost in the group scenarios is the `graphPropagate`/`isAlternativeFeasible` BFS loop (~600k calls at 10 groups) — that's the next step (reachability caching + dirty tracking), also to be validated against the oracle.

Note the trade: first modal query on a large layout now pays the build cost that used to be paid at render time. For the interactive REPL/explorer use cases this is strictly better (render latency drops; first-query latency was already interactive-scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)