### PR TITLE
fix(layout): claim-based edge undo; stop backtracking from corrupting the ordering graphs

### DIFF
--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -124,6 +124,18 @@ class DifferenceConstraintGraph {
     private edgeProvenance: Map<string, LayoutConstraint> = new Map();
     /** Reference count for alignment edge pairs (key: "a\x00b" with a < b lexicographically). */
     private alignmentRefCount: Map<string, number> = new Map();
+    /**
+     * Multiset of active claim weights per directed edge (key: "a\x00b").
+     * Every successful addEdge registers a claim — including the redundant
+     * path (an equal-or-tighter edge already exists) and the tightening path
+     * (which displaces a smaller weight). The stored edge weight is always the
+     * max of its claims. removeEdgeClaim releases one claim and restores the
+     * edge to the strongest remaining claim (or deletes it when none remain).
+     * Without this, undoing an assignment whose constraint duplicated an
+     * existing pair blindly deleted the shared edge — dropping a base
+     * constraint or another assigned alternative's edge from the graph.
+     */
+    private edgeClaims: Map<string, number[]> = new Map();
     private gap: number;
 
     /**
@@ -205,6 +217,7 @@ class DifferenceConstraintGraph {
         g.nodeSize = new Map(this.nodeSize);
         g.edgeProvenance = new Map(this.edgeProvenance);
         g.alignmentRefCount = new Map(this.alignmentRefCount);
+        for (const [k, ws] of this.edgeClaims) g.edgeClaims.set(k, [...ws]);
         g.hasZeroWeightOrderingEdge = this.hasZeroWeightOrderingEdge;
         // Fresh stamps (from the constructor) — the clone is a new object with
         // an empty memo and no cached verdicts keyed on it, so it must not
@@ -257,7 +270,10 @@ class DifferenceConstraintGraph {
         if (a === b) return false;
         const existing = this.adj.get(a)!.get(b);
         if (existing !== undefined && w <= existing) {
-            // Edge exists with equal or tighter weight — redundant, no change needed
+            // Edge exists with equal or tighter weight — no graph change, but
+            // the claim must be registered so a later removeEdgeClaim releases
+            // THIS add instead of deleting the edge someone else still needs.
+            this.registerClaim(a, b, w);
             return true;
         }
         // For new edges or tightening: check if a return path b→...→a exists.
@@ -300,8 +316,66 @@ class DifferenceConstraintGraph {
             this.adj.get(a)!.set(b, w);
             this.radj.get(b)!.set(a, w);
         }
+        this.registerClaim(a, b, w);
         if (constraint) this.edgeProvenance.set(DifferenceConstraintGraph.provenanceKey(a, b), constraint);
         return true;
+    }
+
+    private registerClaim(a: string, b: string, w: number): void {
+        const key = DifferenceConstraintGraph.provenanceKey(a, b);
+        const claims = this.edgeClaims.get(key);
+        if (claims) claims.push(w);
+        else this.edgeClaims.set(key, [w]);
+    }
+
+    /**
+     * Release one claim on edge a → b, mirroring an earlier addEdge with the
+     * same raw weight (the stored claim is `(weight ?? gap) + size(a)`, the
+     * same formula addEdge applies). The edge survives at the strongest
+     * remaining claim's weight; it is physically deleted only when the last
+     * claim is released. A missing claim is a no-op — that add never took
+     * effect (e.g. a cycle-rejected member edge of a BoundingBox alternative).
+     *
+     * This replaces the old blind removeEdge, which deleted unconditionally
+     * and thereby destroyed edges still required by a base constraint or
+     * another assigned alternative whenever an undone constraint duplicated
+     * their pair (validator reported SAT with a cyclic committed set —
+     * caught by the Z3 committed-set cross-check).
+     */
+    removeEdgeClaim(a: string, b: string, weight?: number): void {
+        const w = (weight ?? this.gap) + (this.nodeSize.get(a) ?? 0);
+        const key = DifferenceConstraintGraph.provenanceKey(a, b);
+        const claims = this.edgeClaims.get(key);
+        if (!claims) return;
+        const idx = claims.indexOf(w);
+        if (idx === -1) return;
+        claims.splice(idx, 1);
+
+        if (claims.length === 0) {
+            this.edgeClaims.delete(key);
+            if (this.adj.get(a)?.delete(b)) {
+                this.radj.get(b)?.delete(a);
+                this.removeVersion = nextGraphStamp++;
+                this.markDeltasUnknown();
+            }
+            this.edgeProvenance.delete(key);
+            return;
+        }
+
+        let newW = -Infinity;
+        for (const c of claims) { if (c > newW) newW = c; }
+        const cur = this.adj.get(a)?.get(b);
+        if (cur !== undefined && newW < cur) {
+            this.adj.get(a)!.set(b, newW);
+            this.radj.get(b)!.set(a, newW);
+            if (cur > 0 && newW <= 0) {
+                // Strict-orderedness may have shrunk — removal-like event for
+                // the reachability caches. (Positive→positive decreases change
+                // neither reachability nor strictness: no bump needed.)
+                this.removeVersion = nextGraphStamp++;
+                this.markDeltasUnknown();
+            }
+        }
     }
 
     /**
@@ -343,15 +417,6 @@ class DifferenceConstraintGraph {
                 }
             }
         }
-    }
-
-    removeEdge(a: string, b: string): void {
-        if (this.adj.get(a)?.delete(b)) {
-            this.radj.get(b)?.delete(a);
-            this.removeVersion = nextGraphStamp++;
-            this.markDeltasUnknown();
-        }
-        this.edgeProvenance.delete(DifferenceConstraintGraph.provenanceKey(a, b));
     }
 
     hasEdge(a: string, b: string): boolean {
@@ -2183,29 +2248,49 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         }
     }
 
+    /**
+     * Undo of addQualitativeEdge, releasing exactly the claims that add took
+     * (claim-based so shared edges survive — see removeEdgeClaim). The
+     * BoundingBox case mirrors the add's Rule C loop: the add creates the
+     * node↔group edge AND per-member edges, so the undo must release the
+     * member claims too — the old code removed only the group edge, leaving
+     * the member edges behind after backtracking (over-constrained graph).
+     */
     private removeQualitativeEdge(constraint: LayoutConstraint): void {
         if (isLeftConstraint(constraint)) {
-            this.hGraph.removeEdge(constraint.left.id, constraint.right.id);
+            this.hGraph.removeEdgeClaim(constraint.left.id, constraint.right.id, constraint.minDistance);
         } else if (isTopConstraint(constraint)) {
-            this.vGraph.removeEdge(constraint.top.id, constraint.bottom.id);
+            this.vGraph.removeEdgeClaim(constraint.top.id, constraint.bottom.id, constraint.minDistance);
         } else if (isBoundingBoxConstraint(constraint)) {
             const bc = constraint as BoundingBoxConstraint;
             const groupId = `_group_${bc.group.name}`;
             switch (bc.side) {
-                case 'left':   this.hGraph.removeEdge(bc.node.id, groupId); break;
-                case 'right':  this.hGraph.removeEdge(groupId, bc.node.id); break;
-                case 'top':    this.vGraph.removeEdge(bc.node.id, groupId); break;
-                case 'bottom': this.vGraph.removeEdge(groupId, bc.node.id); break;
+                case 'left':
+                    this.hGraph.removeEdgeClaim(bc.node.id, groupId, bc.minDistance);
+                    for (const mId of bc.group.nodeIds) this.hGraph.removeEdgeClaim(bc.node.id, mId, bc.minDistance);
+                    break;
+                case 'right':
+                    this.hGraph.removeEdgeClaim(groupId, bc.node.id, bc.minDistance);
+                    for (const mId of bc.group.nodeIds) this.hGraph.removeEdgeClaim(mId, bc.node.id, bc.minDistance);
+                    break;
+                case 'top':
+                    this.vGraph.removeEdgeClaim(bc.node.id, groupId, bc.minDistance);
+                    for (const mId of bc.group.nodeIds) this.vGraph.removeEdgeClaim(bc.node.id, mId, bc.minDistance);
+                    break;
+                case 'bottom':
+                    this.vGraph.removeEdgeClaim(groupId, bc.node.id, bc.minDistance);
+                    for (const mId of bc.group.nodeIds) this.vGraph.removeEdgeClaim(mId, bc.node.id, bc.minDistance);
+                    break;
             }
         } else if (isGroupBoundaryConstraint(constraint)) {
             const gc = constraint as GroupBoundaryConstraint;
             const gAId = `_group_${gc.groupA.name}`;
             const gBId = `_group_${gc.groupB.name}`;
             switch (gc.side) {
-                case 'left':   this.hGraph.removeEdge(gAId, gBId); break;
-                case 'right':  this.hGraph.removeEdge(gBId, gAId); break;
-                case 'top':    this.vGraph.removeEdge(gAId, gBId); break;
-                case 'bottom': this.vGraph.removeEdge(gBId, gAId); break;
+                case 'left':   this.hGraph.removeEdgeClaim(gAId, gBId, gc.minDistance); break;
+                case 'right':  this.hGraph.removeEdgeClaim(gBId, gAId, gc.minDistance); break;
+                case 'top':    this.vGraph.removeEdgeClaim(gAId, gBId, gc.minDistance); break;
+                case 'bottom': this.vGraph.removeEdgeClaim(gBId, gAId, gc.minDistance); break;
             }
         } else if (isAlignmentConstraint(constraint)) {
             const ac = constraint as AlignmentConstraint;

--- a/tests/edge-undo-integrity.test.ts
+++ b/tests/edge-undo-integrity.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression tests for edge undo integrity in QualitativeConstraintValidator.
+ *
+ * Two former asymmetries between addQualitativeEdge and removeQualitativeEdge
+ * could corrupt the ordering graphs during CDCL backtracking:
+ *
+ *  1. addEdge's redundant path (an equal-or-tighter edge already exists)
+ *     inserted nothing, and its tightening path overwrote the weight — but
+ *     removeEdge deleted unconditionally. Undoing an assignment whose
+ *     constraint duplicated an existing pair therefore destroyed an edge a
+ *     base constraint (or another assigned alternative) still required, after
+ *     which contradictory alternatives became addable: the validator could
+ *     answer SAT with a cyclic committed constraint set (see the minimal
+ *     divergence specimen below; found via Z3 fuzzing, validator=SAT while
+ *     Z3=UNSAT).
+ *
+ *  2. addQualitativeEdge(BoundingBox) added the node↔group edge AND the
+ *     per-member Rule C edges, but removeQualitativeEdge removed only the
+ *     group edge — member edges leaked after backtracking, leaving the graph
+ *     over-constrained.
+ *
+ * The fix makes every successful addEdge register a claim (multiset of
+ * weights per directed edge) and replaces blind removal with
+ * removeEdgeClaim, which releases one matching claim, keeps the edge at the
+ * strongest remaining claim, and deletes it only when the last claim goes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { QualitativeConstraintValidator } from '../src/layout/qualitative-constraint-validator';
+import {
+    DisjunctiveConstraint,
+    InstanceLayout,
+    LayoutConstraint,
+    LayoutGroup,
+    LayoutNode,
+} from '../src/layout/interfaces';
+import { RelativeOrientationConstraint, GroupByField } from '../src/layout/layoutspec';
+
+const SRC = new RelativeOrientationConstraint(['left'], 'undo-integrity');
+const GBF = new GroupByField('type', 0, 1, 'type');
+
+function node(id: string, width = 100, height = 60): LayoutNode {
+    return {
+        id, label: id, color: 'black', groups: [], attributes: {},
+        width, height, mostSpecificType: 'Node', types: ['Node'], showLabels: true,
+    };
+}
+
+function leftOf(a: LayoutNode, b: LayoutNode, minDistance: number): LayoutConstraint {
+    return { left: a, right: b, minDistance, sourceConstraint: SRC };
+}
+
+/** Validator with private access for driving assign/undo paths directly. */
+function rig(layout: InstanceLayout): any {
+    return new QualitativeConstraintValidator(layout) as any;
+}
+
+describe('Edge undo integrity (claim-based add/remove)', () => {
+
+    describe('duplicate-pair constraints', () => {
+
+        it('undoing a redundant duplicate preserves the base edge and weight', () => {
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [leftOf(A, B, 15)], groups: [] });
+            expect(v.validateConstraints()).toBeNull();
+            const w = v.hGraph.getEdgeWeight('A', 'B'); // 15 + width(A) = 115
+
+            const dup = leftOf(A, B, 10); // strictly looser → redundant add path
+            expect(v.addQualitativeEdge(dup)).toBe(true);
+            v.removeQualitativeEdge(dup);
+
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(true);
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(w);
+        });
+
+        it('undoing a tightening duplicate restores the displaced weight', () => {
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [leftOf(A, B, 15)], groups: [] });
+            expect(v.validateConstraints()).toBeNull();
+            const w = v.hGraph.getEdgeWeight('A', 'B');
+
+            const tighter = leftOf(A, B, 500);
+            expect(v.addQualitativeEdge(tighter)).toBe(true);
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(500 + A.width);
+            v.removeQualitativeEdge(tighter);
+
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(true);
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(w);
+        });
+
+        it('non-LIFO release keeps the strongest remaining claim', () => {
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [leftOf(A, B, 15)], groups: [] });
+            expect(v.validateConstraints()).toBeNull();
+            const base = v.hGraph.getEdgeWeight('A', 'B'); // 115
+
+            const tighter = leftOf(A, B, 500);
+            const looser = leftOf(A, B, 10);
+            v.addQualitativeEdge(tighter); // weight → 600
+            v.addQualitativeEdge(looser);  // redundant claim (110)
+            v.removeQualitativeEdge(tighter); // release out of add order
+
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(base); // max(115, 110)
+            v.removeQualitativeEdge(looser);
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(base);
+        });
+    });
+
+    describe('BoundingBox alternatives', () => {
+
+        const bboxLeft = (x: LayoutNode, group: LayoutGroup): LayoutConstraint =>
+            ({ node: x, group, side: 'left', minDistance: 15, sourceConstraint: GBF } as any);
+
+        it('undo releases the group edge AND the Rule C member edges', () => {
+            const M1 = node('M1'), M2 = node('M2'), X = node('X');
+            const group: LayoutGroup = { name: 'G', nodeIds: ['M1', 'M2'], keyNodeId: 'M1', showLabel: true, sourceConstraint: GBF };
+            // No validateConstraints: its own solving would add claims of its own.
+            const v = rig({ nodes: [M1, M2, X], edges: [], constraints: [], groups: [group] });
+
+            const bbox = bboxLeft(X, group);
+            expect(v.addQualitativeEdge(bbox)).toBe(true);
+            expect(v.hGraph.hasEdge('X', '_group_G')).toBe(true);
+            expect(v.hGraph.hasEdge('X', 'M1')).toBe(true);
+            expect(v.hGraph.hasEdge('X', 'M2')).toBe(true);
+
+            v.removeQualitativeEdge(bbox);
+            expect(v.hGraph.hasEdge('X', '_group_G')).toBe(false);
+            expect(v.hGraph.hasEdge('X', 'M1')).toBe(false);
+            expect(v.hGraph.hasEdge('X', 'M2')).toBe(false);
+        });
+
+        it('undo leaves a member edge intact while another constraint claims it', () => {
+            const M1 = node('M1'), M2 = node('M2'), X = node('X');
+            const group: LayoutGroup = { name: 'G', nodeIds: ['M1', 'M2'], keyNodeId: 'M1', showLabel: true, sourceConstraint: GBF };
+            const v = rig({ nodes: [M1, M2, X], edges: [], constraints: [], groups: [group] });
+
+            const ordering = leftOf(X, M1, 15);
+            const bbox = bboxLeft(X, group);
+            expect(v.addQualitativeEdge(ordering)).toBe(true);
+            expect(v.addQualitativeEdge(bbox)).toBe(true);
+
+            v.removeQualitativeEdge(bbox);
+            expect(v.hGraph.hasEdge('X', 'M1')).toBe(true); // ordering's claim survives
+            expect(v.hGraph.hasEdge('X', 'M2')).toBe(false);
+
+            v.removeQualitativeEdge(ordering);
+            expect(v.hGraph.hasEdge('X', 'M1')).toBe(false);
+        });
+    });
+
+    describe('end-to-end soundness', () => {
+
+        it('minimal divergence specimen: duplicate + cycle-closer alternative is UNSAT and leaves the base edge intact', () => {
+            // Base: N0 <x N3. Both alternatives contain N3 <x N0, so the
+            // instance is UNSAT. Pre-fix trajectory: pickBranch tries a0 (same
+            // length as a1); its duplicate add was redundant (no insert), its
+            // closer failed on the base cycle, and undoAlternativeEdges then
+            // deleted the BASE edge — letting a1's closer succeed and the
+            // validator answer SAT with the cyclic committed set
+            // {N0 <x N3, N3 <x N0}. Found by Z3 differential fuzzing.
+            const N0 = node('N0', 52, 89), N3 = node('N3', 89, 85);
+            const N1 = node('N1', 60, 40), N2 = node('N2', 60, 40);
+            const layout: InstanceLayout = {
+                nodes: [N0, N1, N2, N3], edges: [],
+                constraints: [leftOf(N0, N3, 20)],
+                groups: [],
+                disjunctiveConstraints: [
+                    new DisjunctiveConstraint(SRC, [
+                        [leftOf(N0, N3, 13), leftOf(N3, N0, 5)],
+                        [leftOf(N3, N0, 5), leftOf(N1, N2, 5)],
+                    ]),
+                ],
+            };
+            const v = rig(layout);
+            const error = v.validateConstraints();
+            expect(error).not.toBeNull();
+            expect(v.hGraph.hasEdge('N0', 'N3')).toBe(true);
+            // The committed set must not contain both directions of a pair.
+            const committed = layout.constraints.filter((c: any) => c.left).map((c: any) => `${c.left.id}->${c.right.id}`);
+            for (const dir of committed) {
+                const [a, b] = dir.split('->');
+                expect(committed).not.toContain(`${b}->${a}`);
+            }
+        });
+    });
+});

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -36,6 +36,7 @@ import {
     aboveOf,
     alignOnX,
     alignOnY,
+    makeNode,
     parseConstraintSpec,
     SRC,
 } from './helpers/constraint-dsl';
@@ -52,7 +53,7 @@ import {
     arbMixedOrdering,
     arbGroup,
 } from './helpers/constraint-arbitraries';
-import type { LayoutGroup } from '../src/layout/interfaces';
+import type { LayoutGroup, LayoutNode } from '../src/layout/interfaces';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -304,6 +305,76 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
                         }
                     }
                     const layout = buildLayout(nodes, [], disjs);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: 30, timeout: TIMEOUT });
+        });
+
+        // ── Duplicate-pair alternatives (edge undo integrity) ──────────
+        // Alternatives that DUPLICATE a base constraint's pair (with an equal
+        // or smaller distance) exercise addEdge's redundant path; combined
+        // with a cycle-closing reversal in the same alternative, the undo of
+        // the failed tryAssign used to blind-delete the shared base edge,
+        // corrupting the graph mid-search (SAT verdicts with cyclic committed
+        // sets). The plain generators above never emit duplicate pairs, which
+        // is how this survived them.
+
+        it('duplicate + cycle-closer alternative deletes no base edge — UNSAT (Z3 cross-check)', async () => {
+            const N0 = makeNode('N0', 52, 89), N3 = makeNode('N3', 89, 85);
+            const N1 = makeNode('N1', 60, 40), N2 = makeNode('N2', 60, 40);
+            const dup = (a: LayoutNode, b: LayoutNode, d: number): LayoutConstraint =>
+                ({ left: a, right: b, minDistance: d, sourceConstraint: SRC });
+            const layout = buildLayout(
+                [N0, N1, N2, N3],
+                [dup(N0, N3, 20)],
+                [new DisjunctiveConstraint(SRC, [
+                    [dup(N0, N3, 13), dup(N3, N0, 5)],
+                    [dup(N3, N0, 5), dup(N1, N2, 5)],
+                ])],
+            );
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(false);
+        });
+
+        it('random duplicate-pair and reversed-pair alternatives (Z3 cross-check)', async () => {
+            const dupOf = (c: LayoutConstraint, delta: number): LayoutConstraint => {
+                const anyC = c as any;
+                return anyC.left
+                    ? { left: anyC.left, right: anyC.right, minDistance: Math.max(0, anyC.minDistance - delta), sourceConstraint: SRC }
+                    : { top: anyC.top, bottom: anyC.bottom, minDistance: Math.max(0, anyC.minDistance - delta), sourceConstraint: SRC };
+            };
+            const revOf = (c: LayoutConstraint, d: number): LayoutConstraint => {
+                const anyC = c as any;
+                return anyC.left
+                    ? { left: anyC.right, right: anyC.left, minDistance: d, sourceConstraint: SRC }
+                    : { top: anyC.bottom, bottom: anyC.top, minDistance: d, sourceConstraint: SRC };
+            };
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(4).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 1, maxLength: 2 }),
+                        fc.array(fc.record({
+                            baseIdx: fc.nat(3),
+                            dupDelta: fc.nat(15),
+                            revDist: fc.nat(20),
+                            benign: arbOrdering(nodes),
+                            benignOnlySecond: fc.boolean(),
+                        }), { minLength: 1, maxLength: 3 }),
+                    )
+                ),
+                async ([nodes, base, specs]) => {
+                    const disjs = specs.map(spec => {
+                        const target = base[spec.baseIdx % base.length];
+                        const altA = [dupOf(target, spec.dupDelta), revOf(target, spec.revDist)];
+                        const altB = spec.benignOnlySecond
+                            ? [spec.benign, dupOf(target, spec.dupDelta)]
+                            : [revOf(target, spec.revDist), spec.benign];
+                        return new DisjunctiveConstraint(SRC, [altA, altB]);
+                    });
+                    const layout = buildLayout(nodes, base, disjs);
                     const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
                     assertAgreement(layout, validatorSat, oracleSat);
                 }


### PR DESCRIPTION
Stacked on [#519](https://github.com/sidprasad/spytial-core/pull/519) (targets `perf/propagate-reachability-cache`; retarget to `dev-validator` once #519 merges).

Fixes two **pre-existing** asymmetries between `addQualitativeEdge` and `removeQualitativeEdge` that let CDCL backtracking leave the ordering graphs in a state different from before the assignment. Both were spotted by inspection during #519; **one is a confirmed soundness bug** — Z3 differential fuzzing over duplicate-pair shapes produced a validator=SAT / Z3=UNSAT divergence at seed 64.

## Bug 1 — blind `removeEdge` destroys shared edges (soundness)

`addEdge(a, b, w)` returns `true` **without inserting** when an equal-or-tighter `a→b` already exists, and overwrites the weight when tightening. `removeEdge(a, b)` deleted unconditionally. So undoing an assignment whose constraint duplicated an existing pair destroyed an edge a base constraint — or another assigned alternative — still required.

Minimal specimen (now a regression test):

```
base:         N0 <x N3 (d=20)
disjunction:  [N0 <x N3 (d=13), N3 <x N0 (d=5)]   ← duplicate + cycle-closer
           |  [N3 <x N0 (d=5),  N1 <x N2 (d=5)]
```

Ground truth is UNSAT (both alternatives close a cycle with the base). Pre-fix: `pickBranch` tries the first alternative, its duplicate add takes the redundant path (no insert), its cycle-closer fails, and `undoAlternativeEdges` deletes the **base** edge — after which the second alternative's closer succeeds and the validator answers **SAT** with the cyclic committed set `{N0 <x N3, N3 <x N0}`.

## Bug 2 — BoundingBox member edges leak on undo

`addQualitativeEdge(BoundingBox)` adds the `node↔_group_` edge **and** the per-member Rule C containment edges; `removeQualitativeEdge` removed only the group edge. Member edges survived backtracking, leaving the graph over-constrained (spurious UNSAT / wrongly pruned alternatives). No SAT-side divergence found for this one, but the leak is directly demonstrable.

## Fix

Reference-counted edges, modeled on the existing `alignmentRefCount`:
- Every successful `addEdge` registers a **claim** (a multiset of weights per directed edge) — including the redundant path and the tightening path.
- `removeEdgeClaim(a, b, weight)` releases one matching claim, restores the edge to the **strongest remaining claim's** weight, and physically deletes it only when the last claim is released. A missing claim is a no-op (that add never took effect, e.g. a cycle-rejected member edge).
- The BoundingBox undo now mirrors its add and releases the member claims too.

Non-LIFO release is handled (release order need not match add order), and `clone()` deep-copies claims so checkpoint/restore stays consistent.

## Verification
- **New `tests/edge-undo-integrity.test.ts`** (6 tests): redundant-duplicate undo preserves base weight; tightening undo restores the displaced weight; non-LIFO release keeps the strongest claim; bbox undo releases group + member edges; bbox undo leaves a member edge held by another constraint intact; the end-to-end specimen is UNSAT with the base edge intact and no committed pair in both directions.
- **Two new `z3-equivalence` cases**: the deterministic specimen, plus a generator emitting duplicate-pair and reversed-pair alternatives. The existing arbitraries never emit duplicate pairs — that's precisely why this survived them.
- All **52 Z3 oracle tests** pass (run in chunks; the host kills long-lived 2 GiB WASM processes under memory pressure).
- Full gate: **2000 tests**, 0 failures.
- **400-seed × 2-shape Z3 fuzz sweep: 0 divergences** (diverged at seed 64 before the fix).

## Cost
Claim bookkeeping adds ~6% on the 10-group benchmark (73 ms → 78 ms), against #519's 49× improvement on the same scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)