### PR TITLE
[Constraint Validator Refactor] Perf and Correctness improvements by comparing against an oracle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spytial-core",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spytial-core",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spytial-core",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "A fully client-side application for SpyTial.",
   "main": "./dist/browser/spytial-core-complete.global.js",
   "types": "./dist/types/index.d.ts",

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -991,6 +991,8 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     /** Conjunctive-only graph snapshots (before CDCL disjunction resolution). */
     private mustHGraph: DifferenceConstraintGraph | null = null;
     private mustVGraph: DifferenceConstraintGraph | null = null;
+    /** Set only when validatePositionalConstraints completes without error. */
+    private validationSucceeded = false;
     /** Precomputed must-ordering pairs: "A\x00B" means A is strictly before B. */
     private mustHPairs: Set<string> | null = null;
     private mustVPairs: Set<string> | null = null;
@@ -1095,6 +1097,12 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         if (overlapError) return this.enforceMaximalFeasibleSubset(overlapError);
 
         this.layout.constraints = this.layout.constraints.concat(implicitConstraints);
+        // Only now may modal queries build their state: every error path above
+        // routes through enforceMaximalFeasibleSubset, which REPLACES
+        // layout.constraints with the feasible subset — so the must-graph
+        // snapshots taken at Phase 4b would describe a constraint system the
+        // layout no longer has. See ensureModalQueryState.
+        this.validationSucceeded = true;
         return null;
     }
 
@@ -1110,6 +1118,17 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         if (error.maximalFeasibleSubset) {
             this.layout.constraints = error.maximalFeasibleSubset;
         }
+        // Every error return in validatePositionalConstraints funnels through
+        // here, so this is the one place that has to drop the modal must-graph
+        // snapshots. They are taken at Phase 4b (before CDCL), so a later
+        // failure would otherwise leave them describing a constraint system
+        // this method just replaced on the layout — and getCannot /
+        // getCannotAligned read those graphs DIRECTLY (not the lazily-built
+        // pair sets), so gating the lazy build alone would not stop them
+        // answering. Clearing here makes every reader fall back to its
+        // empty/reflexive default via the null checks they already have.
+        this.mustHGraph = null;
+        this.mustVGraph = null;
         return error;
     }
 
@@ -3731,14 +3750,26 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * Build modal state on first use. Safe to defer past validation because
      * buildModalQueryState reads only the must-graph snapshots (taken before
      * CDCL) and this.allDisjunctions (final after solveCDCL) — neither
-     * changes after validatePositionalConstraints returns. If validation
-     * failed (or never ran), the snapshots are null and modal queries keep
-     * their pre-existing behavior of returning empty/reflexive sets.
+     * changes after validatePositionalConstraints returns.
+     *
+     * Gated on validationSucceeded, NOT merely on the snapshots being present:
+     * they are taken at Phase 4b, before CDCL, so a later failure (CDCL UNSAT,
+     * node overlap) would otherwise leave them populated for a rejected layout
+     * and this deferred build would answer must/cannot queries about a
+     * constraint system enforceMaximalFeasibleSubset already replaced. When
+     * the eager build lived at Phase 5b it simply never ran on the CDCL-UNSAT
+     * path; this restores that, and extends it to the overlap path.
+     *
+     * enforceMaximalFeasibleSubset also nulls the snapshots, which is what
+     * covers the getters that read the must-graphs directly. This flag is the
+     * belt to that braces: it keeps the build correct even for a future error
+     * path that forgets to route through there.
      */
     private modalStateBuilt = false;
 
     private ensureModalQueryState(): void {
-        if (this.modalStateBuilt || !this.mustHGraph || !this.mustVGraph) return;
+        if (this.modalStateBuilt || !this.validationSucceeded) return;
+        if (!this.mustHGraph || !this.mustVGraph) return;
         this.modalStateBuilt = true;
         this.buildModalQueryState();
     }

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -432,71 +432,90 @@ class DifferenceConstraintGraph {
     }
 
     /**
+     * All strongly connected components of the graph (any-weight edges).
+     * In a consistent graph, mutual reachability is only possible through
+     * zero-weight alignment cycles (positive-weight cycles are rejected at
+     * insertion), so SCCs are exactly the alignment classes.
+     *
+     * Iterative Tarjan, O(V + E) — replaces the old per-node nested-BFS
+     * approach, which was O(V·(V+E)) and dominated computeAlignmentOrders
+     * (87ms of a 200-node chain's validation, with zero alignments present).
+     */
+    private tarjanSCCs(): string[][] {
+        const index = new Map<string, number>();
+        const lowlink = new Map<string, number>();
+        const onStack = new Set<string>();
+        const stack: string[] = [];
+        const components: string[][] = [];
+        let next = 0;
+
+        interface Frame { node: string; succs: string[]; i: number }
+
+        for (const root of this.nodes) {
+            if (index.has(root)) continue;
+            const frames: Frame[] = [];
+            const open = (n: string): void => {
+                index.set(n, next);
+                lowlink.set(n, next);
+                next++;
+                stack.push(n);
+                onStack.add(n);
+                frames.push({ node: n, succs: [...(this.adj.get(n)?.keys() ?? [])], i: 0 });
+            };
+            open(root);
+            while (frames.length > 0) {
+                const f = frames[frames.length - 1];
+                if (f.i < f.succs.length) {
+                    const s = f.succs[f.i++];
+                    if (!index.has(s)) {
+                        open(s);
+                    } else if (onStack.has(s)) {
+                        lowlink.set(f.node, Math.min(lowlink.get(f.node)!, index.get(s)!));
+                    }
+                } else {
+                    frames.pop();
+                    if (lowlink.get(f.node) === index.get(f.node)) {
+                        const comp: string[] = [];
+                        let m: string;
+                        do {
+                            m = stack.pop()!;
+                            onStack.delete(m);
+                            comp.push(m);
+                        } while (m !== f.node);
+                        components.push(comp);
+                    }
+                    const parent = frames[frames.length - 1];
+                    if (parent) {
+                        lowlink.set(parent.node, Math.min(lowlink.get(parent.node)!, lowlink.get(f.node)!));
+                    }
+                }
+            }
+        }
+        return components;
+    }
+
+    /**
      * Get alignment classes: groups of nodes connected by mutual zero-weight paths.
      * Returns a map from canonical representative to list of class members.
      * Classes with only one member are omitted.
      */
     getAlignmentClasses(): Map<string, string[]> {
-        // Find SCCs using Tarjan's or simpler approach: for each node, find its
-        // SCC by checking mutual reachability. For small graphs, nested BFS is fine.
         const classes = new Map<string, string[]>();
-        const assigned = new Set<string>();
-
-        for (const node of this.nodes) {
-            if (assigned.has(node)) continue;
-
-            // Find all nodes mutually reachable from this node (same SCC)
-            const forwardReachable = this.reachableSet(node);
-            const classMembers: string[] = [];
-
-            for (const candidate of forwardReachable) {
-                if (this.canReach(candidate, node)) {
-                    classMembers.push(candidate);
-                }
-            }
-
-            if (classMembers.length > 1) {
-                classMembers.sort(); // deterministic
-                const representative = classMembers[0];
-                classes.set(representative, classMembers);
-                for (const m of classMembers) assigned.add(m);
-            } else {
-                assigned.add(node);
+        for (const comp of this.tarjanSCCs()) {
+            if (comp.length > 1) {
+                comp.sort(); // deterministic
+                classes.set(comp[0], comp);
             }
         }
-
         return classes;
     }
 
     /** Get the alignment class (SCC) containing the given node. */
     getAlignmentClassOf(nodeId: string): string[] {
-        const forward = this.reachableSet(nodeId);
-        const members: string[] = [];
-        for (const candidate of forward) {
-            if (this.canReach(candidate, nodeId)) {
-                members.push(candidate);
-            }
+        for (const comp of this.tarjanSCCs()) {
+            if (comp.includes(nodeId)) return comp;
         }
-        return members;
-    }
-
-    /** Get all nodes reachable from `start` via any edges. */
-    private reachableSet(start: string): Set<string> {
-        const visited = new Set<string>();
-        const queue: string[] = [start];
-        visited.add(start);
-        while (queue.length > 0) {
-            const cur = queue.shift()!;
-            const succs = this.adj.get(cur);
-            if (!succs) continue;
-            for (const s of succs.keys()) {
-                if (!visited.has(s)) {
-                    visited.add(s);
-                    queue.push(s);
-                }
-            }
-        }
-        return visited;
+        return [nodeId];
     }
 
     /**
@@ -727,8 +746,13 @@ class QualitativeConstraintValidator implements IConstraintValidator {
             this.layout.constraints = this.layout.constraints.concat(chosenConstraints);
         }
 
-        // Phase 5b: Build modal query state (must/can/cannot)
-        this.buildModalQueryState();
+        // Phase 5b: Modal query state (must/can/cannot) is built LAZILY on the
+        // first modal query (ensureModalQueryState). It is pure post-solve
+        // analysis over the must-graph snapshots and this.allDisjunctions —
+        // both frozen from here on — and profiling showed it dominating
+        // validation wall time (e.g. 78% on a 200-node conjunctive chain)
+        // while its only consumers (layout-evaluator, spytial-explorer) query
+        // interactively after render, and often never.
 
         // Phase 6: Alignment orders
         const implicitConstraints = this.computeAlignmentOrders();
@@ -3073,12 +3097,28 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     // ─── Modal query computation ────────────────────────────────────────────
 
     /**
+     * Build modal state on first use. Safe to defer past validation because
+     * buildModalQueryState reads only the must-graph snapshots (taken before
+     * CDCL) and this.allDisjunctions (final after solveCDCL) — neither
+     * changes after validatePositionalConstraints returns. If validation
+     * failed (or never ran), the snapshots are null and modal queries keep
+     * their pre-existing behavior of returning empty/reflexive sets.
+     */
+    private modalStateBuilt = false;
+
+    private ensureModalQueryState(): void {
+        if (this.modalStateBuilt || !this.mustHGraph || !this.mustVGraph) return;
+        this.modalStateBuilt = true;
+        this.buildModalQueryState();
+    }
+
+    /**
      * Build the precomputed must-ordering pairs by:
      * 1. Starting with the conjunctive base (post-presolve snapshot)
      * 2. Strengthening via disjunction intersection: for each remaining disjunction,
      *    compute which orderings ALL alternatives agree on
      *
-     * Called once after successful validation (feasible layout).
+     * Called once, lazily, via ensureModalQueryState.
      */
     private buildModalQueryState(): void {
         if (!this.mustHGraph || !this.mustVGraph) return;
@@ -3115,17 +3155,20 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         return pairs;
     }
 
-    /** Collect alignment equivalence classes from a graph. */
+    /** Collect alignment equivalence classes from a graph (one SCC pass). */
     private collectAlignmentClasses(graph: DifferenceConstraintGraph, nodeIds: string[]): Map<string, Set<string>> {
         const classes = new Map<string, Set<string>>();
         const realSet = new Set(nodeIds);
-        for (const id of nodeIds) {
-            const members = graph.getAlignmentClassOf(id);
-            const filtered = new Set<string>();
-            for (const m of members) {
-                if (m !== id && realSet.has(m)) filtered.add(m);
+        for (const id of nodeIds) classes.set(id, new Set());
+        for (const [, members] of graph.getAlignmentClasses()) {
+            const real = members.filter(m => realSet.has(m));
+            for (const m of real) {
+                const set = classes.get(m);
+                if (!set) continue;
+                for (const other of real) {
+                    if (other !== m) set.add(other);
+                }
             }
-            classes.set(id, filtered);
         }
         return classes;
     }
@@ -3278,6 +3321,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * Derived from conjunctive entailment + disjunction intersection.
      */
     public getMust(nodeId: string, relation: 'leftOf' | 'rightOf' | 'above' | 'below'): Set<string> {
+        this.ensureModalQueryState();
         const realNodeIds = new Set(this.nodes.map(n => n.id));
         const result = new Set<string>();
         if (!this.mustHPairs || !this.mustVPairs) return result;
@@ -3307,6 +3351,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * because it also catches infeasibility via zero-weight path chains.
      */
     public getCannot(nodeId: string, relation: 'leftOf' | 'rightOf' | 'above' | 'below'): Set<string> {
+        this.ensureModalQueryState();
         const result = new Set<string>();
         result.add(nodeId); // reflexive exclusion
 
@@ -3353,6 +3398,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
 
     /** Alignment equivalence class — nodes that MUST be aligned with nodeId. */
     public getMustAligned(nodeId: string, axis: 'x' | 'y'): Set<string> {
+        this.ensureModalQueryState();
         const classes = axis === 'x' ? this.mustHAlignmentClasses : this.mustVAlignmentClasses;
         return classes?.get(nodeId) ?? new Set();
     }
@@ -3373,6 +3419,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      *    e.g. "A =x B" alone would report that A and B can also be y-aligned.
      */
     public getCannotAligned(nodeId: string, axis: 'x' | 'y'): Set<string> {
+        this.ensureModalQueryState();
         const result = new Set<string>();
         result.add(nodeId); // X is not "aligned with itself" in the query sense
         const graph = axis === 'x' ? this.mustHGraph : this.mustVGraph;

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -124,6 +124,18 @@ class DifferenceConstraintGraph {
     private edgeProvenance: Map<string, LayoutConstraint> = new Map();
     /** Reference count for alignment edge pairs (key: "a\x00b" with a < b lexicographically). */
     private alignmentRefCount: Map<string, number> = new Map();
+    /**
+     * Multiset of active claim weights per directed edge (key: "a\x00b").
+     * Every successful addEdge registers a claim — including the redundant
+     * path (an equal-or-tighter edge already exists) and the tightening path
+     * (which displaces a smaller weight). The stored edge weight is always the
+     * max of its claims. removeEdgeClaim releases one claim and restores the
+     * edge to the strongest remaining claim (or deletes it when none remain).
+     * Without this, undoing an assignment whose constraint duplicated an
+     * existing pair blindly deleted the shared edge — dropping a base
+     * constraint or another assigned alternative's edge from the graph.
+     */
+    private edgeClaims: Map<string, number[]> = new Map();
     private gap: number;
 
     /**
@@ -205,6 +217,7 @@ class DifferenceConstraintGraph {
         g.nodeSize = new Map(this.nodeSize);
         g.edgeProvenance = new Map(this.edgeProvenance);
         g.alignmentRefCount = new Map(this.alignmentRefCount);
+        for (const [k, ws] of this.edgeClaims) g.edgeClaims.set(k, [...ws]);
         g.hasZeroWeightOrderingEdge = this.hasZeroWeightOrderingEdge;
         // Fresh stamps (from the constructor) — the clone is a new object with
         // an empty memo and no cached verdicts keyed on it, so it must not
@@ -257,7 +270,10 @@ class DifferenceConstraintGraph {
         if (a === b) return false;
         const existing = this.adj.get(a)!.get(b);
         if (existing !== undefined && w <= existing) {
-            // Edge exists with equal or tighter weight — redundant, no change needed
+            // Edge exists with equal or tighter weight — no graph change, but
+            // the claim must be registered so a later removeEdgeClaim releases
+            // THIS add instead of deleting the edge someone else still needs.
+            this.registerClaim(a, b, w);
             return true;
         }
         // For new edges or tightening: check if a return path b→...→a exists.
@@ -300,8 +316,66 @@ class DifferenceConstraintGraph {
             this.adj.get(a)!.set(b, w);
             this.radj.get(b)!.set(a, w);
         }
+        this.registerClaim(a, b, w);
         if (constraint) this.edgeProvenance.set(DifferenceConstraintGraph.provenanceKey(a, b), constraint);
         return true;
+    }
+
+    private registerClaim(a: string, b: string, w: number): void {
+        const key = DifferenceConstraintGraph.provenanceKey(a, b);
+        const claims = this.edgeClaims.get(key);
+        if (claims) claims.push(w);
+        else this.edgeClaims.set(key, [w]);
+    }
+
+    /**
+     * Release one claim on edge a → b, mirroring an earlier addEdge with the
+     * same raw weight (the stored claim is `(weight ?? gap) + size(a)`, the
+     * same formula addEdge applies). The edge survives at the strongest
+     * remaining claim's weight; it is physically deleted only when the last
+     * claim is released. A missing claim is a no-op — that add never took
+     * effect (e.g. a cycle-rejected member edge of a BoundingBox alternative).
+     *
+     * This replaces the old blind removeEdge, which deleted unconditionally
+     * and thereby destroyed edges still required by a base constraint or
+     * another assigned alternative whenever an undone constraint duplicated
+     * their pair (validator reported SAT with a cyclic committed set —
+     * caught by the Z3 committed-set cross-check).
+     */
+    removeEdgeClaim(a: string, b: string, weight?: number): void {
+        const w = (weight ?? this.gap) + (this.nodeSize.get(a) ?? 0);
+        const key = DifferenceConstraintGraph.provenanceKey(a, b);
+        const claims = this.edgeClaims.get(key);
+        if (!claims) return;
+        const idx = claims.indexOf(w);
+        if (idx === -1) return;
+        claims.splice(idx, 1);
+
+        if (claims.length === 0) {
+            this.edgeClaims.delete(key);
+            if (this.adj.get(a)?.delete(b)) {
+                this.radj.get(b)?.delete(a);
+                this.removeVersion = nextGraphStamp++;
+                this.markDeltasUnknown();
+            }
+            this.edgeProvenance.delete(key);
+            return;
+        }
+
+        let newW = -Infinity;
+        for (const c of claims) { if (c > newW) newW = c; }
+        const cur = this.adj.get(a)?.get(b);
+        if (cur !== undefined && newW < cur) {
+            this.adj.get(a)!.set(b, newW);
+            this.radj.get(b)!.set(a, newW);
+            if (cur > 0 && newW <= 0) {
+                // Strict-orderedness may have shrunk — removal-like event for
+                // the reachability caches. (Positive→positive decreases change
+                // neither reachability nor strictness: no bump needed.)
+                this.removeVersion = nextGraphStamp++;
+                this.markDeltasUnknown();
+            }
+        }
     }
 
     /**
@@ -343,15 +417,6 @@ class DifferenceConstraintGraph {
                 }
             }
         }
-    }
-
-    removeEdge(a: string, b: string): void {
-        if (this.adj.get(a)?.delete(b)) {
-            this.radj.get(b)?.delete(a);
-            this.removeVersion = nextGraphStamp++;
-            this.markDeltasUnknown();
-        }
-        this.edgeProvenance.delete(DifferenceConstraintGraph.provenanceKey(a, b));
     }
 
     hasEdge(a: string, b: string): boolean {
@@ -2183,29 +2248,49 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         }
     }
 
+    /**
+     * Undo of addQualitativeEdge, releasing exactly the claims that add took
+     * (claim-based so shared edges survive — see removeEdgeClaim). The
+     * BoundingBox case mirrors the add's Rule C loop: the add creates the
+     * node↔group edge AND per-member edges, so the undo must release the
+     * member claims too — the old code removed only the group edge, leaving
+     * the member edges behind after backtracking (over-constrained graph).
+     */
     private removeQualitativeEdge(constraint: LayoutConstraint): void {
         if (isLeftConstraint(constraint)) {
-            this.hGraph.removeEdge(constraint.left.id, constraint.right.id);
+            this.hGraph.removeEdgeClaim(constraint.left.id, constraint.right.id, constraint.minDistance);
         } else if (isTopConstraint(constraint)) {
-            this.vGraph.removeEdge(constraint.top.id, constraint.bottom.id);
+            this.vGraph.removeEdgeClaim(constraint.top.id, constraint.bottom.id, constraint.minDistance);
         } else if (isBoundingBoxConstraint(constraint)) {
             const bc = constraint as BoundingBoxConstraint;
             const groupId = `_group_${bc.group.name}`;
             switch (bc.side) {
-                case 'left':   this.hGraph.removeEdge(bc.node.id, groupId); break;
-                case 'right':  this.hGraph.removeEdge(groupId, bc.node.id); break;
-                case 'top':    this.vGraph.removeEdge(bc.node.id, groupId); break;
-                case 'bottom': this.vGraph.removeEdge(groupId, bc.node.id); break;
+                case 'left':
+                    this.hGraph.removeEdgeClaim(bc.node.id, groupId, bc.minDistance);
+                    for (const mId of bc.group.nodeIds) this.hGraph.removeEdgeClaim(bc.node.id, mId, bc.minDistance);
+                    break;
+                case 'right':
+                    this.hGraph.removeEdgeClaim(groupId, bc.node.id, bc.minDistance);
+                    for (const mId of bc.group.nodeIds) this.hGraph.removeEdgeClaim(mId, bc.node.id, bc.minDistance);
+                    break;
+                case 'top':
+                    this.vGraph.removeEdgeClaim(bc.node.id, groupId, bc.minDistance);
+                    for (const mId of bc.group.nodeIds) this.vGraph.removeEdgeClaim(bc.node.id, mId, bc.minDistance);
+                    break;
+                case 'bottom':
+                    this.vGraph.removeEdgeClaim(groupId, bc.node.id, bc.minDistance);
+                    for (const mId of bc.group.nodeIds) this.vGraph.removeEdgeClaim(mId, bc.node.id, bc.minDistance);
+                    break;
             }
         } else if (isGroupBoundaryConstraint(constraint)) {
             const gc = constraint as GroupBoundaryConstraint;
             const gAId = `_group_${gc.groupA.name}`;
             const gBId = `_group_${gc.groupB.name}`;
             switch (gc.side) {
-                case 'left':   this.hGraph.removeEdge(gAId, gBId); break;
-                case 'right':  this.hGraph.removeEdge(gBId, gAId); break;
-                case 'top':    this.vGraph.removeEdge(gAId, gBId); break;
-                case 'bottom': this.vGraph.removeEdge(gBId, gAId); break;
+                case 'left':   this.hGraph.removeEdgeClaim(gAId, gBId, gc.minDistance); break;
+                case 'right':  this.hGraph.removeEdgeClaim(gBId, gAId, gc.minDistance); break;
+                case 'top':    this.vGraph.removeEdgeClaim(gAId, gBId, gc.minDistance); break;
+                case 'bottom': this.vGraph.removeEdgeClaim(gBId, gAId, gc.minDistance); break;
             }
         } else if (isAlignmentConstraint(constraint)) {
             const ac = constraint as AlignmentConstraint;

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -125,17 +125,18 @@ class DifferenceConstraintGraph {
     /** Reference count for alignment edge pairs (key: "a\x00b" with a < b lexicographically). */
     private alignmentRefCount: Map<string, number> = new Map();
     /**
-     * Multiset of active claim weights per directed edge (key: "a\x00b").
-     * Every successful addEdge registers a claim — including the redundant
-     * path (an equal-or-tighter edge already exists) and the tightening path
-     * (which displaces a smaller weight). The stored edge weight is always the
-     * max of its claims. removeEdgeClaim releases one claim and restores the
-     * edge to the strongest remaining claim (or deletes it when none remain).
-     * Without this, undoing an assignment whose constraint duplicated an
-     * existing pair blindly deleted the shared edge — dropping a base
-     * constraint or another assigned alternative's edge from the graph.
+     * Active claims per directed edge (key: "a\x00b"), each the weight an
+     * addEdge asked for plus the constraint that asked. Every successful
+     * addEdge registers one — including the redundant path (an equal-or-tighter
+     * edge already exists) and the tightening path (which displaces a smaller
+     * weight). The stored edge weight is always the max of its claims, and
+     * edgeProvenance always names the strongest claim's constraint.
+     * removeEdgeClaim releases one claim and restores both (or deletes the
+     * edge when none remain). Without this, undoing an assignment whose
+     * constraint duplicated an existing pair blindly deleted the shared edge —
+     * dropping a base constraint or another assigned alternative's edge.
      */
-    private edgeClaims: Map<string, number[]> = new Map();
+    private edgeClaims: Map<string, { w: number; c?: LayoutConstraint }[]> = new Map();
     private gap: number;
 
     /**
@@ -217,7 +218,9 @@ class DifferenceConstraintGraph {
         g.nodeSize = new Map(this.nodeSize);
         g.edgeProvenance = new Map(this.edgeProvenance);
         g.alignmentRefCount = new Map(this.alignmentRefCount);
-        for (const [k, ws] of this.edgeClaims) g.edgeClaims.set(k, [...ws]);
+        // Claim records are never mutated in place (only pushed/spliced), so
+        // copying the arrays is enough — the entries can be shared.
+        for (const [k, claims] of this.edgeClaims) g.edgeClaims.set(k, [...claims]);
         g.hasZeroWeightOrderingEdge = this.hasZeroWeightOrderingEdge;
         // Fresh stamps (from the constructor) — the clone is a new object with
         // an empty memo and no cached verdicts keyed on it, so it must not
@@ -273,7 +276,7 @@ class DifferenceConstraintGraph {
             // Edge exists with equal or tighter weight — no graph change, but
             // the claim must be registered so a later removeEdgeClaim releases
             // THIS add instead of deleting the edge someone else still needs.
-            this.registerClaim(a, b, w);
+            this.registerClaim(a, b, w, constraint);
             return true;
         }
         // For new edges or tightening: check if a return path b→...→a exists.
@@ -316,16 +319,50 @@ class DifferenceConstraintGraph {
             this.adj.get(a)!.set(b, w);
             this.radj.get(b)!.set(a, w);
         }
-        this.registerClaim(a, b, w);
-        if (constraint) this.edgeProvenance.set(DifferenceConstraintGraph.provenanceKey(a, b), constraint);
+        this.registerClaim(a, b, w, constraint);
         return true;
     }
 
-    private registerClaim(a: string, b: string, w: number): void {
+    private registerClaim(a: string, b: string, w: number, constraint?: LayoutConstraint): void {
         const key = DifferenceConstraintGraph.provenanceKey(a, b);
         const claims = this.edgeClaims.get(key);
-        if (claims) claims.push(w);
-        else this.edgeClaims.set(key, [w]);
+        if (claims) claims.push({ w, c: constraint });
+        else this.edgeClaims.set(key, [{ w, c: constraint }]);
+        this.refreshProvenance(key);
+    }
+
+    /**
+     * Point edgeProvenance at the strongest remaining claim that carries a
+     * constraint, or drop it when no claim does. Provenance has to follow the
+     * claims because conflict analysis maps path edges back to trail entries
+     * through it (analyzeConflictForDecision / analyzeTheoryConflict): naming a
+     * constraint whose claim was already released finds no trail entry, which
+     * silently OMITS a literal and yields a learned clause stronger than the
+     * conflict justifies. Before claims existed this could not arise — an undo
+     * deleted the edge and its provenance together.
+     *
+     * Ties keep the earliest claim, and a claim without a constraint never
+     * displaces one that has it, so the add-side outcomes are exactly what the
+     * previous `if (constraint) set(...)` produced: a fresh edge takes its
+     * constraint, a redundant add leaves the stronger claim's constraint in
+     * place, and a tightening add takes over.
+     */
+    private refreshProvenance(key: string): void {
+        const claims = this.edgeClaims.get(key);
+        if (!claims || claims.length === 0) {
+            this.edgeProvenance.delete(key);
+            return;
+        }
+        let best: LayoutConstraint | undefined;
+        let bestW = -Infinity;
+        for (const claim of claims) {
+            if (claim.c !== undefined && claim.w > bestW) {
+                bestW = claim.w;
+                best = claim.c;
+            }
+        }
+        if (best !== undefined) this.edgeProvenance.set(key, best);
+        else this.edgeProvenance.delete(key);
     }
 
     /**
@@ -347,7 +384,7 @@ class DifferenceConstraintGraph {
         const key = DifferenceConstraintGraph.provenanceKey(a, b);
         const claims = this.edgeClaims.get(key);
         if (!claims) return;
-        const idx = claims.indexOf(w);
+        const idx = claims.findIndex(claim => claim.w === w);
         if (idx === -1) return;
         claims.splice(idx, 1);
 
@@ -363,7 +400,7 @@ class DifferenceConstraintGraph {
         }
 
         let newW = -Infinity;
-        for (const c of claims) { if (c > newW) newW = c; }
+        for (const claim of claims) { if (claim.w > newW) newW = claim.w; }
         const cur = this.adj.get(a)?.get(b);
         if (cur !== undefined && newW < cur) {
             this.adj.get(a)!.set(b, newW);
@@ -376,6 +413,8 @@ class DifferenceConstraintGraph {
                 this.markDeltasUnknown();
             }
         }
+        // The released claim may have been the one naming this edge.
+        this.refreshProvenance(key);
     }
 
     /**

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -970,6 +970,16 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * two value domains never mix.
      */
     private altVerdictCache: Map<DisjunctiveConstraint, AltVerdictEntry> = new Map();
+    /**
+     * Positional memo of altVerdictCache for the graphPropagate scan, which
+     * revisits every unassigned disjunction each pass (~300k Map probes on the
+     * 10-group benchmark). verdictEntryDisj holds the disjunction the slot was
+     * filled from, and the scan only trusts a slot when that object is still
+     * identical — so a reshaped allDisjunctions can never alias the wrong
+     * entry, independent of the explicit clears.
+     */
+    private verdictEntryByIndex: (AltVerdictEntry | null)[] = [];
+    private verdictEntryDisj: (DisjunctiveConstraint | null)[] = [];
     /** (axis, from, to) probe → verdicts whose feasibility it supports. */
     private probeIndex: Map<string, { entry: AltVerdictEntry; aIdx: number }[]> = new Map();
     /** Bumped whenever a graph reports unknown reachability deltas. */
@@ -1986,16 +1996,46 @@ class QualitativeConstraintValidator implements IConstraintValidator {
             // (and stale-FEASIBLE verdicts can only over-count, never force a
             // wrong alternative or fabricate a conflict).
             this.consumeGraphDeltas();
+
             for (let d = 0; d < this.allDisjunctions.length; d++) {
                 if (assigned[d] !== -1) continue;
 
                 const disj = this.allDisjunctions[d];
+                // Re-read per disjunction, not per pass: a tryAssign below can
+                // both add and REMOVE edges (a partially-applied alternative is
+                // rolled back), and a stale remove-stamp would keep an
+                // INFEASIBLE verdict alive across a removal — under-counting
+                // feasible alternatives, which could fabricate a conflict.
+                // Alternatives of one disjunction are only read, never mutated
+                // between, so this granularity is exactly right.
+                //
+                // Zero-weight ordering edges break the monotonicity invariants
+                // the cache relies on — bypass it entirely then (the memoized
+                // reachability inside isAlternativeFeasible is still
+                // exact-version-safe, so results stay correct, just slower).
+                const bypassCache = this.hGraph.hasZeroWeightOrderingEdge
+                    || this.vGraph.hasZeroWeightOrderingEdge;
+                const curAdd = this.hGraph.addVersion + this.vGraph.addVersion;
+                const curRem = this.hGraph.removeVersion + this.vGraph.removeVersion;
+                let entry: AltVerdictEntry | null = null;
+                if (!bypassCache) {
+                    if (this.verdictEntryDisj[d] === disj) {
+                        entry = this.verdictEntryByIndex[d];
+                    } else {
+                        entry = this.verdictEntryFor(disj);
+                        this.verdictEntryDisj[d] = disj;
+                        this.verdictEntryByIndex[d] = entry;
+                    }
+                }
 
                 let feasibleCount = 0;
                 let lastFeasibleIdx = -1;
 
                 for (let a = 0; a < disj.alternatives.length; a++) {
-                    if (this.isAlternativeFeasibleCached(disj, a)) {
+                    const feasible = entry === null
+                        ? this.isAlternativeFeasible(disj.alternatives[a])
+                        : this.altFeasibleCached(disj, entry, a, curAdd, curRem);
+                    if (feasible) {
                         feasibleCount++;
                         lastFeasibleIdx = a;
                     }
@@ -2088,15 +2128,8 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         return hasAlignment;
     }
 
-    /** Cached isAlternativeFeasible — validity rules documented at altVerdictCache. */
-    private isAlternativeFeasibleCached(disj: DisjunctiveConstraint, aIdx: number): boolean {
-        // Zero-weight ordering edges break the monotonicity invariants the
-        // cache relies on — bypass it entirely (memoized reachability inside
-        // isAlternativeFeasible remains exact-version-safe).
-        if (this.hGraph.hasZeroWeightOrderingEdge || this.vGraph.hasZeroWeightOrderingEdge) {
-            return this.isAlternativeFeasible(disj.alternatives[aIdx]);
-        }
-
+    /** Fetch the verdict-cache entry for a disjunction, creating and registering its probes on first use. */
+    private verdictEntryFor(disj: DisjunctiveConstraint): AltVerdictEntry {
         let entry = this.altVerdictCache.get(disj);
         if (!entry) {
             const n = disj.alternatives.length;
@@ -2111,10 +2144,23 @@ class QualitativeConstraintValidator implements IConstraintValidator {
             }
             this.altVerdictCache.set(disj, entry);
         }
-        const curRem = this.hGraph.removeVersion + this.vGraph.removeVersion;
-        const addKey = entry.hasAlignment[aIdx]
-            ? this.hGraph.addVersion + this.vGraph.addVersion
-            : this.additionEpoch;
+        return entry;
+    }
+
+    /**
+     * Cached isAlternativeFeasible for one alternative of an already-fetched
+     * entry — validity rules documented at altVerdictCache. Split from the
+     * entry lookup so the scan in graphPropagate pays one Map probe per
+     * disjunction instead of one per alternative.
+     */
+    private altFeasibleCached(
+        disj: DisjunctiveConstraint,
+        entry: AltVerdictEntry,
+        aIdx: number,
+        curAdd: number,
+        curRem: number,
+    ): boolean {
+        const addKey = entry.hasAlignment[aIdx] ? curAdd : this.additionEpoch;
 
         const v = entry.verdict[aIdx];
         // Feasible: stable under removals; add-side staleness is handled by
@@ -2719,6 +2765,8 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         // edge that an undo path had over-eagerly removed.
         this.altVerdictCache.clear();
         this.probeIndex.clear();
+        this.verdictEntryByIndex.length = 0;
+        this.verdictEntryDisj.length = 0;
         this.additionEpoch++;
     }
 
@@ -3657,6 +3705,8 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         this.assignmentTrail = [];
         this.altVerdictCache.clear();
         this.probeIndex.clear();
+        this.verdictEntryByIndex.length = 0;
+        this.verdictEntryDisj.length = 0;
         this.lastPropagateOkStamp = -1;
     }
 

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -379,12 +379,25 @@ class DifferenceConstraintGraph {
      * their pair (validator reported SAT with a cyclic committed set —
      * caught by the Z3 committed-set cross-check).
      */
-    removeEdgeClaim(a: string, b: string, weight?: number): void {
+    removeEdgeClaim(a: string, b: string, weight?: number, constraint?: LayoutConstraint): void {
         const w = (weight ?? this.gap) + (this.nodeSize.get(a) ?? 0);
         const key = DifferenceConstraintGraph.provenanceKey(a, b);
         const claims = this.edgeClaims.get(key);
         if (!claims) return;
-        const idx = claims.findIndex(claim => claim.w === w);
+        // Match the RELEASING constraint's own claim, not just any claim of the
+        // same weight: two distinct constraints can claim one edge at the same
+        // weight (equal minDistance on the same pair), and dropping the wrong
+        // record leaves the released constraint's claim alive — so provenance
+        // then names a constraint that is off the trail while the still-active
+        // one goes unnamed, which is exactly the omitted-literal case that
+        // makes a learned clause stronger than its conflict.
+        //
+        // Identity matching also makes a missed claim a true no-op: a member
+        // edge whose add was cycle-rejected registers nothing, and weight-only
+        // matching could have released some other constraint's claim instead.
+        const idx = constraint !== undefined
+            ? claims.findIndex(claim => claim.w === w && claim.c === constraint)
+            : claims.findIndex(claim => claim.w === w);
         if (idx === -1) return;
         claims.splice(idx, 1);
 
@@ -2379,28 +2392,28 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      */
     private removeQualitativeEdge(constraint: LayoutConstraint): void {
         if (isLeftConstraint(constraint)) {
-            this.hGraph.removeEdgeClaim(constraint.left.id, constraint.right.id, constraint.minDistance);
+            this.hGraph.removeEdgeClaim(constraint.left.id, constraint.right.id, constraint.minDistance, constraint);
         } else if (isTopConstraint(constraint)) {
-            this.vGraph.removeEdgeClaim(constraint.top.id, constraint.bottom.id, constraint.minDistance);
+            this.vGraph.removeEdgeClaim(constraint.top.id, constraint.bottom.id, constraint.minDistance, constraint);
         } else if (isBoundingBoxConstraint(constraint)) {
             const bc = constraint as BoundingBoxConstraint;
             const groupId = `_group_${bc.group.name}`;
             switch (bc.side) {
                 case 'left':
-                    this.hGraph.removeEdgeClaim(bc.node.id, groupId, bc.minDistance);
-                    for (const mId of bc.group.nodeIds) this.hGraph.removeEdgeClaim(bc.node.id, mId, bc.minDistance);
+                    this.hGraph.removeEdgeClaim(bc.node.id, groupId, bc.minDistance, constraint);
+                    for (const mId of bc.group.nodeIds) this.hGraph.removeEdgeClaim(bc.node.id, mId, bc.minDistance, constraint);
                     break;
                 case 'right':
-                    this.hGraph.removeEdgeClaim(groupId, bc.node.id, bc.minDistance);
-                    for (const mId of bc.group.nodeIds) this.hGraph.removeEdgeClaim(mId, bc.node.id, bc.minDistance);
+                    this.hGraph.removeEdgeClaim(groupId, bc.node.id, bc.minDistance, constraint);
+                    for (const mId of bc.group.nodeIds) this.hGraph.removeEdgeClaim(mId, bc.node.id, bc.minDistance, constraint);
                     break;
                 case 'top':
-                    this.vGraph.removeEdgeClaim(bc.node.id, groupId, bc.minDistance);
-                    for (const mId of bc.group.nodeIds) this.vGraph.removeEdgeClaim(bc.node.id, mId, bc.minDistance);
+                    this.vGraph.removeEdgeClaim(bc.node.id, groupId, bc.minDistance, constraint);
+                    for (const mId of bc.group.nodeIds) this.vGraph.removeEdgeClaim(bc.node.id, mId, bc.minDistance, constraint);
                     break;
                 case 'bottom':
-                    this.vGraph.removeEdgeClaim(groupId, bc.node.id, bc.minDistance);
-                    for (const mId of bc.group.nodeIds) this.vGraph.removeEdgeClaim(mId, bc.node.id, bc.minDistance);
+                    this.vGraph.removeEdgeClaim(groupId, bc.node.id, bc.minDistance, constraint);
+                    for (const mId of bc.group.nodeIds) this.vGraph.removeEdgeClaim(mId, bc.node.id, bc.minDistance, constraint);
                     break;
             }
         } else if (isGroupBoundaryConstraint(constraint)) {
@@ -2408,10 +2421,10 @@ class QualitativeConstraintValidator implements IConstraintValidator {
             const gAId = `_group_${gc.groupA.name}`;
             const gBId = `_group_${gc.groupB.name}`;
             switch (gc.side) {
-                case 'left':   this.hGraph.removeEdgeClaim(gAId, gBId, gc.minDistance); break;
-                case 'right':  this.hGraph.removeEdgeClaim(gBId, gAId, gc.minDistance); break;
-                case 'top':    this.vGraph.removeEdgeClaim(gAId, gBId, gc.minDistance); break;
-                case 'bottom': this.vGraph.removeEdgeClaim(gBId, gAId, gc.minDistance); break;
+                case 'left':   this.hGraph.removeEdgeClaim(gAId, gBId, gc.minDistance, constraint); break;
+                case 'right':  this.hGraph.removeEdgeClaim(gBId, gAId, gc.minDistance, constraint); break;
+                case 'top':    this.vGraph.removeEdgeClaim(gAId, gBId, gc.minDistance, constraint); break;
+                case 'bottom': this.vGraph.removeEdgeClaim(gBId, gAId, gc.minDistance, constraint); break;
             }
         } else if (isAlignmentConstraint(constraint)) {
             const ac = constraint as AlignmentConstraint;

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -903,18 +903,15 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         const remaining: DisjunctiveConstraint[] = [];
 
         for (const disj of this.allDisjunctions) {
-            const regionPair = this.getDisjunctionRegionPair(disj);
-
-            // Already separated?
-            if (regionPair && this.areSeparated(regionPair[0], regionPair[1])) {
-                const satisfyingAlt = this.findSatisfyingAlternative(disj, regionPair);
-                if (satisfyingAlt !== null) {
-                    for (const constraint of disj.alternatives[satisfyingAlt]) {
-                        this.addedConstraints.push(constraint);
-                    }
-                    this.prunedByTransitivity++;
-                    continue;
+            // Already satisfied? An alternative fully implied by the current
+            // graphs can be committed without adding edges (already entailed).
+            const impliedAlt = this.findImpliedAlternative(disj);
+            if (impliedAlt !== null) {
+                for (const constraint of disj.alternatives[impliedAlt]) {
+                    this.addedConstraints.push(constraint);
                 }
+                this.prunedByTransitivity++;
+                continue;
             }
 
             // Prune infeasible alternatives
@@ -1287,13 +1284,6 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     // Geometric pruning helpers
     // ═══════════════════════════════════════════════════════════════════════════
 
-    private areSeparated(idA: string, idB: string): boolean {
-        return (
-            this.hGraph.isOrdered(idA, idB) || this.hGraph.isOrdered(idB, idA) ||
-            this.vGraph.isOrdered(idA, idB) || this.vGraph.isOrdered(idB, idA)
-        );
-    }
-
     /**
      * Check if an alternative is feasible:
      * 1. No cycle (transitivity check)
@@ -1397,20 +1387,24 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     // alignment conflicts are caught automatically by DifferenceConstraintGraph.addEdge
     // (which checks canReach for cycles through zero-weight alignment edges).
 
-    private getDisjunctionRegionPair(disj: DisjunctiveConstraint): [string, string] | null {
-        if (disj.alternatives.length === 0) return null;
-        const first = disj.alternatives[0][0];
-        if (isBoundingBoxConstraint(first)) return [first.node.id, `_group_${first.group.name}`];
-        if (isGroupBoundaryConstraint(first)) return [`_group_${first.groupA.name}`, `_group_${first.groupB.name}`];
-        if (isLeftConstraint(first)) return [first.left.id, first.right.id];
-        if (isTopConstraint(first)) return [first.top.id, first.bottom.id];
-        return null;
-    }
-
-    private findSatisfyingAlternative(disj: DisjunctiveConstraint, pair: [string, string]): number | null {
-        // Find an alternative whose constraints are all actually implied by
-        // the current ordering graphs (forward direction is ordered or alignment
-        // already holds).
+    /**
+     * Find an alternative whose constraints are ALL already implied by the
+     * current ordering graphs (forward direction is ordered or the alignment
+     * already holds). Only such an alternative may be committed WITHOUT adding
+     * its edges to the graphs — the facts are already entailed, so nothing can
+     * later contradict them undetected.
+     *
+     * There is deliberately NO "merely not contradicted" fallback here. The
+     * old fallback checked each constraint of an alternative against the
+     * graphs individually and committed the alternative without edges; the
+     * constraints could then contradict each other JOINTLY with the base
+     * (e.g. a negated-group tuple N1 <x N2 <x N0 against base N0 <x N1),
+     * producing a SAT verdict with an unsatisfiable committed constraint set.
+     * Caught by the Z3 committed-model cross-check in z3-equivalence.test.ts.
+     * Non-implied alternatives must go through the normal path, where commits
+     * add graph edges (addConjunctiveConstraint / tryAssign).
+     */
+    private findImpliedAlternative(disj: DisjunctiveConstraint): number | null {
         for (let i = 0; i < disj.alternatives.length; i++) {
             let allImplied = true;
             for (const constraint of disj.alternatives[i]) {
@@ -1427,32 +1421,6 @@ class QualitativeConstraintValidator implements IConstraintValidator {
                 if (!graph.isOrdered(edge.from, edge.to)) { allImplied = false; break; }
             }
             if (allImplied) return i;
-        }
-        // Fallback: if no alternative is fully implied, find one that's at least
-        // not contradicted. Must also check alignment conflicts — an ordering
-        // between aligned nodes is contradicted even if no reverse edge exists.
-        // With zero-weight alignment edges, isStrictlyOrdered catches this:
-        // ordering aligned nodes would create a negative cycle through the
-        // zero-weight alignment path.
-        for (let i = 0; i < disj.alternatives.length; i++) {
-            let feasible = true;
-            for (const constraint of disj.alternatives[i]) {
-                if (isAlignmentConstraint(constraint)) {
-                    const ac = constraint as AlignmentConstraint;
-                    const graph = ac.axis === 'x' ? this.hGraph : this.vGraph;
-                    // Alignment is contradicted if the nodes are strictly ordered
-                    if (graph.isStrictlyOrdered(ac.node1.id, ac.node2.id) || graph.isStrictlyOrdered(ac.node2.id, ac.node1.id)) {
-                        feasible = false; break;
-                    }
-                    continue;
-                }
-                const edge = this.constraintToEdge(constraint);
-                if (!edge) continue;
-                const graph = edge.axis === 'h' ? this.hGraph : this.vGraph;
-                // Contradicted by reverse ordering (including through alignment paths)?
-                if (graph.canReach(edge.to, edge.from)) { feasible = false; break; }
-            }
-            if (feasible) return i;
         }
         return null;
     }
@@ -2108,13 +2076,10 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         const pruned: DisjunctiveConstraint[] = [];
 
         for (const disj of this.allDisjunctions) {
-            const regionPair = this.getDisjunctionRegionPair(disj);
-            if (regionPair && this.areSeparated(regionPair[0], regionPair[1])) {
-                const satisfyingAlt = this.findSatisfyingAlternative(disj, regionPair);
-                if (satisfyingAlt !== null) {
-                    for (const c of disj.alternatives[satisfyingAlt]) this.addedConstraints.push(c);
-                    continue;
-                }
+            const impliedAlt = this.findImpliedAlternative(disj);
+            if (impliedAlt !== null) {
+                for (const c of disj.alternatives[impliedAlt]) this.addedConstraints.push(c);
+                continue;
             }
 
             const validAlternatives: LayoutConstraint[][] = [];
@@ -3396,19 +3361,33 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * Nodes that CANNOT be aligned with nodeId on the given axis.
      *
      * Feasibility check: adding alignment(X, Y) means zero-weight edges in both
-     * directions. This is infeasible if there's a strict ordering between them
-     * (isStrictlyOrdered in either direction), because the zero-weight cycle
-     * would contradict the positive-weight edge.
+     * directions. This is infeasible if:
+     * 1. There's a strict ordering between them (isStrictlyOrdered in either
+     *    direction) — the zero-weight cycle would contradict the positive-weight
+     *    edge; or
+     * 2. Merging their alignment classes on this axis would put two distinct
+     *    nodes that are aligned on the OTHER axis into the same class —
+     *    dual-axis alignment forces identical positions, i.e. node overlap.
+     *    This is the same rule the solver applies in isAlternativeFeasible
+     *    (classHasDualAxisOverlap); without it getCanAligned over-claims,
+     *    e.g. "A =x B" alone would report that A and B can also be y-aligned.
      */
     public getCannotAligned(nodeId: string, axis: 'x' | 'y'): Set<string> {
         const result = new Set<string>();
         result.add(nodeId); // X is not "aligned with itself" in the query sense
         const graph = axis === 'x' ? this.mustHGraph : this.mustVGraph;
+        const otherGraph = axis === 'x' ? this.mustVGraph : this.mustHGraph;
         if (!graph) return result;
 
         for (const n of this.nodes) {
             if (n.id === nodeId) continue;
             if (graph.isStrictlyOrdered(nodeId, n.id) || graph.isStrictlyOrdered(n.id, nodeId)) {
+                result.add(n.id);
+                continue;
+            }
+            if (otherGraph && QualitativeConstraintValidator.classHasDualAxisOverlap(
+                graph, otherGraph, nodeId, n.id, false,
+            )) {
                 result.add(n.id);
             }
         }

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -88,6 +88,15 @@ import type { PositionalConstraintError, GroupOverlapError } from './constraint-
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
+ * Global mutation-stamp counter shared by all DifferenceConstraintGraph
+ * instances. Every stamp ever handed out is unique, so "stamp unchanged"
+ * always means "no structural mutation on that graph object since" — even
+ * across checkpoint/restore, which installs fresh graph objects with fresh
+ * stamps (never reusing values that older cached verdicts were keyed on).
+ */
+let nextGraphStamp = 1;
+
+/**
  * Weighted DAG representing difference constraints between spatial elements.
  *
  * Each edge (a → b, weight w) encodes the constraint "b must be at least w
@@ -117,6 +126,73 @@ class DifferenceConstraintGraph {
     private alignmentRefCount: Map<string, number> = new Map();
     private gap: number;
 
+    /**
+     * Mutation stamps. addVersion changes when an edge is inserted (or a
+     * zero-weight edge becomes positive); removeVersion changes when an edge
+     * is deleted. Positive-weight tightenings change neither reachability nor
+     * strict-orderedness, so they deliberately do NOT bump (keeps caches warm).
+     */
+    addVersion: number = nextGraphStamp++;
+    removeVersion: number = nextGraphStamp++;
+    /**
+     * Set if any non-alignment edge was ever inserted with weight ≤ 0. Such
+     * edges break the invariant "zero-weight edges occur only in symmetric
+     * alignment pairs", which the validator's cross-version feasibility-verdict
+     * reuse relies on (see graphPropagate). When set, callers must fall back
+     * to exact-stamp cache validity.
+     */
+    hasZeroWeightOrderingEdge = false;
+
+    /** Per-source reachability memo: src → (target → some path has a positive edge). */
+    private reachMemo: Map<string, Map<string, boolean>> = new Map();
+    /** Memoized Tarjan SCC components. */
+    private sccMemo: string[][] | null = null;
+    private memoAddV = -1;
+    private memoRemV = -1;
+
+    /**
+     * Reachability deltas accumulated since the last consumeReachDeltas():
+     * (from, to) pairs whose reach-status changed (became reachable, or a
+     * positive-weight path appeared where only zero-weight paths existed).
+     * Deltas are exact when produced by the incremental-closure path in
+     * addEdge; any mutation that goes the clear-the-memo route (alignment
+     * edges, removals, cold memo, zero-weight hazard) sets this to null =
+     * "unknown, assume anything changed". Starts null so workloads that never
+     * consume record nothing; the first consume (which precedes any cached
+     * verdict) arms tracking. Capped as a memory backstop.
+     */
+    private pendingDeltas: { from: string; to: string }[] | null = null;
+    /**
+     * Overflow degrades gracefully (consumer sees null = unknown), so this cap
+     * only needs to bound memory for workloads that never consume. Consuming
+     * workloads reset per propagation pass and stay far below it.
+     */
+    private static readonly MAX_PENDING_DELTAS = 65536;
+
+    /**
+     * Hand back the reachability deltas since the last call (and reset the
+     * accumulator). Returns null if the deltas are unknown — the caller must
+     * assume any pair's reachability may have changed.
+     */
+    consumeReachDeltas(): { from: string; to: string }[] | null {
+        const d = this.pendingDeltas;
+        this.pendingDeltas = [];
+        return d;
+    }
+
+    private markDeltasUnknown(): void {
+        this.pendingDeltas = null;
+    }
+
+    private recordDelta(from: string, to: string): void {
+        if (this.pendingDeltas === null) return;
+        if (this.pendingDeltas.length >= DifferenceConstraintGraph.MAX_PENDING_DELTAS) {
+            this.pendingDeltas = null;
+            return;
+        }
+        this.pendingDeltas.push({ from, to });
+    }
+
     constructor(gap: number = 15) {
         this.gap = gap;
     }
@@ -129,9 +205,26 @@ class DifferenceConstraintGraph {
         g.nodeSize = new Map(this.nodeSize);
         g.edgeProvenance = new Map(this.edgeProvenance);
         g.alignmentRefCount = new Map(this.alignmentRefCount);
+        g.hasZeroWeightOrderingEdge = this.hasZeroWeightOrderingEdge;
+        // Fresh stamps (from the constructor) — the clone is a new object with
+        // an empty memo and no cached verdicts keyed on it, so it must not
+        // inherit stamps that other caches associate with the original.
         return g;
     }
 
+    /** Drop memoized reachability/SCC state if the graph mutated since it was built. */
+    private validateMemo(): void {
+        if (this.memoAddV !== this.addVersion || this.memoRemV !== this.removeVersion) {
+            this.reachMemo.clear();
+            this.sccMemo = null;
+            this.memoAddV = this.addVersion;
+            this.memoRemV = this.removeVersion;
+        }
+    }
+
+    // Note: adding an isolated node deliberately does NOT bump the mutation
+    // stamps — it creates no paths, so cached reachability stays valid, and
+    // SCC consumers treat nodes absent from the memo as singletons.
     ensureNode(id: string, size: number = 0): void {
         if (!this.nodes.has(id)) {
             this.nodes.add(id);
@@ -173,15 +266,91 @@ class DifferenceConstraintGraph {
         // Zero-weight addEdge calls are only used internally via addAlignmentEdges
         // which has its own reachability checks, so reject all canReach here.
         if (this.canReach(b, a)) return false;
-        this.adj.get(a)!.set(b, w);
-        this.radj.get(b)!.set(a, w);
+        if (w <= 0) this.hasZeroWeightOrderingEdge = true;
+        // New edge, or a zero-weight edge becoming positive: reachability or
+        // strict-orderedness changed. (Positive→positive tightening changes
+        // neither, so it neither bumps nor invalidates.)
+        if (existing === undefined || existing === 0) {
+            // Incremental closure: a plain acyclic insert (the canReach check
+            // above guarantees b cannot reach a) only creates paths of the form
+            // s →* a → b →* t, so the memoized closure can be patched in place
+            // — and the patched (s, t) pairs are exactly the reachability
+            // deltas. Requires a current memo and no zero-weight hazard.
+            const incremental = existing === undefined
+                && !this.hasZeroWeightOrderingEdge
+                && this.memoAddV === this.addVersion
+                && this.memoRemV === this.removeVersion;
+            this.adj.get(a)!.set(b, w);
+            this.radj.get(b)!.set(a, w);
+            if (incremental) {
+                // Patch BEFORE bumping the stamp: reachFrom inside the patch
+                // must see matching stamps, or validateMemo would wipe the
+                // memo it is meant to update.
+                this.applyIncrementalClosure(a, b, w > 0);
+                // Memo (and SCC memo — an acyclic insert cannot merge SCCs)
+                // maintained in place; keep the stamps synced so validateMemo
+                // doesn't discard them.
+                this.addVersion = nextGraphStamp++;
+                this.memoAddV = this.addVersion;
+            } else {
+                this.addVersion = nextGraphStamp++;
+                this.markDeltasUnknown();
+            }
+        } else {
+            this.adj.get(a)!.set(b, w);
+            this.radj.get(b)!.set(a, w);
+        }
         if (constraint) this.edgeProvenance.set(DifferenceConstraintGraph.provenanceKey(a, b), constraint);
         return true;
     }
 
+    /**
+     * Patch the memoized closure after inserting acyclic edge u → v, recording
+     * every (source, target) pair whose reach-status changed as a delta.
+     *
+     * New paths are exactly s →* u → v →* t, so for every cached source s that
+     * reaches u (or s === u), merge v's closure (plus v itself) into s's set,
+     * OR-ing path positivity. Sources not in the memo recompute from the
+     * updated adjacency on demand. Coverage note: consumers' cached verdicts
+     * only ever probe sources they queried when computing — queries warm the
+     * memo, and the memo is only ever cleared wholesale by mutations that also
+     * mark deltas unknown — so every probe source of a live verdict is cached
+     * here and gets its deltas recorded.
+     */
+    private applyIncrementalClosure(u: string, v: string, edgePositive: boolean): void {
+        const vSet = this.reachFrom(v); // v's closure is unaffected by u → v (no cycle)
+        for (const [s, sSet] of this.reachMemo) {
+            let posToU: boolean;
+            if (s === u) {
+                posToU = false;
+            } else {
+                const e = sSet.get(u);
+                if (e === undefined) continue; // s does not reach u — unaffected
+                posToU = e;
+            }
+            const posToV = posToU || edgePositive;
+            const curV = sSet.get(v);
+            if (curV === undefined || (!curV && posToV)) {
+                sSet.set(v, posToV);
+                if (s !== v) this.recordDelta(s, v);
+            }
+            for (const [t, posVT] of vSet) {
+                const p = posToV || posVT;
+                const cur = sSet.get(t);
+                if (cur === undefined || (!cur && p)) {
+                    sSet.set(t, p);
+                    if (s !== t) this.recordDelta(s, t);
+                }
+            }
+        }
+    }
+
     removeEdge(a: string, b: string): void {
-        this.adj.get(a)?.delete(b);
-        this.radj.get(b)?.delete(a);
+        if (this.adj.get(a)?.delete(b)) {
+            this.radj.get(b)?.delete(a);
+            this.removeVersion = nextGraphStamp++;
+            this.markDeltasUnknown();
+        }
         this.edgeProvenance.delete(DifferenceConstraintGraph.provenanceKey(a, b));
     }
 
@@ -200,22 +369,54 @@ class DifferenceConstraintGraph {
 
     canReach(from: string, to: string): boolean {
         if (from === to) return true;
-        const visited = new Set<string>();
-        const queue: string[] = [from];
-        visited.add(from);
-        while (queue.length > 0) {
-            const cur = queue.shift()!;
-            const succs = this.adj.get(cur);
+        return this.reachFrom(from).has(to);
+    }
+
+    /**
+     * Memoized per-source reachability. One two-state BFS computes, for every
+     * node reachable from `src`, whether some path there contains a positive-
+     * weight edge — answering all canReach AND isStrictlyOrdered queries from
+     * `src` until the graph next mutates. Amortizes the ~600k single-pair BFS
+     * calls graphPropagate used to issue (each pass re-queries the same
+     * sources: bbox members, alignment endpoints, disjunction edge endpoints).
+     *
+     * Entry semantics: key present = reachable; value true = some path has a
+     * positive edge (strict ordering). `src` itself gets an entry with value
+     * false initially and may upgrade to true via a cycle through `src`,
+     * mirroring the original BFS exactly.
+     */
+    private reachFrom(src: string): Map<string, boolean> {
+        this.validateMemo();
+        const cached = this.reachMemo.get(src);
+        if (cached) return cached;
+
+        const m = new Map<string, boolean>(); // node → best "hasPositive" seen
+        const queue: string[] = [src];
+        const queuePositive: boolean[] = [false];
+        m.set(src, false);
+        let head = 0;
+        while (head < queue.length) {
+            const node = queue[head];
+            const hasPositive = queuePositive[head];
+            head++;
+            const succs = this.adj.get(node);
             if (!succs) continue;
-            for (const s of succs.keys()) {
-                if (s === to) return true;
-                if (!visited.has(s)) {
-                    visited.add(s);
+            for (const [s, w] of succs) {
+                const newHasPositive = hasPositive || w > 0;
+                const prev = m.get(s);
+                if (prev === undefined || (!prev && newHasPositive)) {
+                    m.set(s, newHasPositive);
                     queue.push(s);
+                    queuePositive.push(newHasPositive);
                 }
             }
         }
-        return false;
+        // src is trivially "reachable" from itself; drop the seed entry unless
+        // a real cycle re-reached it (upgraded to true), so `has(src)` reflects
+        // actual edge-reachability for canReach's non-early-exit path.
+        if (m.get(src) === false) m.delete(src);
+        this.reachMemo.set(src, m);
+        return m;
     }
 
     /**
@@ -349,15 +550,21 @@ class DifferenceConstraintGraph {
         }
 
         // Add zero-weight edges (don't overwrite existing positive-weight edges)
+        // Alignment pairs create deliberate 2-cycles — no incremental closure
+        // patch for those; take the clear-and-recompute route.
         if (!this.adj.get(a)!.has(b)) {
             this.adj.get(a)!.set(b, 0);
             this.radj.get(b)!.set(a, 0);
             if (constraint) this.edgeProvenance.set(DifferenceConstraintGraph.provenanceKey(a, b), constraint);
+            this.addVersion = nextGraphStamp++;
+            this.markDeltasUnknown();
         }
         if (!this.adj.get(b)!.has(a)) {
             this.adj.get(b)!.set(a, 0);
             this.radj.get(a)!.set(b, 0);
             if (constraint) this.edgeProvenance.set(DifferenceConstraintGraph.provenanceKey(b, a), constraint);
+            this.addVersion = nextGraphStamp++;
+            this.markDeltasUnknown();
         }
 
         // Increment reference count for this alignment pair
@@ -384,11 +591,15 @@ class DifferenceConstraintGraph {
             this.adj.get(a)!.delete(b);
             this.radj.get(b)!.delete(a);
             this.edgeProvenance.delete(DifferenceConstraintGraph.provenanceKey(a, b));
+            this.removeVersion = nextGraphStamp++;
+            this.markDeltasUnknown();
         }
         if (this.adj.get(b)?.get(a) === 0) {
             this.adj.get(b)!.delete(a);
             this.radj.get(a)!.delete(b);
             this.edgeProvenance.delete(DifferenceConstraintGraph.provenanceKey(b, a));
+            this.removeVersion = nextGraphStamp++;
+            this.markDeltasUnknown();
         }
     }
 
@@ -410,25 +621,7 @@ class DifferenceConstraintGraph {
      */
     isStrictlyOrdered(a: string, b: string): boolean {
         if (a === b) return false;
-        // BFS tracking whether we've traversed any positive-weight edge
-        const visited = new Map<string, boolean>(); // node → best "hasPositive" seen
-        const queue: { node: string; hasPositive: boolean }[] = [{ node: a, hasPositive: false }];
-        visited.set(a, false);
-        while (queue.length > 0) {
-            const { node, hasPositive } = queue.shift()!;
-            const succs = this.adj.get(node);
-            if (!succs) continue;
-            for (const [s, w] of succs) {
-                const newHasPositive = hasPositive || w > 0;
-                if (s === b && newHasPositive) return true;
-                const prevPositive = visited.get(s);
-                if (prevPositive === undefined || (!prevPositive && newHasPositive)) {
-                    visited.set(s, newHasPositive);
-                    queue.push({ node: s, hasPositive: newHasPositive });
-                }
-            }
-        }
-        return false;
+        return this.reachFrom(a).get(b) === true;
     }
 
     /**
@@ -442,6 +635,8 @@ class DifferenceConstraintGraph {
      * (87ms of a 200-node chain's validation, with zero alignments present).
      */
     private tarjanSCCs(): string[][] {
+        this.validateMemo();
+        if (this.sccMemo) return this.sccMemo;
         const index = new Map<string, number>();
         const lowlink = new Map<string, number>();
         const onStack = new Set<string>();
@@ -491,6 +686,7 @@ class DifferenceConstraintGraph {
                 }
             }
         }
+        this.sccMemo = components;
         return components;
     }
 
@@ -599,6 +795,18 @@ interface Assignment {
     isDecision: boolean;
 }
 
+/** Cached feasibility verdicts for one disjunction — see altVerdictCache. */
+interface AltVerdictEntry {
+    /** Per-alternative: 0 = unknown, 1 = feasible, 2 = infeasible. */
+    verdict: Int8Array;
+    /** Per-alternative: additionEpoch (probe-tracked) or add-stamp sum (alignment-bearing) at compute time. */
+    addStamp: Float64Array;
+    /** Per-alternative: remove-stamp sum at compute time. */
+    remStamp: Float64Array;
+    /** Per-alternative: 1 if the alternative contains an AlignmentConstraint. */
+    hasAlignment: Uint8Array;
+}
+
 interface SolverCheckpoint {
     hGraph: DifferenceConstraintGraph;
     vGraph: DifferenceConstraintGraph;
@@ -653,6 +861,44 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     // ─── Statistics ───
     private prunedByTransitivity: number = 0;
     private prunedByDecomposition: number = 0;
+
+    // ─── graphPropagate feasibility-verdict cache ───
+    /**
+     * Per-(disjunction, alternative) cached isAlternativeFeasible verdicts,
+     * keyed by disjunction object identity (pruneDisjunctions builds new
+     * objects, which naturally start cold). Validity rests on the monotonicity
+     * of feasibility in the edge set:
+     *   - edge ADDITIONS only shrink feasibility → an INFEASIBLE verdict stays
+     *     valid while no edge has been removed (remStamp unchanged);
+     *   - edge REMOVALS only grow feasibility → a FEASIBLE verdict stays valid
+     *     across removals unconditionally.
+     * For additions, feasible verdicts are invalidated PRECISELY rather than
+     * wholesale: each non-alignment alternative's feasibility depends on a
+     * fixed set of (axis, from, to) reachability probes, registered in
+     * probeIndex; when the graphs report exact reachability deltas
+     * (consumeReachDeltas), only verdicts whose probes match a delta are
+     * dirtied. When deltas are unknown (alignment-pair edges, removals, cold
+     * memo), additionEpoch bumps, invalidating all probe-tracked feasible
+     * verdicts at once. Alternatives containing an AlignmentConstraint query
+     * alignment classes (a dynamic probe set), so their feasible verdicts fall
+     * back to exact add-stamp validity.
+     * The monotone rules additionally need "zero-weight edges occur only in
+     * symmetric alignment pairs"; if either graph ever sees a zero-weight
+     * ordering edge (hasZeroWeightOrderingEdge), the cache is bypassed
+     * entirely.
+     * Sums of per-graph stamps are safe keys: stamps are globally unique and
+     * monotonically increasing, so an unchanged sum implies both unchanged.
+     * addStamp stores additionEpoch for probe-tracked alternatives and the
+     * add-stamp sum for alignment-bearing ones — fixed per alternative, so the
+     * two value domains never mix.
+     */
+    private altVerdictCache: Map<DisjunctiveConstraint, AltVerdictEntry> = new Map();
+    /** (axis, from, to) probe → verdicts whose feasibility it supports. */
+    private probeIndex: Map<string, { entry: AltVerdictEntry; aIdx: number }[]> = new Map();
+    /** Bumped whenever a graph reports unknown reachability deltas. */
+    private additionEpoch = 0;
+    /** Combined stamp of the last graphPropagate that reached 'ok' fixpoint; bail early if unchanged. */
+    private lastPropagateOkStamp = -1;
 
     // ─── Modal query state (populated after successful validation) ───
     /** Conjunctive-only graph snapshots (before CDCL disjunction resolution). */
@@ -1645,9 +1891,24 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         // alignment backtracking.
         if (this.groups.length === 0) return 'ok';
 
+        // Fast bail: if the graphs haven't structurally changed since the last
+        // 'ok' fixpoint, every feasibility verdict is unchanged, so the fixpoint
+        // still holds. (Any assignment or backtrack that matters bumps a stamp;
+        // an assignment whose edges were all already present changes nothing
+        // the feasibility checks can observe.)
+        if (this.combinedGraphStamp() === this.lastPropagateOkStamp) return 'ok';
+
         let changed = true;
         while (changed) {
             changed = false;
+            // Apply reachability deltas accumulated since the last pass (from
+            // decisions, unit propagation, backtracking, or tryAssigns made by
+            // the previous pass) to the verdict cache. Mid-pass mutations leave
+            // deltas pending until the next pass — sound, because a mid-pass
+            // mutation means a tryAssign succeeded, which forces another pass
+            // (and stale-FEASIBLE verdicts can only over-count, never force a
+            // wrong alternative or fabricate a conflict).
+            this.consumeGraphDeltas();
             for (let d = 0; d < this.allDisjunctions.length; d++) {
                 if (assigned[d] !== -1) continue;
 
@@ -1657,7 +1918,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
                 let lastFeasibleIdx = -1;
 
                 for (let a = 0; a < disj.alternatives.length; a++) {
-                    if (this.isAlternativeFeasible(disj.alternatives[a])) {
+                    if (this.isAlternativeFeasibleCached(disj, a)) {
                         feasibleCount++;
                         lastFeasibleIdx = a;
                     }
@@ -1675,7 +1936,121 @@ class QualitativeConstraintValidator implements IConstraintValidator {
                 }
             }
         }
+        this.lastPropagateOkStamp = this.combinedGraphStamp();
         return 'ok';
+    }
+
+    private combinedGraphStamp(): number {
+        // Stamps are globally unique and monotone, so this sum changes iff any
+        // structural mutation happened on either graph (including checkpoint
+        // restores, which install fresh graph objects with fresh stamps).
+        return this.hGraph.addVersion + this.hGraph.removeVersion
+            + this.vGraph.addVersion + this.vGraph.removeVersion;
+    }
+
+    /**
+     * Pull reachability deltas from both graphs and dirty exactly the cached
+     * feasible verdicts whose probes they hit. Unknown deltas (null) bump
+     * additionEpoch, invalidating every probe-tracked feasible verdict.
+     */
+    private consumeGraphDeltas(): void {
+        const hd = this.hGraph.consumeReachDeltas();
+        const vd = this.vGraph.consumeReachDeltas();
+        if (hd === null || vd === null) {
+            this.additionEpoch++;
+            return;
+        }
+        for (const d of hd) this.dirtyProbe('h', d.from, d.to);
+        for (const d of vd) this.dirtyProbe('v', d.from, d.to);
+    }
+
+    private dirtyProbe(axis: 'h' | 'v', from: string, to: string): void {
+        const hits = this.probeIndex.get(`${axis}\x00${from}\x00${to}`);
+        if (!hits) return;
+        for (const { entry, aIdx } of hits) {
+            // Only feasible verdicts can be flipped by an addition; infeasible
+            // ones are stable under additions (guarded by remStamp instead).
+            if (entry.verdict[aIdx] === 1) entry.verdict[aIdx] = 0;
+        }
+    }
+
+    /**
+     * Register the fixed reachability probes that alternative aIdx's
+     * feasibility depends on — mirrors isAlternativeFeasible's queries exactly:
+     *   - Left/Top/BBox/GroupBoundary edge: canReach(edge.to, edge.from);
+     *   - BBox additionally, per member m on the side's axis:
+     *     areAligned(node, m) (both directions) and the isBboxFeasibleInGraphs
+     *     isOrdered check (one of those directions).
+     * Returns true if the alternative contains an AlignmentConstraint (dynamic
+     * alignment-class probes — not trackable; falls back to add-stamp validity).
+     */
+    private registerProbes(entry: AltVerdictEntry, aIdx: number, alternative: LayoutConstraint[]): boolean {
+        let hasAlignment = false;
+        const add = (axis: 'h' | 'v', from: string, to: string): void => {
+            const key = `${axis}\x00${from}\x00${to}`;
+            let arr = this.probeIndex.get(key);
+            if (!arr) { arr = []; this.probeIndex.set(key, arr); }
+            arr.push({ entry, aIdx });
+        };
+        for (const constraint of alternative) {
+            if (isAlignmentConstraint(constraint)) {
+                hasAlignment = true;
+                continue;
+            }
+            if (isBoundingBoxConstraint(constraint)) {
+                const bc = constraint as BoundingBoxConstraint;
+                const axis = (bc.side === 'left' || bc.side === 'right') ? 'h' : 'v';
+                for (const m of bc.group.nodeIds) {
+                    add(axis, bc.node.id, m);
+                    add(axis, m, bc.node.id);
+                }
+            }
+            const edge = this.constraintToEdge(constraint);
+            if (edge) add(edge.axis, edge.to, edge.from);
+        }
+        return hasAlignment;
+    }
+
+    /** Cached isAlternativeFeasible — validity rules documented at altVerdictCache. */
+    private isAlternativeFeasibleCached(disj: DisjunctiveConstraint, aIdx: number): boolean {
+        // Zero-weight ordering edges break the monotonicity invariants the
+        // cache relies on — bypass it entirely (memoized reachability inside
+        // isAlternativeFeasible remains exact-version-safe).
+        if (this.hGraph.hasZeroWeightOrderingEdge || this.vGraph.hasZeroWeightOrderingEdge) {
+            return this.isAlternativeFeasible(disj.alternatives[aIdx]);
+        }
+
+        let entry = this.altVerdictCache.get(disj);
+        if (!entry) {
+            const n = disj.alternatives.length;
+            entry = {
+                verdict: new Int8Array(n),
+                addStamp: new Float64Array(n),
+                remStamp: new Float64Array(n),
+                hasAlignment: new Uint8Array(n),
+            };
+            for (let a = 0; a < n; a++) {
+                if (this.registerProbes(entry, a, disj.alternatives[a])) entry.hasAlignment[a] = 1;
+            }
+            this.altVerdictCache.set(disj, entry);
+        }
+        const curRem = this.hGraph.removeVersion + this.vGraph.removeVersion;
+        const addKey = entry.hasAlignment[aIdx]
+            ? this.hGraph.addVersion + this.vGraph.addVersion
+            : this.additionEpoch;
+
+        const v = entry.verdict[aIdx];
+        // Feasible: stable under removals; add-side staleness is handled by
+        // probe dirtying (verdict zeroed) or epoch/add-stamp mismatch.
+        if (v === 1 && entry.addStamp[aIdx] === addKey) return true;
+        // Infeasible: stable under additions; only removals can flip it.
+        if (v === 2 && entry.remStamp[aIdx] === curRem) return false;
+
+        const feasible = this.isAlternativeFeasible(disj.alternatives[aIdx]);
+        entry.verdict[aIdx] = feasible ? 1 : 2;
+        entry.addStamp[aIdx] = addKey;
+        entry.remStamp[aIdx] = curRem;
+        return feasible;
     }
 
     // disjunctionHasAlignment is no longer needed — all disjunctions (including
@@ -2145,6 +2520,14 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     private restoreCheckpoint(cp: SolverCheckpoint): void {
         this.hGraph = cp.hGraph.clone();
         this.vGraph = cp.vGraph.clone();
+        // The restored graphs are fresh objects with fresh stamps and empty
+        // delta accumulators; drop all cached verdicts and probes (restarts
+        // are rare, and pruneDisjunctions rebuilds the disjunction objects
+        // anyway). Also covers the corner where a restore re-introduces an
+        // edge that an undo path had over-eagerly removed.
+        this.altVerdictCache.clear();
+        this.probeIndex.clear();
+        this.additionEpoch++;
     }
 
     private constraintToEdge(constraint: LayoutConstraint): { axis: 'h' | 'v'; from: string; to: string } | null {
@@ -3077,6 +3460,9 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         this.learnedClauses = [];
         this.activity.clear();
         this.assignmentTrail = [];
+        this.altVerdictCache.clear();
+        this.probeIndex.clear();
+        this.lastPropagateOkStamp = -1;
     }
 
     public getStats(): {

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -913,7 +913,19 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     private assignmentTrail: Assignment[] = [];
     private decisionLevel: number = 0;
     private learnedClauses: LearnedClause[] = [];
-    private activity: Map<string, number> = new Map();
+    /**
+     * VSIDS activity, indexed by `disjunctionIndex * branchStride +
+     * alternativeIndex` (replaces a `d${d}a${a}`-keyed Map: pickBranch built
+     * one string per alternative per call — ~1.2M allocations on the 10-group
+     * benchmark). The stride never shrinks, so an entry keeps its (d, a)
+     * identity across restarts exactly as the string keys did.
+     */
+    private activityFlat: Float64Array = new Float64Array(0);
+    /** Branching tiebreaker 1/(1 + altLength), same indexing as activityFlat. */
+    private simplicityFlat: Float64Array = new Float64Array(0);
+    /** Reusable scratch for pickBranch's learned-clause elimination bitmap. */
+    private elimScratch: Uint8Array = new Uint8Array(0);
+    private branchStride = 0;
     private activityDecay: number = 0.95;
     private conflictCount: number = 0;
     private restartThreshold: number = 32;
@@ -1773,11 +1785,7 @@ class QualitativeConstraintValidator implements IConstraintValidator {
 
         let assigned = new Int32Array(this.allDisjunctions.length).fill(-1);
 
-        for (let d = 0; d < this.allDisjunctions.length; d++) {
-            for (let a = 0; a < this.allDisjunctions[d].alternatives.length; a++) {
-                this.activity.set(`d${d}a${a}`, 0);
-            }
-        }
+        this.rebuildBranchIndex(true);
 
         const initialCheckpoint = this.checkpoint();
         const initialAddedLength = this.addedConstraints.length;
@@ -1796,6 +1804,10 @@ class QualitativeConstraintValidator implements IConstraintValidator {
                 this.pruneDisjunctions();
                 if (this.allDisjunctions.length === 0) return { satisfiable: true };
                 assigned = new Int32Array(this.allDisjunctions.length).fill(-1);
+                // Pruning reshapes allDisjunctions; refresh the simplicity terms
+                // for the new shape but keep accumulated activity (the old
+                // index-keyed Map behaved the same way).
+                this.rebuildBranchIndex(false);
             }
 
             const result = this.cdclSearchLoop(assigned);
@@ -2506,17 +2518,108 @@ class QualitativeConstraintValidator implements IConstraintValidator {
 
     // ─── Decision heuristic (VSIDS + simplicity, from V1) ───────────────────
 
+    /**
+     * (Re)build the flat branching arrays for the current allDisjunctions.
+     * `reset` zeroes activity (start of a solve); restarts keep it.
+     * The stride only ever grows, so an alternative's slot keeps its (d, a)
+     * identity — matching the old index-keyed activity Map.
+     */
+    private rebuildBranchIndex(reset: boolean): void {
+        const numD = this.allDisjunctions.length;
+        let maxAlts = 1;
+        for (const disj of this.allDisjunctions) {
+            if (disj.alternatives.length > maxAlts) maxAlts = disj.alternatives.length;
+        }
+
+        if (maxAlts > this.branchStride) {
+            const oldStride = this.branchStride;
+            const oldAct = this.activityFlat;
+            this.branchStride = maxAlts;
+            this.activityFlat = new Float64Array(Math.max(numD, 1) * maxAlts);
+            if (oldStride > 0 && !reset) {
+                const oldD = Math.floor(oldAct.length / oldStride);
+                for (let d = 0; d < oldD && d < numD; d++) {
+                    for (let a = 0; a < oldStride; a++) {
+                        this.activityFlat[d * maxAlts + a] = oldAct[d * oldStride + a];
+                    }
+                }
+            }
+        } else if (numD * this.branchStride > this.activityFlat.length) {
+            const grown = new Float64Array(numD * this.branchStride);
+            if (!reset) grown.set(this.activityFlat);
+            this.activityFlat = grown;
+        } else if (reset) {
+            this.activityFlat.fill(0);
+        }
+
+        const size = Math.max(numD, 1) * this.branchStride;
+        if (this.simplicityFlat.length < size) {
+            this.simplicityFlat = new Float64Array(size);
+            this.elimScratch = new Uint8Array(size);
+        }
+        this.simplicityFlat.fill(0);
+        for (let d = 0; d < numD; d++) {
+            const alts = this.allDisjunctions[d].alternatives;
+            const base = d * this.branchStride;
+            for (let a = 0; a < alts.length; a++) {
+                this.simplicityFlat[base + a] = 1.0 / (1 + alts[a].length);
+            }
+        }
+    }
+
+    /** Activity for (d, a), 0 when out of range — mirrors the old `?? 0`. */
+    private activityAt(d: number, a: number): number {
+        const i = d * this.branchStride + a;
+        return i >= 0 && i < this.activityFlat.length ? this.activityFlat[i] : 0;
+    }
+
+    /**
+     * Mark alternatives eliminated by learned clauses, for ALL disjunctions in
+     * one pass over the clause list. getRemainingAlternatives did this per
+     * disjunction — O(D · C · L) per pickBranch call, allocating a Set and an
+     * array each time; this is O(C · L) into a reused bitmap. Returns null
+     * when there are no learned clauses (nothing can be eliminated).
+     */
+    private computeEliminatedFlags(assigned: Int32Array): Uint8Array | null {
+        if (this.learnedClauses.length === 0) return null;
+        const elim = this.elimScratch;
+        elim.fill(0);
+        const stride = this.branchStride;
+        for (const clause of this.learnedClauses) {
+            for (const lit of clause) {
+                if (lit.sign) continue;
+                const idx = lit.disjunctionIndex * stride + lit.alternativeIndex;
+                // Stale index from a pre-restart clause, or already eliminated.
+                if (idx < 0 || idx >= elim.length || elim[idx] === 1) continue;
+                let allOthersFalse = true;
+                for (const l of clause) {
+                    if (l === lit) continue;
+                    const cur = assigned[l.disjunctionIndex];
+                    if (cur === -1
+                        || (l.sign ? cur === l.alternativeIndex : cur !== l.alternativeIndex)) {
+                        allOthersFalse = false;
+                        break;
+                    }
+                }
+                if (allOthersFalse) elim[idx] = 1;
+            }
+        }
+        return elim;
+    }
+
     private pickBranch(assigned: Int32Array): { dIdx: number; aIdx: number } {
         let bestDIdx = -1, bestAIdx = -1, bestScore = -1;
+        const elim = this.computeEliminatedFlags(assigned);
+        const stride = this.branchStride;
 
         for (let d = 0; d < this.allDisjunctions.length; d++) {
             if (assigned[d] !== -1) continue;
-            // Only consider alternatives not eliminated by learned clauses
-            const remaining = this.getRemainingAlternatives(d, assigned);
-            const disj = this.allDisjunctions[d];
-            for (const a of remaining) {
-                const score = (this.activity.get(`d${d}a${a}`) ?? 0)
-                    + 1.0 / (1 + disj.alternatives[a].length);
+            const alts = this.allDisjunctions[d].alternatives;
+            const base = d * stride;
+            for (let a = 0; a < alts.length; a++) {
+                // Only consider alternatives not eliminated by learned clauses
+                if (elim !== null && elim[base + a] === 1) continue;
+                const score = this.activityFlat[base + a] + this.simplicityFlat[base + a];
                 if (score > bestScore) {
                     bestScore = score;
                     bestDIdx = d;
@@ -2531,13 +2634,17 @@ class QualitativeConstraintValidator implements IConstraintValidator {
 
     private bumpActivity(clause: LearnedClause): void {
         for (const lit of clause) {
-            const key = `d${lit.disjunctionIndex}a${lit.alternativeIndex}`;
-            this.activity.set(key, (this.activity.get(key) ?? 0) + 1);
+            const i = lit.disjunctionIndex * this.branchStride + lit.alternativeIndex;
+            if (i >= 0 && i < this.activityFlat.length) this.activityFlat[i] += 1;
         }
     }
 
     private decayActivity(): void {
-        for (const [key, val] of this.activity) this.activity.set(key, val * this.activityDecay);
+        // Multiply-all, same as the old Map sweep (zero slots are unaffected),
+        // so branching order is bit-for-bit what it was.
+        const act = this.activityFlat;
+        const decay = this.activityDecay;
+        for (let i = 0; i < act.length; i++) act[i] *= decay;
     }
 
     // ─── Restart management ──────────────────────────────────────────────────
@@ -2837,8 +2944,8 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         const sortedDisjunctions = [...disjSource].sort((a, b) => {
             const aIdx = disjSource.indexOf(a);
             const bIdx = disjSource.indexOf(b);
-            const aMax = Math.max(...a.alternatives.map((_, ai) => this.activity.get(`d${aIdx}a${ai}`) ?? 0));
-            const bMax = Math.max(...b.alternatives.map((_, bi) => this.activity.get(`d${bIdx}a${bi}`) ?? 0));
+            const aMax = Math.max(...a.alternatives.map((_, ai) => this.activityAt(aIdx, ai)));
+            const bMax = Math.max(...b.alternatives.map((_, bi) => this.activityAt(bIdx, bi)));
             // Stable tiebreaker: use original index when activity scores are equal
             return aMax - bMax || aIdx - bIdx;
         });
@@ -3543,7 +3650,10 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         this.hGraph = new DifferenceConstraintGraph(this.minPadding);
         this.vGraph = new DifferenceConstraintGraph(this.minPadding);
         this.learnedClauses = [];
-        this.activity.clear();
+        this.activityFlat = new Float64Array(0);
+        this.simplicityFlat = new Float64Array(0);
+        this.elimScratch = new Uint8Array(0);
+        this.branchStride = 0;
         this.assignmentTrail = [];
         this.altVerdictCache.clear();
         this.probeIndex.clear();

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -158,6 +158,15 @@ class DifferenceConstraintGraph {
 
     /** Per-source reachability memo: src → (target → some path has a positive edge). */
     private reachMemo: Map<string, Map<string, boolean>> = new Map();
+    /** Per-source longest-path memo: src → (target → max total edge weight). */
+    private maxWeightMemo: Map<string, Map<string, number>> = new Map();
+    /** Source-independent contraction backing maxWeightMemo (see contractedDag). */
+    private contractedMemo: {
+        rep: Map<string, string>;
+        adj: Map<string, Map<string, number>>;
+        order: string[];
+        members: Map<string, string[]>;
+    } | null = null;
     /** Memoized Tarjan SCC components. */
     private sccMemo: string[][] | null = null;
     private memoAddV = -1;
@@ -232,6 +241,8 @@ class DifferenceConstraintGraph {
     private validateMemo(): void {
         if (this.memoAddV !== this.addVersion || this.memoRemV !== this.removeVersion) {
             this.reachMemo.clear();
+            this.maxWeightMemo.clear();
+            this.contractedMemo = null;
             this.sccMemo = null;
             this.memoAddV = this.addVersion;
             this.memoRemV = this.removeVersion;
@@ -739,6 +750,147 @@ class DifferenceConstraintGraph {
     isStrictlyOrdered(a: string, b: string): boolean {
         if (a === b) return false;
         return this.reachFrom(a).get(b) === true;
+    }
+
+    /**
+     * Check if a sits entirely before b on this axis: coord_a + size_a < coord_b.
+     *
+     * This is the spatial relation the query language means by "left of" /
+     * "above" — a is clear of b, not merely starting earlier. isStrictlyOrdered
+     * is the weaker "coord_a < coord_b"; use that one for questions about
+     * ordering or alignment feasibility, and this one for questions about where
+     * a box actually sits relative to another.
+     *
+     * The two coincide when every box has the same size on this axis, because
+     * any forced separation is then at least one box plus its padding. They
+     * come apart as soon as sizes differ: with A aligned to a narrow N and
+     * N before B, the forced separation is N's width, which says nothing about
+     * whether the much wider A clears B.
+     *
+     * Sound but not complete: maxWeightFrom is the separation this graph
+     * entails, and non-overlap and unresolved disjunctions can force more.
+     * Claiming less than is true is the safe direction for a must-fact.
+     */
+    isProperlyBefore(a: string, b: string): boolean {
+        if (a === b) return false;
+        const w = this.maxWeightFrom(a).get(b);
+        return w !== undefined && w > (this.nodeSize.get(a) ?? 0);
+    }
+
+    /**
+     * Memoized per-source longest-path weight. reachFrom answers "is there a
+     * path with any separation at all", which entails only coord_a < coord_b.
+     * Deciding whether a box CLEARS another needs the total separation the
+     * constraints force — coord_target ≥ coord_src + maxWeightFrom(src, target)
+     * — and that is the maximum over paths, not the existence of one.
+     *
+     * Alignment classes are contracted first: their members share a coordinate,
+     * so every edge inside a class weighs 0 and contributes nothing to a path.
+     * What remains is a DAG (positive-weight cycles are rejected at insertion),
+     * so the longest path is a single topological relaxation pass.
+     */
+    private maxWeightFrom(src: string): Map<string, number> {
+        this.validateMemo();
+        const cached = this.maxWeightMemo.get(src);
+        if (cached) return cached;
+
+        const { rep, adj, order, members } = this.contractedDag();
+        const srcRep = rep.get(src) ?? src;
+
+        const dist = new Map<string, number>();
+        dist.set(srcRep, 0);
+        for (const n of order) {
+            const base = dist.get(n);
+            if (base === undefined) continue; // not downstream of src
+            for (const [s, w] of adj.get(n)!) {
+                const cand = base + w;
+                const cur = dist.get(s);
+                if (cur === undefined || cand > cur) dist.set(s, cand);
+            }
+        }
+
+        // Expand super-nodes back to members. Walking `dist` rather than every
+        // node keeps this proportional to what src actually reaches, matching
+        // reachFrom — expanding over all nodes instead made each source O(V)
+        // even when it reaches nothing.
+        const result = new Map<string, number>();
+        for (const [r, d] of dist) {
+            const ms = members.get(r);
+            if (ms === undefined) { result.set(r, d); continue; }
+            for (const m of ms) result.set(m, d);
+        }
+        this.maxWeightMemo.set(src, result);
+        return result;
+    }
+
+    /**
+     * The alignment-contracted DAG plus a topological order, shared by every
+     * maxWeightFrom source. Building it is O(V + E) and it does not depend on
+     * the source, so it is computed once per graph version — rebuilding it per
+     * source made the lazy modal build ~3-5x slower on chains.
+     *
+     * Members of an alignment class share a coordinate, so intra-class edges
+     * (necessarily zero-weight) are dropped and the class collapses to one
+     * super-node. Between super-nodes only the heaviest edge matters, since a
+     * longest-path relaxation would pick it anyway.
+     */
+    private contractedDag(): {
+        rep: Map<string, string>;
+        adj: Map<string, Map<string, number>>;
+        order: string[];
+        members: Map<string, string[]>;
+    } {
+        if (this.contractedMemo) return this.contractedMemo;
+
+        const rep = new Map<string, string>();
+        const members = this.getAlignmentClasses();
+        for (const [r, ms] of members) {
+            for (const m of ms) rep.set(m, r);
+        }
+        const repOf = (id: string): string => rep.get(id) ?? id;
+
+        const adj = new Map<string, Map<string, number>>();
+        const indeg = new Map<string, number>();
+        for (const n of this.nodes) {
+            const r = repOf(n);
+            if (!adj.has(r)) { adj.set(r, new Map()); indeg.set(r, 0); }
+        }
+        for (const [u, succs] of this.adj) {
+            const ru = repOf(u);
+            const out = adj.get(ru);
+            if (!out) continue;
+            for (const [v, w] of succs) {
+                const rv = repOf(v);
+                if (ru === rv) continue;
+                const cur = out.get(rv);
+                if (cur === undefined) {
+                    out.set(rv, w);
+                    indeg.set(rv, (indeg.get(rv) ?? 0) + 1);
+                } else if (w > cur) {
+                    out.set(rv, w);
+                }
+            }
+        }
+
+        // Kahn order. Anything left unordered would sit on a surviving cycle,
+        // which after contraction means a positive-weight cycle — rejected at
+        // insertion, so unreachable in practice. Such nodes simply never get a
+        // distance, which reads as "no entailed separation": conservative.
+        const order: string[] = [];
+        const queue: string[] = [];
+        for (const [n, d] of indeg) if (d === 0) queue.push(n);
+        for (let head = 0; head < queue.length; head++) {
+            const n = queue[head];
+            order.push(n);
+            for (const [s] of adj.get(n)!) {
+                const d = (indeg.get(s) ?? 1) - 1;
+                indeg.set(s, d);
+                if (d === 0) queue.push(s);
+            }
+        }
+
+        this.contractedMemo = { rep, adj, order, members };
+        return this.contractedMemo;
     }
 
     /**
@@ -3883,12 +4035,18 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         this.mustVAlignmentClasses = this.collectAlignmentClasses(this.mustVGraph, realNodeIds);
     }
 
-    /** Collect all strict ordering pairs from a graph. */
+    /**
+     * Collect the pairs this graph forces into a proper spatial relation:
+     * a sits entirely before b, which is what getMust reports as "a is left of
+     * / above b". Deliberately isProperlyBefore and not isStrictlyOrdered —
+     * the latter only entails coord_a < coord_b, which for a box wider than
+     * the forced separation still leaves a overlapping b's span.
+     */
     private collectStrictPairs(graph: DifferenceConstraintGraph, nodeIds: string[]): Set<string> {
         const pairs = new Set<string>();
         for (const a of nodeIds) {
             for (const b of nodeIds) {
-                if (a !== b && graph.isStrictlyOrdered(a, b)) {
+                if (a !== b && graph.isProperlyBefore(a, b)) {
                     pairs.add(`${a}\x00${b}`);
                 }
             }
@@ -4257,7 +4415,13 @@ class QualitativeConstraintValidator implements IConstraintValidator {
 
     // ─── Post-CDCL resolved model queries (what's true in THIS layout) ───
 
-    /** Get all nodes reachable from `nodeId` in the given direction (resolved model). */
+    /**
+     * Get all nodes reachable from `nodeId` in the given direction (resolved model).
+     *
+     * Uses isProperlyBefore for the same reason getMust does: the question is
+     * which boxes actually sit to the given side, not which ones merely start
+     * earlier on the axis.
+     */
     public getReachable(nodeId: string, relation: 'leftOf' | 'rightOf' | 'above' | 'below'): Set<string> {
         const realNodeIds = new Set(this.nodes.map(n => n.id));
         const result = new Set<string>();
@@ -4265,25 +4429,25 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         switch (relation) {
             case 'rightOf': {
                 for (const n of realNodeIds) {
-                    if (n !== nodeId && this.hGraph.isStrictlyOrdered(nodeId, n)) result.add(n);
+                    if (n !== nodeId && this.hGraph.isProperlyBefore(nodeId, n)) result.add(n);
                 }
                 break;
             }
             case 'leftOf': {
                 for (const n of realNodeIds) {
-                    if (n !== nodeId && this.hGraph.isStrictlyOrdered(n, nodeId)) result.add(n);
+                    if (n !== nodeId && this.hGraph.isProperlyBefore(n, nodeId)) result.add(n);
                 }
                 break;
             }
             case 'below': {
                 for (const n of realNodeIds) {
-                    if (n !== nodeId && this.vGraph.isStrictlyOrdered(nodeId, n)) result.add(n);
+                    if (n !== nodeId && this.vGraph.isProperlyBefore(nodeId, n)) result.add(n);
                 }
                 break;
             }
             case 'above': {
                 for (const n of realNodeIds) {
-                    if (n !== nodeId && this.vGraph.isStrictlyOrdered(n, nodeId)) result.add(n);
+                    if (n !== nodeId && this.vGraph.isProperlyBefore(n, nodeId)) result.add(n);
                 }
                 break;
             }

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -148,6 +148,13 @@ class DifferenceConstraintGraph {
     addVersion: number = nextGraphStamp++;
     removeVersion: number = nextGraphStamp++;
     /**
+     * Bumped by every change to an edge's WEIGHT, including the
+     * positive→positive tightenings that deliberately leave
+     * addVersion/removeVersion alone. Distances depend on weights, so the
+     * longest-path caches key on this instead (see validateMemo).
+     */
+    private weightVersion: number = nextGraphStamp++;
+    /**
      * Set if any non-alignment edge was ever inserted with weight ≤ 0. Such
      * edges break the invariant "zero-weight edges occur only in symmetric
      * alignment pairs", which the validator's cross-version feasibility-verdict
@@ -171,6 +178,7 @@ class DifferenceConstraintGraph {
     private sccMemo: string[][] | null = null;
     private memoAddV = -1;
     private memoRemV = -1;
+    private memoWeightV = -1;
 
     /**
      * Reachability deltas accumulated since the last consumeReachDeltas():
@@ -237,15 +245,35 @@ class DifferenceConstraintGraph {
         return g;
     }
 
-    /** Drop memoized reachability/SCC state if the graph mutated since it was built. */
+    /**
+     * Drop memoized state the graph has outgrown. Two tiers, because the
+     * reachability caches and the longest-path caches depend on different
+     * things:
+     *
+     *  - reachMemo / sccMemo depend on the edge SET, tracked by
+     *    addVersion/removeVersion. A positive→positive tightening leaves both
+     *    untouched, which is why it deliberately does not bump them.
+     *  - maxWeightMemo / contractedMemo depend on edge WEIGHTS, tracked by
+     *    weightVersion. Tightening an edge changes distances without changing
+     *    reachability, and the incremental-closure path in addEdge keeps
+     *    reachMemo alive across an insert without recomputing distances — so
+     *    without this second tier both would stay stale while looking valid.
+     */
     private validateMemo(): void {
         if (this.memoAddV !== this.addVersion || this.memoRemV !== this.removeVersion) {
             this.reachMemo.clear();
+            this.sccMemo = null;
             this.maxWeightMemo.clear();
             this.contractedMemo = null;
-            this.sccMemo = null;
             this.memoAddV = this.addVersion;
             this.memoRemV = this.removeVersion;
+            this.memoWeightV = this.weightVersion;
+            return;
+        }
+        if (this.memoWeightV !== this.weightVersion) {
+            this.maxWeightMemo.clear();
+            this.contractedMemo = null;
+            this.memoWeightV = this.weightVersion;
         }
     }
 
@@ -312,6 +340,7 @@ class DifferenceConstraintGraph {
                 && this.memoRemV === this.removeVersion;
             this.adj.get(a)!.set(b, w);
             this.radj.get(b)!.set(a, w);
+            this.weightVersion = nextGraphStamp++;
             if (incremental) {
                 // Patch BEFORE bumping the stamp: reachFrom inside the patch
                 // must see matching stamps, or validateMemo would wipe the
@@ -327,8 +356,11 @@ class DifferenceConstraintGraph {
                 this.markDeltasUnknown();
             }
         } else {
+            // Tightening only: reachability and strict-orderedness are
+            // unchanged (so no add/removeVersion bump), but distances are not.
             this.adj.get(a)!.set(b, w);
             this.radj.get(b)!.set(a, w);
+            this.weightVersion = nextGraphStamp++;
         }
         this.registerClaim(a, b, w, constraint);
         return true;
@@ -417,6 +449,7 @@ class DifferenceConstraintGraph {
             if (this.adj.get(a)?.delete(b)) {
                 this.radj.get(b)?.delete(a);
                 this.removeVersion = nextGraphStamp++;
+                this.weightVersion = nextGraphStamp++;
                 this.markDeltasUnknown();
             }
             this.edgeProvenance.delete(key);
@@ -429,6 +462,7 @@ class DifferenceConstraintGraph {
         if (cur !== undefined && newW < cur) {
             this.adj.get(a)!.set(b, newW);
             this.radj.get(b)!.set(a, newW);
+            this.weightVersion = nextGraphStamp++;
             if (cur > 0 && newW <= 0) {
                 // Strict-orderedness may have shrunk — removal-like event for
                 // the reachability caches. (Positive→positive decreases change
@@ -685,6 +719,7 @@ class DifferenceConstraintGraph {
             this.radj.get(b)!.set(a, 0);
             if (constraint) this.edgeProvenance.set(DifferenceConstraintGraph.provenanceKey(a, b), constraint);
             this.addVersion = nextGraphStamp++;
+            this.weightVersion = nextGraphStamp++;
             this.markDeltasUnknown();
         }
         if (!this.adj.get(b)!.has(a)) {
@@ -692,6 +727,7 @@ class DifferenceConstraintGraph {
             this.radj.get(a)!.set(b, 0);
             if (constraint) this.edgeProvenance.set(DifferenceConstraintGraph.provenanceKey(b, a), constraint);
             this.addVersion = nextGraphStamp++;
+            this.weightVersion = nextGraphStamp++;
             this.markDeltasUnknown();
         }
 
@@ -720,6 +756,7 @@ class DifferenceConstraintGraph {
             this.radj.get(b)!.delete(a);
             this.edgeProvenance.delete(DifferenceConstraintGraph.provenanceKey(a, b));
             this.removeVersion = nextGraphStamp++;
+            this.weightVersion = nextGraphStamp++;
             this.markDeltasUnknown();
         }
         if (this.adj.get(b)?.get(a) === 0) {
@@ -727,6 +764,7 @@ class DifferenceConstraintGraph {
             this.radj.get(a)!.delete(b);
             this.edgeProvenance.delete(DifferenceConstraintGraph.provenanceKey(b, a));
             this.removeVersion = nextGraphStamp++;
+            this.weightVersion = nextGraphStamp++;
             this.markDeltasUnknown();
         }
     }
@@ -775,6 +813,22 @@ class DifferenceConstraintGraph {
         if (a === b) return false;
         const w = this.maxWeightFrom(a).get(b);
         return w !== undefined && w > (this.nodeSize.get(a) ?? 0);
+    }
+
+    /**
+     * Does the graph already force at least the separation an edge (a → b) with
+     * this raw minDistance would add? Converts the same way addEdge does
+     * (minDistance + source size) and compares against the entailed longest
+     * path, so an identical existing edge qualifies but a weaker one does not.
+     *
+     * "Ordered" is not enough to call such a constraint implied: a path merely
+     * proves SOME separation, while the constraint demands a specific amount.
+     */
+    entailsSeparation(a: string, b: string, weight?: number): boolean {
+        if (a === b) return false;
+        const required = (weight ?? this.gap) + (this.nodeSize.get(a) ?? 0);
+        const w = this.maxWeightFrom(a).get(b);
+        return w !== undefined && w >= required;
     }
 
     /**
@@ -2002,8 +2056,20 @@ class QualitativeConstraintValidator implements IConstraintValidator {
                 const edge = this.constraintToEdge(constraint);
                 if (!edge) continue;
                 const graph = edge.axis === 'h' ? this.hGraph : this.vGraph;
-                // Must be actually ordered in the forward direction
-                if (!graph.isOrdered(edge.from, edge.to)) { allImplied = false; break; }
+                // Must be ordered in the forward direction AND already forced
+                // to at least this constraint's separation. Ordering alone let
+                // a stronger constraint on an already-ordered pair count as
+                // implied, so it was committed without tightening the graph and
+                // the graph then under-entailed what the committed set requires
+                // (visible through getReachable / the must-queries). Both
+                // checks are kept: the conjunction can only ever shrink the
+                // implied set relative to the old behaviour, never grow it.
+                const minDistance = (constraint as { minDistance?: number }).minDistance;
+                if (!graph.isOrdered(edge.from, edge.to)
+                    || !graph.entailsSeparation(edge.from, edge.to, minDistance)) {
+                    allImplied = false;
+                    break;
+                }
             }
             if (allImplied) return i;
         }

--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -1025,6 +1025,13 @@ class QualitativeConstraintValidator implements IConstraintValidator {
     }
 
     public validatePositionalConstraints(): PositionalConstraintError | null {
+        // Any modal state belongs to a previous run over a possibly different
+        // constraint set — drop it before this one can be observed. Without
+        // this, a re-validation serves the earlier run's facts: modalStateBuilt
+        // short-circuits the rebuild on success, and the derived pair sets
+        // outlive the graphs on failure.
+        this.resetModalQueryState();
+
         // Phase 1: Add conjunctive constraints — stop on first error but don't return yet
         let phase1Failed = false;
         for (const constraint of this.orientationConstraints) {
@@ -1119,16 +1126,14 @@ class QualitativeConstraintValidator implements IConstraintValidator {
             this.layout.constraints = error.maximalFeasibleSubset;
         }
         // Every error return in validatePositionalConstraints funnels through
-        // here, so this is the one place that has to drop the modal must-graph
-        // snapshots. They are taken at Phase 4b (before CDCL), so a later
+        // here, so this is the one place that has to drop modal state. The
+        // must-graphs are snapshotted at Phase 4b (before CDCL), so a later
         // failure would otherwise leave them describing a constraint system
-        // this method just replaced on the layout — and getCannot /
-        // getCannotAligned read those graphs DIRECTLY (not the lazily-built
-        // pair sets), so gating the lazy build alone would not stop them
-        // answering. Clearing here makes every reader fall back to its
-        // empty/reflexive default via the null checks they already have.
-        this.mustHGraph = null;
-        this.mustVGraph = null;
+        // this method just replaced on the layout. Note the readers disagree on
+        // what they consult — getCannot/getCannotAligned read the must-graphs
+        // DIRECTLY, getMust/getMustAligned read the derived pair and class
+        // sets — so nulling the graphs alone is not enough; reset all of it.
+        this.resetModalQueryState();
         return error;
     }
 
@@ -3727,6 +3732,10 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         this.verdictEntryByIndex.length = 0;
         this.verdictEntryDisj.length = 0;
         this.lastPropagateOkStamp = -1;
+        // The must-pair sets are O(n²) and were the largest thing this method
+        // left behind; dropping them also stops modal getters answering from a
+        // disposed validator.
+        this.resetModalQueryState();
     }
 
     public getStats(): {
@@ -3766,6 +3775,24 @@ class QualitativeConstraintValidator implements IConstraintValidator {
      * path that forgets to route through there.
      */
     private modalStateBuilt = false;
+
+    /**
+     * Drop every piece of modal state: the pre-CDCL graph snapshots, the
+     * derived pair/alignment-class sets, and the two flags. Kept in one place
+     * because the getters consult different halves of it — clearing only the
+     * graphs leaves getMust answering from the derived sets, and clearing only
+     * the sets leaves getCannot answering from the graphs.
+     */
+    private resetModalQueryState(): void {
+        this.mustHGraph = null;
+        this.mustVGraph = null;
+        this.mustHPairs = null;
+        this.mustVPairs = null;
+        this.mustHAlignmentClasses = null;
+        this.mustVAlignmentClasses = null;
+        this.modalStateBuilt = false;
+        this.validationSucceeded = false;
+    }
 
     private ensureModalQueryState(): void {
         if (this.modalStateBuilt || !this.validationSucceeded) return;

--- a/tests/edge-undo-integrity.test.ts
+++ b/tests/edge-undo-integrity.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression tests for edge undo integrity in QualitativeConstraintValidator.
+ *
+ * Two former asymmetries between addQualitativeEdge and removeQualitativeEdge
+ * could corrupt the ordering graphs during CDCL backtracking:
+ *
+ *  1. addEdge's redundant path (an equal-or-tighter edge already exists)
+ *     inserted nothing, and its tightening path overwrote the weight — but
+ *     removeEdge deleted unconditionally. Undoing an assignment whose
+ *     constraint duplicated an existing pair therefore destroyed an edge a
+ *     base constraint (or another assigned alternative) still required, after
+ *     which contradictory alternatives became addable: the validator could
+ *     answer SAT with a cyclic committed constraint set (see the minimal
+ *     divergence specimen below; found via Z3 fuzzing, validator=SAT while
+ *     Z3=UNSAT).
+ *
+ *  2. addQualitativeEdge(BoundingBox) added the node↔group edge AND the
+ *     per-member Rule C edges, but removeQualitativeEdge removed only the
+ *     group edge — member edges leaked after backtracking, leaving the graph
+ *     over-constrained.
+ *
+ * The fix makes every successful addEdge register a claim (multiset of
+ * weights per directed edge) and replaces blind removal with
+ * removeEdgeClaim, which releases one matching claim, keeps the edge at the
+ * strongest remaining claim, and deletes it only when the last claim goes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { QualitativeConstraintValidator } from '../src/layout/qualitative-constraint-validator';
+import {
+    DisjunctiveConstraint,
+    InstanceLayout,
+    LayoutConstraint,
+    LayoutGroup,
+    LayoutNode,
+} from '../src/layout/interfaces';
+import { RelativeOrientationConstraint, GroupByField } from '../src/layout/layoutspec';
+
+const SRC = new RelativeOrientationConstraint(['left'], 'undo-integrity');
+const GBF = new GroupByField('type', 0, 1, 'type');
+
+function node(id: string, width = 100, height = 60): LayoutNode {
+    return {
+        id, label: id, color: 'black', groups: [], attributes: {},
+        width, height, mostSpecificType: 'Node', types: ['Node'], showLabels: true,
+    };
+}
+
+function leftOf(a: LayoutNode, b: LayoutNode, minDistance: number): LayoutConstraint {
+    return { left: a, right: b, minDistance, sourceConstraint: SRC };
+}
+
+/** Validator with private access for driving assign/undo paths directly. */
+function rig(layout: InstanceLayout): any {
+    return new QualitativeConstraintValidator(layout) as any;
+}
+
+describe('Edge undo integrity (claim-based add/remove)', () => {
+
+    describe('duplicate-pair constraints', () => {
+
+        it('undoing a redundant duplicate preserves the base edge and weight', () => {
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [leftOf(A, B, 15)], groups: [] });
+            expect(v.validateConstraints()).toBeNull();
+            const w = v.hGraph.getEdgeWeight('A', 'B'); // 15 + width(A) = 115
+
+            const dup = leftOf(A, B, 10); // strictly looser → redundant add path
+            expect(v.addQualitativeEdge(dup)).toBe(true);
+            v.removeQualitativeEdge(dup);
+
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(true);
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(w);
+        });
+
+        it('undoing a tightening duplicate restores the displaced weight', () => {
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [leftOf(A, B, 15)], groups: [] });
+            expect(v.validateConstraints()).toBeNull();
+            const w = v.hGraph.getEdgeWeight('A', 'B');
+
+            const tighter = leftOf(A, B, 500);
+            expect(v.addQualitativeEdge(tighter)).toBe(true);
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(500 + A.width);
+            v.removeQualitativeEdge(tighter);
+
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(true);
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(w);
+        });
+
+        it('non-LIFO release keeps the strongest remaining claim', () => {
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [leftOf(A, B, 15)], groups: [] });
+            expect(v.validateConstraints()).toBeNull();
+            const base = v.hGraph.getEdgeWeight('A', 'B'); // 115
+
+            const tighter = leftOf(A, B, 500);
+            const looser = leftOf(A, B, 10);
+            v.addQualitativeEdge(tighter); // weight → 600
+            v.addQualitativeEdge(looser);  // redundant claim (110)
+            v.removeQualitativeEdge(tighter); // release out of add order
+
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(base); // max(115, 110)
+            v.removeQualitativeEdge(looser);
+            expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(base);
+        });
+    });
+
+    describe('BoundingBox alternatives', () => {
+
+        const bboxLeft = (x: LayoutNode, group: LayoutGroup): LayoutConstraint =>
+            ({ node: x, group, side: 'left', minDistance: 15, sourceConstraint: GBF } as any);
+
+        it('undo releases the group edge AND the Rule C member edges', () => {
+            const M1 = node('M1'), M2 = node('M2'), X = node('X');
+            const group: LayoutGroup = { name: 'G', nodeIds: ['M1', 'M2'], keyNodeId: 'M1', showLabel: true, sourceConstraint: GBF };
+            // No validateConstraints: its own solving would add claims of its own.
+            const v = rig({ nodes: [M1, M2, X], edges: [], constraints: [], groups: [group] });
+
+            const bbox = bboxLeft(X, group);
+            expect(v.addQualitativeEdge(bbox)).toBe(true);
+            expect(v.hGraph.hasEdge('X', '_group_G')).toBe(true);
+            expect(v.hGraph.hasEdge('X', 'M1')).toBe(true);
+            expect(v.hGraph.hasEdge('X', 'M2')).toBe(true);
+
+            v.removeQualitativeEdge(bbox);
+            expect(v.hGraph.hasEdge('X', '_group_G')).toBe(false);
+            expect(v.hGraph.hasEdge('X', 'M1')).toBe(false);
+            expect(v.hGraph.hasEdge('X', 'M2')).toBe(false);
+        });
+
+        it('undo leaves a member edge intact while another constraint claims it', () => {
+            const M1 = node('M1'), M2 = node('M2'), X = node('X');
+            const group: LayoutGroup = { name: 'G', nodeIds: ['M1', 'M2'], keyNodeId: 'M1', showLabel: true, sourceConstraint: GBF };
+            const v = rig({ nodes: [M1, M2, X], edges: [], constraints: [], groups: [group] });
+
+            const ordering = leftOf(X, M1, 15);
+            const bbox = bboxLeft(X, group);
+            expect(v.addQualitativeEdge(ordering)).toBe(true);
+            expect(v.addQualitativeEdge(bbox)).toBe(true);
+
+            v.removeQualitativeEdge(bbox);
+            expect(v.hGraph.hasEdge('X', 'M1')).toBe(true); // ordering's claim survives
+            expect(v.hGraph.hasEdge('X', 'M2')).toBe(false);
+
+            v.removeQualitativeEdge(ordering);
+            expect(v.hGraph.hasEdge('X', 'M1')).toBe(false);
+        });
+    });
+
+    describe('end-to-end soundness', () => {
+
+        it('minimal divergence specimen: duplicate + cycle-closer alternative is UNSAT and leaves the base edge intact', () => {
+            // Base: N0 <x N3. Both alternatives contain N3 <x N0, so the
+            // instance is UNSAT. Pre-fix trajectory: pickBranch tries a0 (same
+            // length as a1); its duplicate add was redundant (no insert), its
+            // closer failed on the base cycle, and undoAlternativeEdges then
+            // deleted the BASE edge — letting a1's closer succeed and the
+            // validator answer SAT with the cyclic committed set
+            // {N0 <x N3, N3 <x N0}. Found by Z3 differential fuzzing.
+            const N0 = node('N0', 52, 89), N3 = node('N3', 89, 85);
+            const N1 = node('N1', 60, 40), N2 = node('N2', 60, 40);
+            const layout: InstanceLayout = {
+                nodes: [N0, N1, N2, N3], edges: [],
+                constraints: [leftOf(N0, N3, 20)],
+                groups: [],
+                disjunctiveConstraints: [
+                    new DisjunctiveConstraint(SRC, [
+                        [leftOf(N0, N3, 13), leftOf(N3, N0, 5)],
+                        [leftOf(N3, N0, 5), leftOf(N1, N2, 5)],
+                    ]),
+                ],
+            };
+            const v = rig(layout);
+            const error = v.validateConstraints();
+            expect(error).not.toBeNull();
+            expect(v.hGraph.hasEdge('N0', 'N3')).toBe(true);
+            // The committed set must not contain both directions of a pair.
+            const committed = layout.constraints.filter((c: any) => c.left).map((c: any) => `${c.left.id}->${c.right.id}`);
+            for (const dir of committed) {
+                const [a, b] = dir.split('->');
+                expect(committed).not.toContain(`${b}->${a}`);
+            }
+        });
+    });
+});

--- a/tests/edge-undo-integrity.test.ts
+++ b/tests/edge-undo-integrity.test.ts
@@ -88,6 +88,45 @@ describe('Edge undo integrity (claim-based add/remove)', () => {
             expect(v.hGraph.getEdgeWeight('A', 'B')).toBe(w);
         });
 
+        it('provenance follows the strongest remaining claim across a release', () => {
+            // Conflict analysis maps path edges back to trail entries through
+            // provenance, so provenance naming a released constraint finds no
+            // trail entry — silently dropping a literal and yielding a learned
+            // clause stronger than the conflict justifies.
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [], groups: [] });
+
+            const weak = leftOf(A, B, 10);
+            const strong = leftOf(A, B, 500);
+            v.addQualitativeEdge(weak);
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBe(weak);
+
+            v.addQualitativeEdge(strong); // tightens; takes over provenance
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBe(strong);
+
+            v.removeQualitativeEdge(strong); // weak still holds the edge
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(true);
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBe(weak);
+
+            v.removeQualitativeEdge(weak);
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(false);
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBeUndefined();
+        });
+
+        it('a redundant add does not steal provenance from the stronger claim', () => {
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [], groups: [] });
+
+            const strong = leftOf(A, B, 500);
+            const weak = leftOf(A, B, 10);
+            v.addQualitativeEdge(strong);
+            v.addQualitativeEdge(weak); // redundant — no graph change
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBe(strong);
+
+            v.removeQualitativeEdge(weak);
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBe(strong);
+        });
+
         it('non-LIFO release keeps the strongest remaining claim', () => {
             const A = node('A'), B = node('B');
             const v = rig({ nodes: [A, B], edges: [], constraints: [leftOf(A, B, 15)], groups: [] });

--- a/tests/edge-undo-integrity.test.ts
+++ b/tests/edge-undo-integrity.test.ts
@@ -113,6 +113,45 @@ describe('Edge undo integrity (claim-based add/remove)', () => {
             expect(v.hGraph.getEdgeProvenance('A', 'B')).toBeUndefined();
         });
 
+        it('releases the releasing constraint own claim when weights collide', () => {
+            // Two DISTINCT constraints on the same pair with the same
+            // minDistance produce claims of equal weight. Matching a release by
+            // weight alone drops the first record, leaving the just-released
+            // constraint's claim alive — so provenance names an off-trail
+            // constraint while the still-active one goes unnamed, and conflict
+            // analysis omits its literal.
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [], groups: [] });
+
+            const first = leftOf(A, B, 15);
+            const second = leftOf(A, B, 15); // distinct object, identical weight
+            v.addQualitativeEdge(first);
+            v.addQualitativeEdge(second);
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBe(first); // ties keep earliest
+
+            v.removeQualitativeEdge(second);
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(true);
+            // Must name `first`, which still holds the edge — not `second`.
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBe(first);
+
+            v.removeQualitativeEdge(first);
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(false);
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBeUndefined();
+        });
+
+        it('releasing a constraint that never claimed the edge is a no-op', () => {
+            const A = node('A'), B = node('B');
+            const v = rig({ nodes: [A, B], edges: [], constraints: [], groups: [] });
+
+            const held = leftOf(A, B, 15);
+            const neverAdded = leftOf(A, B, 15); // same weight, never registered
+            v.addQualitativeEdge(held);
+
+            v.removeQualitativeEdge(neverAdded);
+            expect(v.hGraph.hasEdge('A', 'B')).toBe(true);
+            expect(v.hGraph.getEdgeProvenance('A', 'B')).toBe(held);
+        });
+
         it('a redundant add does not steal provenance from the stronger claim', () => {
             const A = node('A'), B = node('B');
             const v = rig({ nodes: [A, B], edges: [], constraints: [], groups: [] });

--- a/tests/edge-undo-integrity.test.ts
+++ b/tests/edge-undo-integrity.test.ts
@@ -261,4 +261,95 @@ describe('Edge undo integrity (claim-based add/remove)', () => {
             }
         });
     });
+
+    describe('weight-dependent caches and implied alternatives', () => {
+        // Zero-size nodes so an edge weight equals its minDistance exactly.
+        const zn = (id: string): LayoutNode => node(id, 0, 0);
+        const entailed = (v: any, a: string, b: string): number | undefined =>
+            v.hGraph.maxWeightFrom(a).get(b);
+
+        it('tightening a positive edge invalidates the longest-path memo', () => {
+            // A positive→positive tightening deliberately does not bump the
+            // reachability stamps (reachability and strict-orderedness are
+            // unchanged), so the distance caches need their own weight stamp or
+            // they stay stale while looking valid.
+            const A = zn('A'), B = zn('B'), C = zn('C');
+            const first = leftOf(A, B, 1);
+            const constraints = [first, leftOf(B, C, 1)];
+            const v = rig({ nodes: [A, B, C], edges: [], constraints, groups: [] });
+            expect(v.validateConstraints()).toBeNull();
+            expect(entailed(v, 'A', 'C')).toBe(2); // warms the memo
+
+            (first as { minDistance: number }).minDistance = 10;
+            expect(v.validateConstraints()).toBeNull();
+
+            expect(entailed(v, 'A', 'C')).toBe(11);
+        });
+
+        it('an insert invalidates the longest-path memo despite the incremental closure', () => {
+            // The incremental-closure path keeps the reachability memo warm
+            // across an insert by syncing its stamp; distances are not patched,
+            // so they must still be dropped.
+            const A = zn('A'), B = zn('B'), C = zn('C');
+            const constraints = [leftOf(A, B, 3)];
+            const v = rig({ nodes: [A, B, C], edges: [], constraints, groups: [] });
+            expect(v.validateConstraints()).toBeNull();
+            expect(entailed(v, 'A', 'B')).toBe(3);
+            expect(entailed(v, 'A', 'C')).toBeUndefined();
+
+            constraints.push(leftOf(B, C, 4));
+            expect(v.validateConstraints()).toBeNull();
+
+            expect(entailed(v, 'A', 'C')).toBe(7);
+        });
+
+        it('an alternative demanding more separation than is entailed is not treated as implied', () => {
+            // isOrdered proves only that SOME separation is forced; committing a
+            // stronger constraint on that basis left the graph under-entailing
+            // what the committed set requires.
+            const A = zn('A'), B = zn('B'), C = zn('C');
+            const layout: InstanceLayout = {
+                nodes: [A, B, C], edges: [],
+                constraints: [leftOf(A, B, 1)],
+                groups: [],
+                disjunctiveConstraints: [
+                    new DisjunctiveConstraint(SRC, [
+                        [leftOf(A, B, 50)],
+                        [leftOf(A, C, 1)],
+                    ]),
+                ],
+            };
+            const v = rig(layout);
+            expect(v.validateConstraints()).toBeNull();
+
+            const committedAB = layout.constraints.some(
+                (c: any) => c.left?.id === 'A' && c.right?.id === 'B' && c.minDistance === 50,
+            );
+            if (committedAB) {
+                // If it was committed, the graph must actually force it.
+                expect(entailed(v, 'A', 'B')).toBeGreaterThanOrEqual(50);
+            }
+        });
+
+        it('an alternative already entailed at its own distance still counts as implied', () => {
+            // The check must not over-tighten into rejecting genuine
+            // implications: an identical existing edge qualifies.
+            const A = zn('A'), B = zn('B'), C = zn('C');
+            const layout: InstanceLayout = {
+                nodes: [A, B, C], edges: [],
+                constraints: [leftOf(A, B, 20)],
+                groups: [],
+                disjunctiveConstraints: [
+                    new DisjunctiveConstraint(SRC, [
+                        [leftOf(A, B, 20)],
+                        [leftOf(B, A, 5)],
+                    ]),
+                ],
+            };
+            const v = rig(layout);
+            expect(v.validateConstraints()).toBeNull();
+            expect(entailed(v, 'A', 'B')).toBe(20);
+            expect(v.hGraph.hasEdge('B', 'A')).toBe(false); // the reverse was not taken
+        });
+    });
 });

--- a/tests/helpers/constraint-arbitraries.ts
+++ b/tests/helpers/constraint-arbitraries.ts
@@ -17,8 +17,8 @@ import { makeNode, leftOf, aboveOf, alignOnX, alignOnY, negativeLeftOf, negative
 
 // ─── Node pool ──────────────────────────────────────────────────────────────
 
-/** Generate a pool of N nodes with random dimensions. */
-export function arbNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
+/** Pool of N independently-sized nodes. */
+function arbVariedNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
     return fc.tuple(
         ...Array.from({ length: n }, (_, i) =>
             fc.record({
@@ -26,6 +26,33 @@ export function arbNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
                 h: fc.integer({ min: 20, max: 120 }),
             }).map(({ w, h }) => makeNode(`N${i}`, w, h))
         )
+    );
+}
+
+/** Pool of N nodes that all share one size. */
+function arbUniformNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
+    return fc.record({
+        w: fc.integer({ min: 20, max: 200 }),
+        h: fc.integer({ min: 20, max: 120 }),
+    }).map(({ w, h }) =>
+        Array.from({ length: n }, (_, i) => makeNode(`N${i}`, w, h))
+    );
+}
+
+/**
+ * Generate a pool of N nodes.
+ *
+ * Mostly varied sizes, which is what real diagrams have (box width comes from
+ * label text) and what separates the "starts before" and "clears" readings of
+ * an ordering. A minority are UNIFORM: drawing independently from 20..200 makes
+ * an all-equal pool vanishingly unlikely, yet that is the degenerate case where
+ * the two readings coincide, so it needs to be hit on purpose rather than left
+ * to chance.
+ */
+export function arbNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
+    return fc.oneof(
+        { arbitrary: arbVariedNodePool(n), weight: 4 },
+        { arbitrary: arbUniformNodePool(n), weight: 1 },
     );
 }
 
@@ -43,15 +70,32 @@ export function arbPair(n: number): fc.Arbitrary<[number, number]> {
 
 // ─── Atomic constraint generators ───────────────────────────────────────────
 
+/**
+ * Random separation gap.
+ *
+ * The DSL builders default to 15 and `negativeLeftOf` hard-codes 0, so before
+ * this the whole generated suite used exactly two gap values. That matters most
+ * for the modal queries: `isProperlyBefore` compares a summed path weight
+ * against a single node size, so it is the gap-to-size ratio that decides the
+ * answer, and node sizes range over 20..200. 0 is included deliberately — it is
+ * the boundary where the forced separation is exactly one box, so the pair
+ * touches and is NOT "before" under the strict mechanized definition.
+ */
+export const arbGap: fc.Arbitrary<number> = fc.oneof(
+    { arbitrary: fc.constant(0), weight: 1 },   // touching: the strictness boundary
+    { arbitrary: fc.constant(15), weight: 2 },  // the historical default
+    { arbitrary: fc.integer({ min: 1, max: 40 }), weight: 3 },
+);
+
 /** Random ordering constraint: A <x B, B <x A, A <y B, or B <y A. */
 export function arbOrdering(nodes: LayoutNode[]): fc.Arbitrary<LayoutConstraint> {
-    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 0, max: 3 })).map(([[i, j], type]) => {
+    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 0, max: 3 }), arbGap).map(([[i, j], type, gap]) => {
         switch (type) {
-            case 0: return leftOf(nodes[i], nodes[j]);
-            case 1: return leftOf(nodes[j], nodes[i]);
-            case 2: return aboveOf(nodes[i], nodes[j]);
-            case 3: return aboveOf(nodes[j], nodes[i]);
-            default: return leftOf(nodes[i], nodes[j]);
+            case 0: return leftOf(nodes[i], nodes[j], gap);
+            case 1: return leftOf(nodes[j], nodes[i], gap);
+            case 2: return aboveOf(nodes[i], nodes[j], gap);
+            case 3: return aboveOf(nodes[j], nodes[i], gap);
+            default: return leftOf(nodes[i], nodes[j], gap);
         }
     });
 }
@@ -85,13 +129,13 @@ export function arbAlignment(nodes: LayoutNode[]): fc.Arbitrary<LayoutConstraint
 
 /** Random conjunctive constraint (ordering or alignment). */
 export function arbConjunctive(nodes: LayoutNode[]): fc.Arbitrary<LayoutConstraint> {
-    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 0, max: 3 })).map(([[i, j], type]) => {
+    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 0, max: 3 }), arbGap).map(([[i, j], type, gap]) => {
         switch (type) {
-            case 0: return leftOf(nodes[i], nodes[j]);
-            case 1: return aboveOf(nodes[i], nodes[j]);
+            case 0: return leftOf(nodes[i], nodes[j], gap);
+            case 1: return aboveOf(nodes[i], nodes[j], gap);
             case 2: return alignOnX(nodes[i], nodes[j]);
             case 3: return alignOnY(nodes[i], nodes[j]);
-            default: return leftOf(nodes[i], nodes[j]);
+            default: return leftOf(nodes[i], nodes[j], gap);
         }
     });
 }
@@ -100,12 +144,12 @@ export function arbConjunctive(nodes: LayoutNode[]): fc.Arbitrary<LayoutConstrai
 
 /** Random disjunction with 2–4 ordering alternatives between a pair. */
 export function arbDisjunction(nodes: LayoutNode[]): fc.Arbitrary<DisjunctiveConstraint> {
-    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 2, max: 4 })).map(([[i, j], numAlts]) => {
+    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 2, max: 4 }), arbGap).map(([[i, j], numAlts, gap]) => {
         const allAlts: LayoutConstraint[][] = [
-            [leftOf(nodes[i], nodes[j])],
-            [leftOf(nodes[j], nodes[i])],
-            [aboveOf(nodes[i], nodes[j])],
-            [aboveOf(nodes[j], nodes[i])],
+            [leftOf(nodes[i], nodes[j], gap)],
+            [leftOf(nodes[j], nodes[i], gap)],
+            [aboveOf(nodes[i], nodes[j], gap)],
+            [aboveOf(nodes[j], nodes[i], gap)],
         ];
         return new DisjunctiveConstraint(SRC, allAlts.slice(0, numAlts));
     });
@@ -113,13 +157,46 @@ export function arbDisjunction(nodes: LayoutNode[]): fc.Arbitrary<DisjunctiveCon
 
 /** Random disjunction that may include alignment alternatives. */
 export function arbRichDisjunction(nodes: LayoutNode[]): fc.Arbitrary<DisjunctiveConstraint> {
-    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 2, max: 5 })).map(([[i, j], numAlts]) => {
+    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 2, max: 5 }), arbGap).map(([[i, j], numAlts, gap]) => {
         const allAlts: LayoutConstraint[][] = [
-            [leftOf(nodes[i], nodes[j])],
-            [leftOf(nodes[j], nodes[i])],
-            [aboveOf(nodes[i], nodes[j])],
-            [aboveOf(nodes[j], nodes[i])],
+            [leftOf(nodes[i], nodes[j], gap)],
+            [leftOf(nodes[j], nodes[i], gap)],
+            [aboveOf(nodes[i], nodes[j], gap)],
+            [aboveOf(nodes[j], nodes[i], gap)],
             [alignOnX(nodes[i], nodes[j])],
+        ];
+        return new DisjunctiveConstraint(SRC, allAlts.slice(0, numAlts));
+    });
+}
+
+/**
+ * Random disjunction whose alternatives are CONJUNCTIONS of two orderings over
+ * two different pairs.
+ *
+ * arbDisjunction and arbRichDisjunction both emit singleton alternatives over a
+ * single pair, so no generated disjunction could ever fail partway through an
+ * alternative: the first constraint either went in or it did not. Multi-
+ * constraint alternatives are what reach the partial-assignment undo path —
+ * add constraint 1, reject constraint 2, roll back constraint 1 — which is
+ * where #520's edge-deletion bug lived. Only a hand-written generator covered
+ * it before.
+ *
+ * Alternatives deliberately reuse the same pairs in different directions, so
+ * some rollbacks release an edge another alternative or the base set still
+ * claims.
+ */
+export function arbCompoundDisjunction(nodes: LayoutNode[]): fc.Arbitrary<DisjunctiveConstraint> {
+    return fc.tuple(
+        arbPair(nodes.length),
+        arbPair(nodes.length),
+        fc.integer({ min: 2, max: 3 }),
+        arbGap,
+        arbGap,
+    ).map(([[i, j], [k, l], numAlts, gap1, gap2]) => {
+        const allAlts: LayoutConstraint[][] = [
+            [leftOf(nodes[i], nodes[j], gap1), aboveOf(nodes[k], nodes[l], gap2)],
+            [leftOf(nodes[j], nodes[i], gap1), aboveOf(nodes[l], nodes[k], gap2)],
+            [aboveOf(nodes[i], nodes[j], gap2), leftOf(nodes[l], nodes[k], gap1)],
         ];
         return new DisjunctiveConstraint(SRC, allAlts.slice(0, numAlts));
     });

--- a/tests/helpers/constraint-dsl.ts
+++ b/tests/helpers/constraint-dsl.ts
@@ -52,12 +52,15 @@ function makeNode(id: string, width: number, height: number): LayoutNode {
     };
 }
 
-function leftOf(a: LayoutNode, b: LayoutNode): LeftConstraint {
-    return { left: a, right: b, minDistance: 15, sourceConstraint: SRC };
+/** Default gap. Kept as the default so existing fixtures are unchanged. */
+const DEFAULT_GAP = 15;
+
+function leftOf(a: LayoutNode, b: LayoutNode, minDistance = DEFAULT_GAP): LeftConstraint {
+    return { left: a, right: b, minDistance, sourceConstraint: SRC };
 }
 
-function aboveOf(a: LayoutNode, b: LayoutNode): TopConstraint {
-    return { top: a, bottom: b, minDistance: 15, sourceConstraint: SRC };
+function aboveOf(a: LayoutNode, b: LayoutNode, minDistance = DEFAULT_GAP): TopConstraint {
+    return { top: a, bottom: b, minDistance, sourceConstraint: SRC };
 }
 
 function alignOnX(a: LayoutNode, b: LayoutNode): AlignmentConstraint {

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -628,7 +628,8 @@ export type OracleProp =
     | { kind: 'coordGe'; axis: 'x' | 'y'; a: string; b: string }      // coord_a ≥ coord_b
     | { kind: 'properBefore'; axis: 'x' | 'y'; a: string; b: string } // coord_a + size_a ≤ coord_b
     | { kind: 'coordEq'; axis: 'x' | 'y'; a: string; b: string }      // coord_a = coord_b
-    | { kind: 'coordNeq'; axis: 'x' | 'y'; a: string; b: string };    // coord_a ≠ coord_b
+    | { kind: 'coordNeq'; axis: 'x' | 'y'; a: string; b: string }     // coord_a ≠ coord_b
+    | { kind: 'notProperBefore'; axis: 'x' | 'y'; a: string; b: string }; // coord_a + size_a ≥ coord_b
 
 function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool {
     const ctx = z3Ctx;
@@ -651,6 +652,8 @@ function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool 
         case 'properBefore': return coord(p.a).add(size(p.a)).le(coord(p.b));
         case 'coordEq': return coord(p.a).eq(coord(p.b));
         case 'coordNeq': return ctx.Not(coord(p.a).eq(coord(p.b)));
+        // Negation of properBefore — the refutation probe for a must-claim.
+        case 'notProperBefore': return coord(p.a).add(size(p.a)).ge(coord(p.b));
     }
 }
 

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -613,14 +613,53 @@ async function checkedSolve(solver: any, what: string): Promise<boolean> {
     return result === 'sat';
 }
 
+// ─── Modal propositions ─────────────────────────────────────────────────
+//
+// Atomic geometric propositions that can be conjoined onto the full model.
+// These are the building blocks for entailment cross-checks of the
+// validator's modal query API (getMust / getCannot / getCan / *Aligned):
+//   must P    ⟺  UNSAT(model ∧ ¬P)
+//   cannot P  ⟺  UNSAT(model ∧ P)
+//   can P     ⟺  SAT(model ∧ P)
+// `axis: 'x'` reads coordinates from the x vars and sizes from widths;
+// `axis: 'y'` from y vars and heights.
+export type OracleProp =
+    | { kind: 'coordLt'; axis: 'x' | 'y'; a: string; b: string }      // coord_a < coord_b
+    | { kind: 'coordGe'; axis: 'x' | 'y'; a: string; b: string }      // coord_a ≥ coord_b
+    | { kind: 'properBefore'; axis: 'x' | 'y'; a: string; b: string } // coord_a + size_a ≤ coord_b
+    | { kind: 'coordEq'; axis: 'x' | 'y'; a: string; b: string }      // coord_a = coord_b
+    | { kind: 'coordNeq'; axis: 'x' | 'y'; a: string; b: string };    // coord_a ≠ coord_b
+
+function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool {
+    const ctx = z3Ctx;
+    const coord = (id: string) => vars.get(varName(id, p.axis));
+    const size = (id: string): number => {
+        const n = layout.nodes.find(node => node.id === id);
+        if (!n) throw new Z3OracleError(`Unknown node in oracle proposition: ${id}`);
+        return p.axis === 'x' ? n.width : n.height;
+    };
+    switch (p.kind) {
+        case 'coordLt': return coord(p.a).lt(coord(p.b));
+        case 'coordGe': return coord(p.a).ge(coord(p.b));
+        case 'properBefore': return coord(p.a).add(size(p.a)).le(coord(p.b));
+        case 'coordEq': return coord(p.a).eq(coord(p.b));
+        case 'coordNeq': return ctx.Not(coord(p.a).eq(coord(p.b)));
+    }
+}
+
 function buildModelChecked(
     layout: InstanceLayout,
     what: string,
     constraintOverride?: LayoutConstraint[],
+    extraProps?: OracleProp[],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): { solver: any; vars: VarMap } {
     try {
-        return buildModel(layout, constraintOverride);
+        const built = buildModel(layout, constraintOverride);
+        for (const p of extraProps ?? []) {
+            built.solver.add(compileProp(p, layout, built.vars));
+        }
+        return built;
     } catch (e) {
         // Once the runtime has aborted, even AST construction throws — this is
         // the path that produced instant bogus "counterexamples" in CI.
@@ -635,8 +674,9 @@ async function attemptSolve(
     layout: InstanceLayout,
     what: string,
     constraintOverride?: LayoutConstraint[],
+    extraProps?: OracleProp[],
 ): Promise<boolean> {
-    const { solver } = buildModelChecked(layout, what, constraintOverride);
+    const { solver } = buildModelChecked(layout, what, constraintOverride, extraProps);
     return checkedSolve(solver, what);
 }
 
@@ -644,11 +684,12 @@ async function runSolve(
     layout: InstanceLayout,
     what: string,
     constraintOverride?: LayoutConstraint[],
+    extraProps?: OracleProp[],
 ): Promise<boolean> {
     assertNotPoisoned();
     await maybeRecycle();
     try {
-        return await attemptSolve(layout, what, constraintOverride);
+        return await attemptSolve(layout, what, constraintOverride, extraProps);
     } catch (e) {
         if (!(e instanceof Z3UnknownError) || poisonedBy) throw e;
         // A clean 'unknown' (memory ceiling, timeout) from a part-filled heap
@@ -660,7 +701,7 @@ async function runSolve(
         // eslint-disable-next-line no-console
         console.error(`[z3-oracle] retrying ${what} on a fresh module after: ${e}`);
         await recycleZ3(`'unknown' during ${what}`);
-        return attemptSolve(layout, what, constraintOverride);
+        return attemptSolve(layout, what, constraintOverride, extraProps);
     }
 }
 
@@ -683,4 +724,17 @@ export async function verifyFeasibleSubset(
     subset: LayoutConstraint[],
 ): Promise<boolean> {
     return runSolve(layout, 'verifyFeasibleSubset', subset);
+}
+
+/**
+ * Solve the FULL model (constraints, disjunctions, groups, non-overlap)
+ * conjoined with extra atomic propositions. This is the entailment probe
+ * for modal queries: `must P` holds iff solveZ3With(layout, [¬P]) is false;
+ * `can P` holds iff solveZ3With(layout, [P]) is true.
+ */
+export async function solveZ3With(
+    layout: InstanceLayout,
+    props: OracleProp[],
+): Promise<boolean> {
+    return runSolve(layout, 'solveZ3With', undefined, props);
 }

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -626,7 +626,7 @@ async function checkedSolve(solver: any, what: string): Promise<boolean> {
 export type OracleProp =
     | { kind: 'coordLt'; axis: 'x' | 'y'; a: string; b: string }      // coord_a < coord_b
     | { kind: 'coordGe'; axis: 'x' | 'y'; a: string; b: string }      // coord_a ≥ coord_b
-    | { kind: 'properBefore'; axis: 'x' | 'y'; a: string; b: string } // coord_a + size_a ≤ coord_b
+    | { kind: 'properBefore'; axis: 'x' | 'y'; a: string; b: string } // coord_a + size_a < coord_b
     | { kind: 'coordEq'; axis: 'x' | 'y'; a: string; b: string }      // coord_a = coord_b
     | { kind: 'coordNeq'; axis: 'x' | 'y'; a: string; b: string }     // coord_a ≠ coord_b
     | { kind: 'notProperBefore'; axis: 'x' | 'y'; a: string; b: string }; // coord_a + size_a ≥ coord_b
@@ -649,7 +649,16 @@ function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool 
     switch (p.kind) {
         case 'coordLt': return coord(p.a).lt(coord(p.b));
         case 'coordGe': return coord(p.a).ge(coord(p.b));
-        case 'properBefore': return coord(p.a).add(size(p.a)).le(coord(p.b));
+        // Strict, matching the mechanized definition
+        //   leftOf b₁ b₂ := b₁.x_tl + b₁.width < b₂.x_tl
+        // and making this the exact complement of notProperBefore below.
+        // A non-strict `le` here would let a TOUCHING pair (coord_a + size_a =
+        // coord_b) satisfy both props at once, so a cannot-claim could be
+        // "refuted" by a model that does not actually place a before b, and the
+        // can-side exactness check would test a weaker relation than it claims.
+        // Reachable only via zero-gap orderings, where the forced separation is
+        // exactly one box — see the negative-orientation modal tests.
+        case 'properBefore': return coord(p.a).add(size(p.a)).lt(coord(p.b));
         case 'coordEq': return coord(p.a).eq(coord(p.b));
         case 'coordNeq': return ctx.Not(coord(p.a).eq(coord(p.b)));
         // Negation of properBefore — the refutation probe for a must-claim.

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -632,7 +632,14 @@ export type OracleProp =
 
 function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool {
     const ctx = z3Ctx;
-    const coord = (id: string) => vars.get(varName(id, p.axis));
+    const coord = (id: string) => {
+        const v = vars.get(varName(id, p.axis));
+        // Without this the caller gets "cannot read properties of undefined
+        // (reading 'lt')" from inside compileProp, which reads like an oracle
+        // crash rather than a bad probe. Mirrors size() below.
+        if (!v) throw new Z3OracleError(`Unknown node in oracle proposition: ${id} (no ${p.axis} var)`);
+        return v;
+    };
     const size = (id: string): number => {
         const n = layout.nodes.find(node => node.id === id);
         if (!n) throw new Z3OracleError(`Unknown node in oracle proposition: ${id}`);

--- a/tests/layout-evaluator.test.ts
+++ b/tests/layout-evaluator.test.ts
@@ -323,6 +323,57 @@ describe('Modal spatial queries (must/can/cannot)', () => {
             expect(v.getAlignedWith('B', 'x')).toEqual(new Set(['A']));
         });
     });
+
+    describe('Rejected layouts answer no modal facts', () => {
+        // The must-graph snapshots are taken at Phase 4b, before CDCL, so they
+        // survive a later failure. Since #518 made modal state lazy, a rejected
+        // layout could still answer must/cannot — describing a constraint
+        // system enforceMaximalFeasibleSubset had already replaced on the
+        // layout. Note getCannot/getCannotAligned read the must-graphs
+        // DIRECTLY, so gating only the lazy build does not close this; the
+        // snapshots must be cleared on the error path.
+        //
+        // The baseline is a never-validated validator (empty for getMust,
+        // reflexive {self} for getCannot) — a rejected layout must match it.
+
+        const [a, b, c] = ['A', 'B', 'C'].map(createNode);
+        const baseline = () =>
+            new QualitativeConstraintValidator(layout([a, b, c], [], undefined, []));
+
+        it('CDCL-UNSAT layout answers exactly as a never-validated one', () => {
+            // Base A <x B commits before the snapshot; every alternative of the
+            // disjunction closes a cycle with it, so CDCL fails afterwards.
+            const src = new RelativeOrientationConstraint(['left'], 'unsat');
+            const rev = (d: number) => ({ left: b, right: a, minDistance: d, sourceConstraint: src });
+            const v = new QualitativeConstraintValidator(
+                layout([a, b, c], [leftOf(a, b)], [disjunction(src, [[rev(15)], [rev(5)]])]),
+            );
+            expect(v.validateConstraints()).not.toBeNull();
+
+            const ref = baseline();
+            expect(v.getMust('B', 'leftOf')).toEqual(ref.getMust('B', 'leftOf'));
+            // Would be {B, A} if the pre-CDCL snapshot leaked through.
+            expect(v.getCannot('B', 'rightOf')).toEqual(ref.getCannot('B', 'rightOf'));
+            expect(v.getCannotAligned('B', 'x')).toEqual(ref.getCannotAligned('B', 'x'));
+        });
+
+        it('conjunctively infeasible layout answers exactly as a never-validated one', () => {
+            const v = new QualitativeConstraintValidator(
+                layout([a, b, c], [leftOf(a, b), leftOf(b, a)]),
+            );
+            expect(v.validateConstraints()).not.toBeNull();
+
+            const ref = baseline();
+            expect(v.getMust('B', 'leftOf')).toEqual(ref.getMust('B', 'leftOf'));
+            expect(v.getCannot('B', 'rightOf')).toEqual(ref.getCannot('B', 'rightOf'));
+        });
+
+        it('a never-validated validator answers defaults (empty must, reflexive cannot)', () => {
+            const ref = baseline();
+            expect(ref.getMust('B', 'leftOf')).toEqual(new Set());
+            expect(ref.getCannot('B', 'rightOf')).toEqual(new Set(['B']));
+        });
+    });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/layout-evaluator.test.ts
+++ b/tests/layout-evaluator.test.ts
@@ -373,6 +373,47 @@ describe('Modal spatial queries (must/can/cannot)', () => {
             expect(ref.getMust('B', 'leftOf')).toEqual(new Set());
             expect(ref.getCannot('B', 'rightOf')).toEqual(new Set(['B']));
         });
+
+        // getMust reads the DERIVED pair sets while getCannot reads the graphs,
+        // so state has to be reset as a whole — clearing either half alone
+        // leaves the other answering. These cover re-validation and dispose.
+
+        it('a failing re-validation drops the previous run facts', () => {
+            const constraints = [leftOf(a, b)];
+            const v = new QualitativeConstraintValidator(layout([a, b, c], constraints));
+            expect(v.validateConstraints()).toBeNull();
+            expect(v.getMust('A', 'rightOf')).toEqual(new Set(['B'])); // builds modal state
+
+            constraints.push(leftOf(b, a)); // close a cycle on the captured array
+            expect(v.validateConstraints()).not.toBeNull();
+
+            expect(v.getMust('A', 'rightOf')).toEqual(new Set());
+            expect(v.getCannot('A', 'rightOf')).toEqual(new Set(['A']));
+        });
+
+        it('a succeeding re-validation reflects the new system, not the old', () => {
+            const constraints = [leftOf(a, b)];
+            const v = new QualitativeConstraintValidator(layout([a, b, c], constraints));
+            expect(v.validateConstraints()).toBeNull();
+            expect(v.getMust('A', 'rightOf')).toEqual(new Set(['B']));
+
+            constraints.push(leftOf(b, c)); // now A is also left of C, transitively
+            expect(v.validateConstraints()).toBeNull();
+
+            // Stale state would still report just {B}.
+            expect(v.getMust('A', 'rightOf')).toEqual(new Set(['B', 'C']));
+        });
+
+        it('dispose() stops modal getters answering', () => {
+            const v = new QualitativeConstraintValidator(layout([a, b, c], [leftOf(a, b)]));
+            expect(v.validateConstraints()).toBeNull();
+            expect(v.getMust('A', 'rightOf')).toEqual(new Set(['B']));
+
+            v.dispose();
+
+            expect(v.getMust('A', 'rightOf')).toEqual(new Set());
+            expect(v.getCannot('A', 'rightOf')).toEqual(new Set(['A']));
+        });
     });
 });
 

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -36,6 +36,7 @@ import {
     aboveOf,
     alignOnX,
     alignOnY,
+    makeNode,
     parseConstraintSpec,
     SRC,
 } from './helpers/constraint-dsl';
@@ -52,7 +53,7 @@ import {
     arbMixedOrdering,
     arbGroup,
 } from './helpers/constraint-arbitraries';
-import type { LayoutGroup } from '../src/layout/interfaces';
+import type { LayoutGroup, LayoutNode } from '../src/layout/interfaces';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -304,6 +305,76 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
                         }
                     }
                     const layout = buildLayout(nodes, [], disjs);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: 30, timeout: TIMEOUT });
+        });
+
+        // ── Duplicate-pair alternatives (edge undo integrity) ──────────
+        // Alternatives that DUPLICATE a base constraint's pair (with an equal
+        // or smaller distance) exercise addEdge's redundant path; combined
+        // with a cycle-closing reversal in the same alternative, the undo of
+        // the failed tryAssign used to blind-delete the shared base edge,
+        // corrupting the graph mid-search (SAT verdicts with cyclic committed
+        // sets). The plain generators above never emit duplicate pairs, which
+        // is how this survived them.
+
+        it('duplicate + cycle-closer alternative deletes no base edge — UNSAT (Z3 cross-check)', async () => {
+            const N0 = makeNode('N0', 52, 89), N3 = makeNode('N3', 89, 85);
+            const N1 = makeNode('N1', 60, 40), N2 = makeNode('N2', 60, 40);
+            const dup = (a: LayoutNode, b: LayoutNode, d: number): LayoutConstraint =>
+                ({ left: a, right: b, minDistance: d, sourceConstraint: SRC });
+            const layout = buildLayout(
+                [N0, N1, N2, N3],
+                [dup(N0, N3, 20)],
+                [new DisjunctiveConstraint(SRC, [
+                    [dup(N0, N3, 13), dup(N3, N0, 5)],
+                    [dup(N3, N0, 5), dup(N1, N2, 5)],
+                ])],
+            );
+            const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+            assertAgreement(layout, validatorSat, oracleSat);
+            expect(validatorSat).toBe(false);
+        });
+
+        it('random duplicate-pair and reversed-pair alternatives (Z3 cross-check)', async () => {
+            const dupOf = (c: LayoutConstraint, delta: number): LayoutConstraint => {
+                const anyC = c as any;
+                return anyC.left
+                    ? { left: anyC.left, right: anyC.right, minDistance: Math.max(0, anyC.minDistance - delta), sourceConstraint: SRC }
+                    : { top: anyC.top, bottom: anyC.bottom, minDistance: Math.max(0, anyC.minDistance - delta), sourceConstraint: SRC };
+            };
+            const revOf = (c: LayoutConstraint, d: number): LayoutConstraint => {
+                const anyC = c as any;
+                return anyC.left
+                    ? { left: anyC.right, right: anyC.left, minDistance: d, sourceConstraint: SRC }
+                    : { top: anyC.bottom, bottom: anyC.top, minDistance: d, sourceConstraint: SRC };
+            };
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(4).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 1, maxLength: 2 }),
+                        fc.array(fc.record({
+                            baseIdx: fc.nat(3),
+                            dupDelta: fc.nat(15),
+                            revDist: fc.nat(20),
+                            benign: arbOrdering(nodes),
+                            benignOnlySecond: fc.boolean(),
+                        }), { minLength: 1, maxLength: 3 }),
+                    )
+                ),
+                async ([nodes, base, specs]) => {
+                    const disjs = specs.map(spec => {
+                        const target = base[spec.baseIdx % base.length];
+                        const altA = [dupOf(target, spec.dupDelta), revOf(target, spec.revDist)];
+                        const altB = spec.benignOnlySecond
+                            ? [spec.benign, dupOf(target, spec.dupDelta)]
+                            : [revOf(target, spec.revDist), spec.benign];
+                        return new DisjunctiveConstraint(SRC, [altA, altB]);
+                    });
+                    const layout = buildLayout(nodes, base, disjs);
                     const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
                     assertAgreement(layout, validatorSat, oracleSat);
                 }

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -65,8 +65,19 @@ async function checkAgainstOracle(layout: InstanceLayout): Promise<{
     const error = validator.validateConstraints();
     const validatorSat = error === null;
     let oracleSat: boolean;
+    let committedSat = true;
     try {
         oracleSat = await solveZ3(layout);
+
+        // On SAT the validator has committed its chosen disjunct alternatives
+        // plus implicit alignment orders into layoutV.constraints. Boolean
+        // agreement alone would miss a solver that answers SAT while committing
+        // an inconsistent set — so verify the committed conjunctive system too.
+        // (Group bbox variables are unconstrained in this relaxed check, so it
+        // can only under-report inconsistency, never false-alarm.)
+        if (validatorSat) {
+            committedSat = await verifyFeasibleSubset(layoutV, layoutV.constraints);
+        }
     } catch (e) {
         // Log the real cause directly: fast-check wraps predicate errors and
         // the reporter can drop the cause chain, leaving only a meaningless
@@ -76,6 +87,13 @@ async function checkAgainstOracle(layout: InstanceLayout): Promise<{
             `  ${describeLayout(layout)}`
         );
         throw e;
+    }
+    if (!committedSat) {
+        const detail =
+            `Validator said SAT but its committed constraint set is UNSAT per Z3 ` +
+            `(${layoutV.constraints.length} constraints)\n  ${describeLayout(layout)}`;
+        console.error(`[z3-oracle] ${detail}`);
+        throw new Error(detail);
     }
     return { validatorSat, oracleSat };
 }

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -52,6 +52,7 @@ import {
     arbNegativeOrdering,
     arbMixedOrdering,
     arbGroup,
+    arbCompoundDisjunction,
 } from './helpers/constraint-arbitraries';
 import type { LayoutGroup, LayoutNode } from '../src/layout/interfaces';
 
@@ -375,6 +376,47 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
                         return new DisjunctiveConstraint(SRC, [altA, altB]);
                     });
                     const layout = buildLayout(nodes, base, disjs);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: 30, timeout: TIMEOUT });
+        });
+
+        // ── Multi-constraint alternatives (partial-assignment undo) ────
+        // Every other generator emits SINGLETON alternatives, so an
+        // alternative could never fail halfway: constraint 1 either went in or
+        // it did not. These carry two constraints over two pairs, so the
+        // solver regularly adds the first, rejects the second, and must roll
+        // the first back cleanly — the path #520's blind edge-delete corrupted.
+
+        it('random compound (2-constraint) alternatives on 4 nodes (Z3 cross-check)', async () => {
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(4).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 3 }),
+                        fc.array(arbCompoundDisjunction(nodes), { minLength: 1, maxLength: 3 }),
+                    )
+                ),
+                async ([nodes, constraints, disjs]) => {
+                    const layout = buildLayout(nodes, constraints, disjs);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: NUM_RUNS, timeout: TIMEOUT });
+        });
+
+        it('random compound alternatives on 5 nodes, denser (Z3 cross-check)', async () => {
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(5).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 1, maxLength: 4 }),
+                        fc.array(arbCompoundDisjunction(nodes), { minLength: 2, maxLength: 4 }),
+                    )
+                ),
+                async ([nodes, constraints, disjs]) => {
+                    const layout = buildLayout(nodes, constraints, disjs);
                     const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
                     assertAgreement(layout, validatorSat, oracleSat);
                 }

--- a/tests/z3-modal-equivalence.test.ts
+++ b/tests/z3-modal-equivalence.test.ts
@@ -20,10 +20,16 @@
  *     The two readings agree only when every node is the same size on the
  *     axis, so a uniform-size fixture cannot tell them apart.
  *   - cannot/can "Y left of X" is probed as proper placement:
- *     x_Y + w_Y ≤ x_X. The system is pure difference bounds (no upper
+ *     x_Y + w_Y < x_X. The system is pure difference bounds (no upper
  *     bounds), so a model with x_Y < x_X can always be stretched into one
  *     with proper separation — "can be strictly before" ⟺ "can be
  *     properly before" — which makes this probe exact, not conservative.
+ *     Both probes are STRICT, so properBefore and notProperBefore are exact
+ *     complements. A non-strict ≤ would admit a touching pair
+ *     (x_Y + w_Y = x_X) as "before" on the can-side while the must-side
+ *     refutation treats the same model as NOT before. Zero-gap orderings
+ *     force exactly that model, so the gap is reachable, not academic —
+ *     'oracle probes are exact complements' below pins it down.
  *
  * Soundness (claimed must/cannot facts hold per Z3) is always asserted.
  * Exactness of the can-side (no over-claimed "can") is asserted only where
@@ -36,10 +42,23 @@
 
 import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
 
-vi.setConfig({ testTimeout: 120_000 });
+/**
+ * Property size and seed. Defaults are the CI gate: deterministic, and sized
+ * so the whole file stays well inside the Z3 module's recycle budget. Raise
+ * both to search rather than to regression-test, e.g.
+ *   Z3_MODAL_RUNS=400 Z3_MODAL_SEED=$RANDOM npx vitest run tests/z3-modal-equivalence.test.ts
+ */
+const MODAL_RUNS = Number(process.env.Z3_MODAL_RUNS ?? 30);
+const MODAL_SEED = Number(process.env.Z3_MODAL_SEED ?? 20260727);
+
+// A modal case costs one Z3 solve per node pair per axis, so run time is
+// roughly linear in MODAL_RUNS. A fixed ceiling would turn any raise of
+// MODAL_RUNS into a timeout that reads like a hang, so scale with it and keep
+// 120s as the floor for the default size.
+vi.setConfig({ testTimeout: Math.max(120_000, MODAL_RUNS * 4_000) });
 import * as fc from 'fast-check';
 import { QualitativeConstraintValidator } from '../src/layout/qualitative-constraint-validator';
-import { InstanceLayout } from '../src/layout/interfaces';
+import { InstanceLayout, LayoutGroup } from '../src/layout/interfaces';
 import {
     isZ3Available,
     shutdownZ3,
@@ -51,6 +70,13 @@ import {
     cloneLayout,
     describeLayout,
     parseConstraintSpec,
+    makeNode,
+    leftOf,
+    aboveOf,
+    alignOnX,
+    alignOnY,
+    negativeLeftOf,
+    GBF,
 } from './helpers/constraint-dsl';
 import {
     arbNodePool,
@@ -104,6 +130,27 @@ async function checkModalAgainstOracle(
             expect(validator.getCannot(X, 'above').has(Y)).toBe(validator.getCannot(Y, 'below').has(X));
             expect(validator.getMustAligned(X, 'x').has(Y)).toBe(validator.getMustAligned(Y, 'x').has(X));
             expect(validator.getMustAligned(X, 'y').has(Y)).toBe(validator.getMustAligned(Y, 'y').has(X));
+        }
+    }
+
+    // ── getReachable (resolved model) vs getMust (all models) ──────────
+    // getReachable answers over the constraint set the CDCL committed to;
+    // getMust answers over the whole program. With no disjunctions and no
+    // groups there is nothing to commit, so the two sets are IDENTICAL — and
+    // since every getMust claim is Z3-checked below, this pins getReachable to
+    // Z3 too, for free. #524 rewrote all four of its cases and nothing else
+    // covers them.
+    // (With disjunctions the committed set is a strengthening, so getReachable
+    // is a superset and only ⊇ would hold — not asserted here.)
+    const resolvedIsFullProgram =
+        !layout.disjunctiveConstraints?.length && !layout.groups?.length;
+    if (resolvedIsFullProgram) {
+        for (const rel of ['leftOf', 'rightOf', 'above', 'below'] as const) {
+            for (const X of ids) {
+                const reach = validator.getReachable(X, rel);
+                const must = validator.getMust(X, rel);
+                expect([...reach].sort()).toEqual([...must].sort());
+            }
         }
     }
 
@@ -254,7 +301,116 @@ describe.runIf(available)('Modal query entailment vs Z3', () => {
         expect(await solveZ3With(layout, [{ kind: 'coordGe', axis: 'x', a: 'W', b: 'X' }])).toBe(false);
     });
 
-    // ─── Randomized (fixed seed → deterministic in CI) ──────────────────
+    // ─── The zero-gap (touching) boundary ───────────────────────────────
+    // A minDistance=0 ordering forces exactly one box of separation:
+    //   x_a + w_a ≤ x_b.
+    // So the pair may TOUCH, and a touching pair is not "left of" under the
+    // mechanized definition (leftOf b₁ b₂ := b₁.x_tl + b₁.width < b₂.x_tl).
+    // isProperlyBefore requires maxWeight > size, and here maxWeight = size
+    // exactly — the single point where the comparison's strictness decides the
+    // answer. No generator emitted zero gaps into the modal suite before this.
+
+    it('oracle probes are exact complements (properBefore / notProperBefore)', async () => {
+        // Guards the oracle itself, not the validator. A non-strict properBefore
+        // (≤) overlaps notProperBefore (≥) at coord_a + size_a = coord_b, which
+        // a zero-gap ordering makes reachable — so asserting both at once must
+        // be UNSAT. If this ever passes with a ≤ encoding, the can-side
+        // exactness check below is silently testing a weaker relation.
+        const a = makeNode('a', 100, 60), b = makeNode('b', 100, 60);
+        const layout = buildLayout([a, b], [negativeLeftOf(a, b)]);
+        expect(await solveZ3With(layout, [
+            { kind: 'properBefore', axis: 'x', a: 'a', b: 'b' },
+            { kind: 'notProperBefore', axis: 'x', a: 'a', b: 'b' },
+        ])).toBe(false);
+    });
+
+    it('zero-gap ordering permits touching, so it is not a must-leftOf', async () => {
+        const a = makeNode('a', 100, 60), b = makeNode('b', 100, 60);
+        const layout = buildLayout([a, b], [negativeLeftOf(a, b)]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        // Forced separation is exactly w_a, which does not CLEAR b.
+        expect(v.getMust('b', 'leftOf').has('a')).toBe(false);
+        // But nothing caps the separation, so it remains achievable.
+        expect(v.getCannot('b', 'leftOf').has('a')).toBe(false);
+        // The reverse is genuinely impossible, and the validator knows it.
+        expect(v.getCannot('a', 'leftOf').has('b')).toBe(true);
+
+        // Z3 confirms both halves.
+        expect(await solveZ3With(layout, [{ kind: 'notProperBefore', axis: 'x', a: 'a', b: 'b' }])).toBe(true);
+        expect(await solveZ3With(layout, [{ kind: 'properBefore', axis: 'x', a: 'a', b: 'b' }])).toBe(true);
+    });
+
+    it('one unit of gap crosses the boundary into a must-leftOf', async () => {
+        // Same shape as above with minDistance=1: separation is now w_a + 1,
+        // which clears b. The pair of tests brackets the comparison exactly.
+        const a = makeNode('a', 100, 60), b = makeNode('b', 100, 60);
+        const layout = buildLayout([a, b], [leftOf(a, b, 1)]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('b', 'leftOf').has('a')).toBe(true);
+    });
+
+    // ─── Separation accumulated along a chain ───────────────────────────
+    // The non-uniform case above has a path of length 1, so it only tests
+    // "one hop's weight vs one node's size". These walk a 3-hop path where the
+    // total is what decides, with the gap as the only difference between a
+    // false and a true answer.
+
+    it('accumulated separation below the wide node stays out of must-leftOf', async () => {
+        // W is x-aligned with N, so it inherits N's outgoing path: two hops of
+        // (20 + 15) = 70 total. W is 300 wide, so W still spans across X.
+        const W = makeNode('W', 300, 60), N = makeNode('N', 20, 60);
+        const M = makeNode('M', 20, 60), X = makeNode('X', 100, 60);
+        const layout = buildLayout([W, N, M, X], [
+            alignOnX(W, N), leftOf(N, M, 15), leftOf(M, X, 15),
+        ]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('X', 'leftOf').has('N')).toBe(true);  // 20 wide, 70 of run-up
+        expect(v.getMust('X', 'leftOf').has('W')).toBe(false); // 300 wide, same 70
+    });
+
+    it('accumulated separation above the wide node enters must-leftOf', async () => {
+        // Identical except the gap: two hops of (20 + 200) = 440 > 300, so the
+        // same W now does clear X. Only the arithmetic changed.
+        const W = makeNode('W', 300, 60), N = makeNode('N', 20, 60);
+        const M = makeNode('M', 20, 60), X = makeNode('X', 100, 60);
+        const layout = buildLayout([W, N, M, X], [
+            alignOnX(W, N), leftOf(N, M, 200), leftOf(M, X, 200),
+        ]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('X', 'leftOf').has('W')).toBe(true);
+    });
+
+    it('the same gap holds on the vertical axis through a y-alignment class', async () => {
+        // Mirror of the horizontal case: T is y-aligned with S (20 tall) and is
+        // itself 300 tall, so S clears C vertically and T does not. Exercises
+        // the vertical graph and height-based sizes.
+        const T = makeNode('T', 60, 300), S = makeNode('S', 60, 20), C = makeNode('C', 60, 60);
+        const layout = buildLayout([T, S, C], [alignOnY(T, S), aboveOf(S, C, 15)]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('C', 'above').has('S')).toBe(true);
+        expect(v.getMust('C', 'above').has('T')).toBe(false);
+    });
+
+    // ─── Randomized ─────────────────────────────────────────────────────
+    // Fixed seed by default so PR CI is a deterministic regression gate. A
+    // fixed-seed property explores the SAME systems on every run and can never
+    // find anything new, so both knobs are overridable: run with
+    // Z3_MODAL_SEED=$RANDOM (and a larger Z3_MODAL_RUNS) to actually search.
 
     it('random conjunctive systems: modal queries exactly match Z3', async () => {
         await fc.assert(fc.asyncProperty(
@@ -268,7 +424,24 @@ describe.runIf(available)('Modal query entailment vs Z3', () => {
                 const layout = buildLayout(nodes, constraints);
                 await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true });
             }
-        ), { numRuns: 8, seed: 20260727, timeout: 120_000 });
+        ), { numRuns: MODAL_RUNS, seed: MODAL_SEED, timeout: 120_000 });
+    });
+
+    it('random conjunctive systems on 5 nodes: modal queries exactly match Z3', async () => {
+        // Wider than the 4-node property: three-hop paths only exist from 5
+        // nodes up, and accumulated separation is what isProperlyBefore reads.
+        await fc.assert(fc.asyncProperty(
+            arbNodePool(5).chain(nodes =>
+                fc.tuple(
+                    fc.constant(nodes),
+                    fc.array(arbConjunctive(nodes), { minLength: 2, maxLength: 7 }),
+                )
+            ),
+            async ([nodes, constraints]) => {
+                const layout = buildLayout(nodes, constraints);
+                await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true });
+            }
+        ), { numRuns: MODAL_RUNS, seed: MODAL_SEED, timeout: 120_000 });
     });
 
     it('random ordering + disjunction systems: modal claims are sound', async () => {
@@ -286,7 +459,32 @@ describe.runIf(available)('Modal query entailment vs Z3', () => {
                 // (see KNOWN INCOMPLETENESS below).
                 await checkModalAgainstOracle(layout, { canExactOrdering: false, canExactAlignment: false });
             }
-        ), { numRuns: 8, seed: 20260727, timeout: 120_000 });
+        ), { numRuns: MODAL_RUNS, seed: MODAL_SEED, timeout: 120_000 });
+    });
+
+    it('random systems with groups: modal claims are sound', async () => {
+        // Groups add bounding-box variables and Rule C member edges, so must
+        // paths can now run THROUGH a bbox. Nothing randomized covered that.
+        // Soundness only: the bbox inclusion disjunction has the same
+        // per-disjunction limit as any other (see KNOWN INCOMPLETENESS below).
+        await fc.assert(fc.asyncProperty(
+            arbNodePool(5).chain(nodes =>
+                fc.tuple(
+                    fc.constant(nodes),
+                    fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 4 }),
+                    fc.integer({ min: 2, max: 3 }),
+                )
+            ),
+            async ([nodes, constraints, gSize]) => {
+                const memberIds = nodes.slice(0, gSize).map(n => n.id);
+                const group: LayoutGroup = {
+                    name: 'G0', nodeIds: memberIds, keyNodeId: memberIds[0],
+                    showLabel: true, sourceConstraint: GBF,
+                };
+                const layout = buildLayout(nodes, constraints, undefined, [group]);
+                await checkModalAgainstOracle(layout, { canExactOrdering: false, canExactAlignment: false });
+            }
+        ), { numRuns: MODAL_RUNS, seed: MODAL_SEED, timeout: 120_000 });
     });
 
     // ─── Known incompleteness ledger ────────────────────────────────────

--- a/tests/z3-modal-equivalence.test.ts
+++ b/tests/z3-modal-equivalence.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Entailment cross-checks between the validator's modal query API
+ * (getMust / getCannot / getCan / getMustAligned / getCannotAligned)
+ * and the Z3 oracle.
+ *
+ * The modal contracts are exact claims over the ORIGINAL constraint program
+ * (all valid layouts, not the one the CDCL happened to commit):
+ *   getMust(X, rel)    — nodes in `rel` to X in ALL valid layouts
+ *   getCannot(X, rel)  — nodes in `rel` to X in NO valid layout
+ *   getCan(X, rel)     — complement of getCannot
+ * Z3 decides these directly on the full model:
+ *   must P    ⟺  UNSAT(model ∧ ¬P)
+ *   cannot P  ⟺  UNSAT(model ∧ P)
+ *
+ * Propositions:
+ *   - must "Y left of X" is probed with its weakest sound reading,
+ *     coord entailment: UNSAT(x_Y ≥ x_X).
+ *   - cannot/can "Y left of X" is probed as proper placement:
+ *     x_Y + w_Y ≤ x_X. The system is pure difference bounds (no upper
+ *     bounds), so a model with x_Y < x_X can always be stretched into one
+ *     with proper separation — "can be strictly before" ⟺ "can be
+ *     properly before" — which makes this probe exact, not conservative.
+ *
+ * Soundness (claimed must/cannot facts hold per Z3) is always asserted.
+ * Exactness of the can-side (no over-claimed "can") is asserted only where
+ * the theory guarantees the must-graph is complete: conjunctive systems,
+ * where reachability in the difference graph plus the dual-axis overlap
+ * rule exactly characterize entailment. With disjunctions the
+ * per-disjunction intersection strengthening misses joint entailment —
+ * see the KNOWN INCOMPLETENESS ledger at the bottom.
+ */
+
+import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 120_000 });
+import * as fc from 'fast-check';
+import { QualitativeConstraintValidator } from '../src/layout/qualitative-constraint-validator';
+import { InstanceLayout } from '../src/layout/interfaces';
+import {
+    isZ3Available,
+    shutdownZ3,
+    solveZ3With,
+    describeOracleStats,
+    OracleProp,
+} from './helpers/z3-oracle';
+import {
+    cloneLayout,
+    describeLayout,
+    parseConstraintSpec,
+} from './helpers/constraint-dsl';
+import {
+    arbNodePool,
+    arbConjunctive,
+    arbOrdering,
+    arbDisjunction,
+    buildLayout,
+} from './helpers/constraint-arbitraries';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+class ModalDisagreement extends Error {}
+
+function fail(layout: InstanceLayout, claim: string): never {
+    const detail = `Modal disagreement: ${claim}\n  ${describeLayout(layout)}`;
+    // Log directly — fast-check wraps predicate errors and the reporter can
+    // drop the cause chain (same rationale as in z3-equivalence.test.ts).
+    console.error(`[z3-oracle] ${detail}`);
+    throw new ModalDisagreement(detail);
+}
+
+/**
+ * Validate `layout`, then cross-check every modal claim against Z3.
+ * Returns false (checking nothing) when the layout is UNSAT — modal
+ * queries are only defined for feasible layouts.
+ *
+ * `canExactOrdering` / `canExactAlignment` additionally assert that the
+ * can-side does not over-claim (every ¬cannot is Z3-SAT), separately for
+ * ordering and alignment claims — the two have different completeness
+ * frontiers (see the KNOWN INCOMPLETENESS tests).
+ */
+async function checkModalAgainstOracle(
+    layout: InstanceLayout,
+    opts: { canExactOrdering: boolean; canExactAlignment: boolean },
+): Promise<boolean> {
+    const layoutV = cloneLayout(layout);
+    const validator = new QualitativeConstraintValidator(layoutV);
+    if (validator.validateConstraints() !== null) return false;
+
+    const ids = layout.nodes.map(n => n.id);
+
+    // ── Structural coherence (no Z3): mirror relations must agree ──────
+    for (const X of ids) {
+        expect(validator.getCannot(X, 'leftOf').has(X)).toBe(true); // reflexive
+        expect(validator.getCannot(X, 'above').has(X)).toBe(true);
+        for (const Y of ids) {
+            if (X === Y) continue;
+            expect(validator.getMust(X, 'leftOf').has(Y)).toBe(validator.getMust(Y, 'rightOf').has(X));
+            expect(validator.getMust(X, 'above').has(Y)).toBe(validator.getMust(Y, 'below').has(X));
+            expect(validator.getCannot(X, 'leftOf').has(Y)).toBe(validator.getCannot(Y, 'rightOf').has(X));
+            expect(validator.getCannot(X, 'above').has(Y)).toBe(validator.getCannot(Y, 'below').has(X));
+            expect(validator.getMustAligned(X, 'x').has(Y)).toBe(validator.getMustAligned(Y, 'x').has(X));
+            expect(validator.getMustAligned(X, 'y').has(Y)).toBe(validator.getMustAligned(Y, 'y').has(X));
+        }
+    }
+
+    // ── Entailment probes ──────────────────────────────────────────────
+    for (const axis of ['x', 'y'] as const) {
+        const rel = axis === 'x' ? 'leftOf' as const : 'above' as const;
+
+        for (const X of ids) {
+            const must = validator.getMust(X, rel);
+            const cannot = validator.getCannot(X, rel);
+            for (const Y of ids) {
+                if (Y === X) continue;
+
+                if (must.has(Y)) {
+                    // Claim: Y strictly before X on this axis in ALL models.
+                    const refuted: OracleProp = { kind: 'coordGe', axis, a: Y, b: X };
+                    if (await solveZ3With(layout, [refuted])) {
+                        fail(layout, `getMust(${X}, ${rel}) claims ${Y}, but Z3 found a model with ${axis}_${Y} ≥ ${axis}_${X}`);
+                    }
+                }
+
+                const placement: OracleProp = { kind: 'properBefore', axis, a: Y, b: X };
+                if (cannot.has(Y)) {
+                    // Claim: no model places Y properly before X.
+                    if (await solveZ3With(layout, [placement])) {
+                        fail(layout, `getCannot(${X}, ${rel}) claims ${Y}, but Z3 placed ${Y} properly before ${X} on ${axis}`);
+                    }
+                } else if (opts.canExactOrdering) {
+                    // Claim (via getCan = ¬getCannot): some model places Y properly before X.
+                    if (!(await solveZ3With(layout, [placement]))) {
+                        fail(layout, `getCan(${X}, ${rel}) claims ${Y}, but Z3 proved ${Y} can never be properly before ${X} on ${axis}`);
+                    }
+                }
+            }
+        }
+
+        // Alignment claims are symmetric — probe unordered pairs once.
+        for (let i = 0; i < ids.length; i++) {
+            const X = ids[i];
+            const mustA = validator.getMustAligned(X, axis);
+            const cannotA = validator.getCannotAligned(X, axis);
+            for (let j = i + 1; j < ids.length; j++) {
+                const Y = ids[j];
+
+                if (mustA.has(Y)) {
+                    const refuted: OracleProp = { kind: 'coordNeq', axis, a: X, b: Y };
+                    if (await solveZ3With(layout, [refuted])) {
+                        fail(layout, `getMustAligned(${X}, ${axis}) claims ${Y}, but Z3 found a model with ${axis}_${X} ≠ ${axis}_${Y}`);
+                    }
+                }
+
+                const aligned: OracleProp = { kind: 'coordEq', axis, a: X, b: Y };
+                if (cannotA.has(Y)) {
+                    if (await solveZ3With(layout, [aligned])) {
+                        fail(layout, `getCannotAligned(${X}, ${axis}) claims ${Y}, but Z3 aligned them`);
+                    }
+                } else if (opts.canExactAlignment) {
+                    if (!(await solveZ3With(layout, [aligned]))) {
+                        fail(layout, `getCanAligned(${X}, ${axis}) claims ${Y}, but Z3 proved alignment impossible`);
+                    }
+                }
+            }
+        }
+    }
+    return true;
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+const available = await isZ3Available();
+
+afterAll(() => {
+    if (available) shutdownZ3();
+});
+
+afterEach((ctx) => {
+    if (!available) return;
+    console.log(`[z3-oracle] after "${ctx.task.name}": ${describeOracleStats()}`);
+});
+
+describe.runIf(available)('Modal query entailment vs Z3', () => {
+
+    // ─── Deterministic cases (exhaustive pair probes) ───────────────────
+
+    it('transitive chain: modal queries exactly match Z3', async () => {
+        const layout = parseConstraintSpec('a <x b, b <x c');
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        // Spot-check the expected transitive facts surfaced at all.
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('c', 'leftOf').has('a')).toBe(true);
+        expect(v.getCannot('a', 'leftOf').has('c')).toBe(true);
+    });
+
+    it('alignment chain: aligned nodes cannot order, mustAligned is transitive', async () => {
+        const layout = parseConstraintSpec('a =x b, b =x c, a <y b');
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMustAligned('a', 'x').has('c')).toBe(true);
+        expect(v.getCannot('a', 'leftOf').has('b')).toBe(true);
+    });
+
+    it('disjunction with a common consequence yields a must fact', async () => {
+        // Both alternatives contain a <x b, so the intersection strengthening
+        // must surface must(a before b) even though the constraint is disjunctive.
+        // Alignment exactness is off: every alternative x-separates b and c, so
+        // b/c can never be x-aligned, but cannot-aligned facts are not derived
+        // from disjunction intersection (see KNOWN INCOMPLETENESS below).
+        const layout = parseConstraintSpec('[a <x b & b <x c | a <x b & c <x b]');
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: false })).toBe(true);
+
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('b', 'leftOf').has('a')).toBe(true);
+    });
+
+    it('group bounding-box disjunctions leave modal claims exact', async () => {
+        const layout = parseConstraintSpec('x <x a1, x <x a2, {A: a1, a2}');
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+    });
+
+    // ─── Randomized (fixed seed → deterministic in CI) ──────────────────
+
+    it('random conjunctive systems: modal queries exactly match Z3', async () => {
+        await fc.assert(fc.asyncProperty(
+            arbNodePool(4).chain(nodes =>
+                fc.tuple(
+                    fc.constant(nodes),
+                    fc.array(arbConjunctive(nodes), { minLength: 0, maxLength: 5 }),
+                )
+            ),
+            async ([nodes, constraints]) => {
+                const layout = buildLayout(nodes, constraints);
+                await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true });
+            }
+        ), { numRuns: 8, seed: 20260727, timeout: 120_000 });
+    });
+
+    it('random ordering + disjunction systems: modal claims are sound', async () => {
+        await fc.assert(fc.asyncProperty(
+            arbNodePool(4).chain(nodes =>
+                fc.tuple(
+                    fc.constant(nodes),
+                    fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 3 }),
+                    fc.array(arbDisjunction(nodes), { minLength: 1, maxLength: 2 }),
+                )
+            ),
+            async ([nodes, constraints, disjunctions]) => {
+                const layout = buildLayout(nodes, constraints, disjunctions);
+                // Soundness only: with disjunctions the can-side may over-claim
+                // (see KNOWN INCOMPLETENESS below).
+                await checkModalAgainstOracle(layout, { canExactOrdering: false, canExactAlignment: false });
+            }
+        ), { numRuns: 8, seed: 20260727, timeout: 120_000 });
+    });
+
+    // ─── Known incompleteness ledger ────────────────────────────────────
+    // Each specimen has a passing ground-truth test (Z3 proves the fact,
+    // and everything the validator DOES claim stays sound) and an it.fails
+    // test asserting the exact modal semantics. If an it.fails test starts
+    // PASSING, the validator learned that inference — delete the .fails
+    // modifier and fold the case into the exactness suites above.
+
+    // Specimen 1: joint entailment across two disjunctions. Any model
+    // violating a <x b must satisfy BOTH c <x d and d <x c — impossible —
+    // so a <x b is entailed jointly, and "b left of a" is impossible. The
+    // per-disjunction intersection strengthening cannot see this (each
+    // disjunction's alternatives share no common consequence).
+
+    it('joint-entailment ground truth: Z3 proves b can never be left of a', async () => {
+        const layout = parseConstraintSpec('[a <x b | c <x d], [a <x b | d <x c]');
+        expect(await solveZ3With(layout, [{ kind: 'properBefore', axis: 'x', a: 'b', b: 'a' }])).toBe(false);
+        // Soundness of what IS claimed still holds on this layout.
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: false, canExactAlignment: false })).toBe(true);
+    });
+
+    it.fails('joint entailment across two disjunctions is not captured (KNOWN INCOMPLETENESS)', async () => {
+        const layout = parseConstraintSpec('[a <x b | c <x d], [a <x b | d <x c]');
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getCannot('a', 'leftOf').has('b')).toBe(true);
+    });
+
+    // Specimen 2: disjunction-forced alignment impossibility. Every
+    // alternative of [a <x b | b <x a] separates a and b on x, so they can
+    // never be x-aligned — but cannot-aligned facts are derived only from
+    // the must graphs (strict orders + dual-axis overlap), not from
+    // disjunction intersection, so getCanAligned over-claims here.
+
+    it('disjunction-forced ground truth: Z3 proves a and b can never be x-aligned', async () => {
+        const layout = parseConstraintSpec('[a <x b | b <x a]');
+        expect(await solveZ3With(layout, [{ kind: 'coordEq', axis: 'x', a: 'a', b: 'b' }])).toBe(false);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: false })).toBe(true);
+    });
+
+    it.fails('disjunction-forced alignment impossibility is not captured (KNOWN INCOMPLETENESS)', async () => {
+        const layout = parseConstraintSpec('[a <x b | b <x a]');
+        const layoutV = cloneLayout(layout);
+        const v = new QualitativeConstraintValidator(layoutV);
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getCannotAligned('a', 'x').has('b')).toBe(true);
+    });
+});

--- a/tests/z3-modal-equivalence.test.ts
+++ b/tests/z3-modal-equivalence.test.ts
@@ -13,8 +13,12 @@
  *   cannot P  ⟺  UNSAT(model ∧ P)
  *
  * Propositions:
- *   - must "Y left of X" is probed with its weakest sound reading,
- *     coord entailment: UNSAT(x_Y ≥ x_X).
+ *   - must "Y left of X" is probed at full strength, as proper placement:
+ *     UNSAT(x_Y + w_Y ≥ x_X). The weaker coord reading UNSAT(x_Y ≥ x_X) is
+ *     NOT enough — it accepts a Y that starts before X while still spanning
+ *     across it, which is not "left of" in any sense the query language means.
+ *     The two readings agree only when every node is the same size on the
+ *     axis, so a uniform-size fixture cannot tell them apart.
  *   - cannot/can "Y left of X" is probed as proper placement:
  *     x_Y + w_Y ≤ x_X. The system is pure difference bounds (no upper
  *     bounds), so a model with x_Y < x_X can always be stretched into one
@@ -114,10 +118,10 @@ async function checkModalAgainstOracle(
                 if (Y === X) continue;
 
                 if (must.has(Y)) {
-                    // Claim: Y strictly before X on this axis in ALL models.
-                    const refuted: OracleProp = { kind: 'coordGe', axis, a: Y, b: X };
+                    // Claim: Y sits entirely before X on this axis in ALL models.
+                    const refuted: OracleProp = { kind: 'notProperBefore', axis, a: Y, b: X };
                     if (await solveZ3With(layout, [refuted])) {
-                        fail(layout, `getMust(${X}, ${rel}) claims ${Y}, but Z3 found a model with ${axis}_${Y} ≥ ${axis}_${X}`);
+                        fail(layout, `getMust(${X}, ${rel}) claims ${Y}, but Z3 found a model where ${Y} does not clear ${X} on ${axis}`);
                     }
                 }
 
@@ -225,6 +229,29 @@ describe.runIf(available)('Modal query entailment vs Z3', () => {
     it('group bounding-box disjunctions leave modal claims exact', async () => {
         const layout = parseConstraintSpec('x <x a1, x <x a2, {A: a1, a2}');
         expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+    });
+
+    it('non-uniform sizes: sharing a column with a narrow node is not "left of"', async () => {
+        // W shares a column with the narrow N, and N is left of X. That forces
+        // only N's own width of separation, which says nothing about whether
+        // the far wider W clears X — and it does not: W spans right across it.
+        // getMust used to claim it, because reachability alone establishes only
+        // x_W < x_X. Sizes must differ to expose this: at equal widths any
+        // forced separation already exceeds a box, so the readings coincide.
+        const dims = {
+            W: [300, 60] as [number, number],
+            N: [20, 60] as [number, number],
+            X: [100, 60] as [number, number],
+        };
+        const layout = parseConstraintSpec('W =x N, N <x X', dims);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('X', 'leftOf').has('N')).toBe(true);  // N (20 wide) clears X
+        expect(v.getMust('X', 'leftOf').has('W')).toBe(false); // W (300 wide) does not
+        // The weaker reading still holds for W — that is exactly the gap.
+        expect(await solveZ3With(layout, [{ kind: 'coordGe', axis: 'x', a: 'W', b: 'X' }])).toBe(false);
     });
 
     // ─── Randomized (fixed seed → deterministic in CI) ──────────────────


### PR DESCRIPTION
This merges the `dev-validator` staging branch into main. It contains eight squash-merged pull requests: #517 to #522, #524, and #525. Each one was developed and reviewed separately. Each one was checked against a Z3 oracle before it landed.

The work started as performance work. It found four correctness bugs. The differential test net built in #517 found three of them. Two of the four are present in the current release.

Seven of the eight change `src/`. #525 is test-only. It widens the differential net that found the bugs, and fixes one wrong probe inside the oracle itself.

## Correctness

### #517: two wrong answers, found by a new entailment oracle

This added entailment probes to the Z3 oracle (`solveZ3With`). It also made `checkAgainstOracle` verify the constraint set the validator commits to on every SAT verdict, not just the SAT or UNSAT result. Two bugs followed at once:

- Presolve and prune committed alternatives that were only "not contradicted", rather than alternatives that were implied. This produced SAT verdicts whose committed sets contained cycles.
- `getCannotAligned` did not apply the dual-axis overlap rule, so `getCanAligned` reported alignments that are impossible.

### #520: backtracking corrupted the ordering graphs

`addEdge` returns true without inserting when an equal or tighter edge already exists. `removeEdge` deleted unconditionally. Undoing an assignment whose constraint used the same pair as an existing edge therefore deleted an edge that a base constraint still needed. After that, contradictory alternatives became addable.

Minimal case, now a regression test:

```
base:         N0 <x N3 (d=20)
disjunction:  [N0 <x N3 (d=13), N3 <x N0 (d=5)]
           |  [N3 <x N0 (d=5),  N1 <x N2 (d=5)]
```

This system is unsatisfiable. The validator answered SAT, with the cyclic committed set `{N0 <x N3, N3 <x N0}`.

Bounding-box undo had a related fault. It removed only the node-to-group edge and left the per-member Rule C edges behind. Both are fixed with reference-counted edge claims.

This bug predates the campaign and is present in the current release.

Note for reviewers: the existing Z3 generators never produced alternatives that reuse a base constraint's pair. That is why the bug survived them. #520 adds a generator that does.

### #524: must-claims were weaker than the relation they report

`getMust` and `getReachable` used `isStrictlyOrdered`. That test returns true when a path exists with at least one positive-weight edge. It establishes that one box starts before another. It does not establish that the box clears the other.

The query language means the second thing. `must.leftOf(X)` should return the boxes that end before X begins.

The two readings are equal only when every box has the same size on the axis. Box width comes from label text, so sizes differ in normal use.

Example. W is 300 wide. N is 20 wide. W and N share a column. N is left of X. That constraint forces 35 units of separation, because N is narrow. W therefore starts before X, but W spans across it. `getMust(X, 'leftOf')` returned W.

Measured on the existing generator, which already varies sizes from 20 to 200: 21 of 395 must-claims were false under the correct reading. All 395 passed the shipped check, because that check refuted with `x_Y >= x_X`, which is the same weak reading the code used.

The fix adds `isProperlyBefore`. The separation two nodes are forced apart by is the maximum path weight, not the existence of a path, so this needs a longest-path pass over the alignment-contracted graph. `isStrictlyOrdered` is unchanged. It is still used for alignment feasibility and cycle rejection, where it is the correct test. Feasibility verdicts are unaffected.

This bug also predates the campaign and is present in the current release.

## Performance

| Scenario | before | after |
|---|---|---|
| Groups 10×5 + 50 free | 10.1 s | 39 ms (about 260x) |
| Groups 5×5 + 25 free | 321 ms | 7.7 ms |
| Chain N=200 | 374 ms | 4.7 ms |
| Grid 4×4 (96 disjunctions) | 68 ms | 1.6 ms |

Nothing regressed. The changes:

- **#518**: modal query state is built lazily instead of on every validation. Alignment classes use an iterative Tarjan SCC pass, O(V+E), in place of a per-node nested BFS.
- **#519**: per-source reachability is memoized and serves both `canReach` and `isStrictlyOrdered`. Acyclic inserts patch the cached closure in place and report exact reachability deltas. Those deltas invalidate only the feasibility verdicts whose probes were actually hit. This produced the 49x on group layouts.
- **#521**: VSIDS activity moved from a string-keyed Map to a flat Float64Array. Learned-clause eliminations are computed for all disjunctions in one pass. `pickBranch` went from 43 ms to 6.5 ms. Branching order is unchanged bit for bit: decay stays a multiply-all sweep, because decay by increment would rescale activity against the unscaled simplicity tiebreaker and change the heuristic. The committed set and the reported IIS depend on that order.
- **#522**: one cache lookup per disjunction instead of one per alternative. This gained about 7%.

#524 adds cost to the modal query path only. The lazy modal build is 1.35x slower on a 200-node chain (23.9 ms to 32.3 ms), and 1.6x slower with alignments (6.7 ms to 11.1 ms). Validation time is unchanged, because modal state is built lazily and is not on the validation path. The table above is therefore unaffected.

## Where this stops

#522 removed every map probe from the propagation scan and gained 7%. That bounds what is left in scan overhead. The next step would be a dirty set that rescans only the disjunctions a delta affects. That needs a new invariant, because alternatives carrying alignments query dynamic alignment classes and cannot be probe-tracked. That is more subtle reasoning in a file that has now produced two real soundness bugs, for a few milliseconds. I stopped here deliberately.

One measurement note. An intermediate #522 reading suggested a much larger gain. It was taken while the machine was still loaded from test runs, and the instrumented profiler overstates that path on its own. The 7% figure is the back-to-back, unloaded measurement.

## Tests added

- `tests/z3-modal-equivalence.test.ts`: must and cannot soundness through entailment probes, can-side exactness for conjunctive systems, and two known incompleteness cases marked `it.fails`. Those two are documented limits, not regressions. #524 strengthened the must probe in this file and added a regression case for boxes of different sizes.
- `tests/edge-undo-integrity.test.ts`: claim semantics, including non-LIFO release, bounding-box member release, and the end-to-end case shown above.
- Duplicate-pair and degenerate negated-group cases in `z3-equivalence`.

### #525: widening the net

The modal suite generated 16 systems per run against the feasibility suite's 1250, on a fixed seed, so it examined the same 16 systems every time. That is the wrong way round: modal queries state what holds across every valid layout, which is a stronger claim than feasibility, and this suite found the two bugs that shipped.

- One oracle defect fixed. `properBefore` compiled to `coord_a + size_a ≤ coord_b` while `notProperBefore` compiled to `≥`, so the two overlapped at equality instead of being complements. The mechanized definition is strict, so the non-strict one was wrong. A zero-gap ordering makes the overlap reachable. A new test asserts the two probes cannot both hold, and fails under the old encoding.
- Generated gaps were only ever 15 or 0 while node sizes ranged over 20 to 200. `isProperlyBefore` compares a summed path weight against one node size, so the gap-to-size ratio decides the answer and it took two values. Gaps are now drawn from 0 to 40.
- Node pools are uniform-sized one time in five. Independent draws made an all-equal pool vanishingly unlikely, and that is the case where the two readings of "before" coincide.
- Disjunctions can now carry two-constraint alternatives over two pairs. Every prior generator emitted singletons, so no generated alternative could fail partway through — the path #520's bug corrupted.
- Modal generated systems go from 16 to 120, with new properties for 5-node systems and for systems with groups. `Z3_MODAL_RUNS` and `Z3_MODAL_SEED` override the size and seed, so the file can search instead of only regression-testing, and the timeout scales with the run count.
- New deterministic cases: the zero-gap touching boundary and its one-unit-of-gap counterpart, separation accumulated along a three-hop path in two variants that differ only in the gap, and the same shape on the vertical axis.
- `getReachable` had no oracle coverage despite #524 rewriting all four of its cases. On systems with no disjunctions and no groups it must equal `getMust`, which the cross-check now asserts.

The widened search found no further validator bugs: 1800 generated modal systems over three seeds, and five consecutive clean feasibility passes.

## Verification

Every pull request was gated on the full Z3 oracle suite and on the complete 2000-test gate before it merged. The final `dev-validator` tip was checked again on both. A 400-seed by 2-shape Z3 fuzz sweep over the duplicate-pair shapes is clean; it diverged at seed 64 before #520.

For #524, the modal suite was run at 300 generated systems with 5 nodes and reported no disagreements. The same configuration produced 21 disagreements before the fix.

For #525, the modal suite was run over three seeds at 150 runs across four properties, which is 1800 generated systems, with no disagreements. The feasibility suite was run five times in a row with no failures; the base branch was also five for five. The full suite excluding Z3 passes at 2121 tests across 148 files, and typecheck is unchanged at 73 errors.

Note for local runs: this host kills long-lived vitest processes under memory pressure, so full-suite runs can exit with 143 or 144. Those are host kills, not test failures. Running in batches avoids this. Separately, one feasibility pass during #525 died with the oracle's documented single-solve heap mode: the Z3 heap reached 2048 MB and the oracle marked itself dead, with no disagreement reported. That is the oracle failing, not the validator. One occurrence in nine passes on that branch against zero in five on base is not enough to attribute it to the wider generators, and forcing uniform pools did not reproduce it in six targeted runs.

## Known gap, not fixed here

Modal queries return degenerate answers after `enforceMaximalFeasibleSubset` runs. The mechanized semantics defines that case as the realizations of the maximal feasible subset, which is never empty. Answering over that subset is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

