### PR TITLE
fix(layout): require proper separation for must and reachable queries

### DIFF
--- a/src/layout/qualitative-constraint-validator.ts
+++ b/src/layout/qualitative-constraint-validator.ts
@@ -158,6 +158,15 @@ class DifferenceConstraintGraph {
 
     /** Per-source reachability memo: src → (target → some path has a positive edge). */
     private reachMemo: Map<string, Map<string, boolean>> = new Map();
+    /** Per-source longest-path memo: src → (target → max total edge weight). */
+    private maxWeightMemo: Map<string, Map<string, number>> = new Map();
+    /** Source-independent contraction backing maxWeightMemo (see contractedDag). */
+    private contractedMemo: {
+        rep: Map<string, string>;
+        adj: Map<string, Map<string, number>>;
+        order: string[];
+        members: Map<string, string[]>;
+    } | null = null;
     /** Memoized Tarjan SCC components. */
     private sccMemo: string[][] | null = null;
     private memoAddV = -1;
@@ -232,6 +241,8 @@ class DifferenceConstraintGraph {
     private validateMemo(): void {
         if (this.memoAddV !== this.addVersion || this.memoRemV !== this.removeVersion) {
             this.reachMemo.clear();
+            this.maxWeightMemo.clear();
+            this.contractedMemo = null;
             this.sccMemo = null;
             this.memoAddV = this.addVersion;
             this.memoRemV = this.removeVersion;
@@ -739,6 +750,147 @@ class DifferenceConstraintGraph {
     isStrictlyOrdered(a: string, b: string): boolean {
         if (a === b) return false;
         return this.reachFrom(a).get(b) === true;
+    }
+
+    /**
+     * Check if a sits entirely before b on this axis: coord_a + size_a < coord_b.
+     *
+     * This is the spatial relation the query language means by "left of" /
+     * "above" — a is clear of b, not merely starting earlier. isStrictlyOrdered
+     * is the weaker "coord_a < coord_b"; use that one for questions about
+     * ordering or alignment feasibility, and this one for questions about where
+     * a box actually sits relative to another.
+     *
+     * The two coincide when every box has the same size on this axis, because
+     * any forced separation is then at least one box plus its padding. They
+     * come apart as soon as sizes differ: with A aligned to a narrow N and
+     * N before B, the forced separation is N's width, which says nothing about
+     * whether the much wider A clears B.
+     *
+     * Sound but not complete: maxWeightFrom is the separation this graph
+     * entails, and non-overlap and unresolved disjunctions can force more.
+     * Claiming less than is true is the safe direction for a must-fact.
+     */
+    isProperlyBefore(a: string, b: string): boolean {
+        if (a === b) return false;
+        const w = this.maxWeightFrom(a).get(b);
+        return w !== undefined && w > (this.nodeSize.get(a) ?? 0);
+    }
+
+    /**
+     * Memoized per-source longest-path weight. reachFrom answers "is there a
+     * path with any separation at all", which entails only coord_a < coord_b.
+     * Deciding whether a box CLEARS another needs the total separation the
+     * constraints force — coord_target ≥ coord_src + maxWeightFrom(src, target)
+     * — and that is the maximum over paths, not the existence of one.
+     *
+     * Alignment classes are contracted first: their members share a coordinate,
+     * so every edge inside a class weighs 0 and contributes nothing to a path.
+     * What remains is a DAG (positive-weight cycles are rejected at insertion),
+     * so the longest path is a single topological relaxation pass.
+     */
+    private maxWeightFrom(src: string): Map<string, number> {
+        this.validateMemo();
+        const cached = this.maxWeightMemo.get(src);
+        if (cached) return cached;
+
+        const { rep, adj, order, members } = this.contractedDag();
+        const srcRep = rep.get(src) ?? src;
+
+        const dist = new Map<string, number>();
+        dist.set(srcRep, 0);
+        for (const n of order) {
+            const base = dist.get(n);
+            if (base === undefined) continue; // not downstream of src
+            for (const [s, w] of adj.get(n)!) {
+                const cand = base + w;
+                const cur = dist.get(s);
+                if (cur === undefined || cand > cur) dist.set(s, cand);
+            }
+        }
+
+        // Expand super-nodes back to members. Walking `dist` rather than every
+        // node keeps this proportional to what src actually reaches, matching
+        // reachFrom — expanding over all nodes instead made each source O(V)
+        // even when it reaches nothing.
+        const result = new Map<string, number>();
+        for (const [r, d] of dist) {
+            const ms = members.get(r);
+            if (ms === undefined) { result.set(r, d); continue; }
+            for (const m of ms) result.set(m, d);
+        }
+        this.maxWeightMemo.set(src, result);
+        return result;
+    }
+
+    /**
+     * The alignment-contracted DAG plus a topological order, shared by every
+     * maxWeightFrom source. Building it is O(V + E) and it does not depend on
+     * the source, so it is computed once per graph version — rebuilding it per
+     * source made the lazy modal build ~3-5x slower on chains.
+     *
+     * Members of an alignment class share a coordinate, so intra-class edges
+     * (necessarily zero-weight) are dropped and the class collapses to one
+     * super-node. Between super-nodes only the heaviest edge matters, since a
+     * longest-path relaxation would pick it anyway.
+     */
+    private contractedDag(): {
+        rep: Map<string, string>;
+        adj: Map<string, Map<string, number>>;
+        order: string[];
+        members: Map<string, string[]>;
+    } {
+        if (this.contractedMemo) return this.contractedMemo;
+
+        const rep = new Map<string, string>();
+        const members = this.getAlignmentClasses();
+        for (const [r, ms] of members) {
+            for (const m of ms) rep.set(m, r);
+        }
+        const repOf = (id: string): string => rep.get(id) ?? id;
+
+        const adj = new Map<string, Map<string, number>>();
+        const indeg = new Map<string, number>();
+        for (const n of this.nodes) {
+            const r = repOf(n);
+            if (!adj.has(r)) { adj.set(r, new Map()); indeg.set(r, 0); }
+        }
+        for (const [u, succs] of this.adj) {
+            const ru = repOf(u);
+            const out = adj.get(ru);
+            if (!out) continue;
+            for (const [v, w] of succs) {
+                const rv = repOf(v);
+                if (ru === rv) continue;
+                const cur = out.get(rv);
+                if (cur === undefined) {
+                    out.set(rv, w);
+                    indeg.set(rv, (indeg.get(rv) ?? 0) + 1);
+                } else if (w > cur) {
+                    out.set(rv, w);
+                }
+            }
+        }
+
+        // Kahn order. Anything left unordered would sit on a surviving cycle,
+        // which after contraction means a positive-weight cycle — rejected at
+        // insertion, so unreachable in practice. Such nodes simply never get a
+        // distance, which reads as "no entailed separation": conservative.
+        const order: string[] = [];
+        const queue: string[] = [];
+        for (const [n, d] of indeg) if (d === 0) queue.push(n);
+        for (let head = 0; head < queue.length; head++) {
+            const n = queue[head];
+            order.push(n);
+            for (const [s] of adj.get(n)!) {
+                const d = (indeg.get(s) ?? 1) - 1;
+                indeg.set(s, d);
+                if (d === 0) queue.push(s);
+            }
+        }
+
+        this.contractedMemo = { rep, adj, order, members };
+        return this.contractedMemo;
     }
 
     /**
@@ -3883,12 +4035,18 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         this.mustVAlignmentClasses = this.collectAlignmentClasses(this.mustVGraph, realNodeIds);
     }
 
-    /** Collect all strict ordering pairs from a graph. */
+    /**
+     * Collect the pairs this graph forces into a proper spatial relation:
+     * a sits entirely before b, which is what getMust reports as "a is left of
+     * / above b". Deliberately isProperlyBefore and not isStrictlyOrdered —
+     * the latter only entails coord_a < coord_b, which for a box wider than
+     * the forced separation still leaves a overlapping b's span.
+     */
     private collectStrictPairs(graph: DifferenceConstraintGraph, nodeIds: string[]): Set<string> {
         const pairs = new Set<string>();
         for (const a of nodeIds) {
             for (const b of nodeIds) {
-                if (a !== b && graph.isStrictlyOrdered(a, b)) {
+                if (a !== b && graph.isProperlyBefore(a, b)) {
                     pairs.add(`${a}\x00${b}`);
                 }
             }
@@ -4257,7 +4415,13 @@ class QualitativeConstraintValidator implements IConstraintValidator {
 
     // ─── Post-CDCL resolved model queries (what's true in THIS layout) ───
 
-    /** Get all nodes reachable from `nodeId` in the given direction (resolved model). */
+    /**
+     * Get all nodes reachable from `nodeId` in the given direction (resolved model).
+     *
+     * Uses isProperlyBefore for the same reason getMust does: the question is
+     * which boxes actually sit to the given side, not which ones merely start
+     * earlier on the axis.
+     */
     public getReachable(nodeId: string, relation: 'leftOf' | 'rightOf' | 'above' | 'below'): Set<string> {
         const realNodeIds = new Set(this.nodes.map(n => n.id));
         const result = new Set<string>();
@@ -4265,25 +4429,25 @@ class QualitativeConstraintValidator implements IConstraintValidator {
         switch (relation) {
             case 'rightOf': {
                 for (const n of realNodeIds) {
-                    if (n !== nodeId && this.hGraph.isStrictlyOrdered(nodeId, n)) result.add(n);
+                    if (n !== nodeId && this.hGraph.isProperlyBefore(nodeId, n)) result.add(n);
                 }
                 break;
             }
             case 'leftOf': {
                 for (const n of realNodeIds) {
-                    if (n !== nodeId && this.hGraph.isStrictlyOrdered(n, nodeId)) result.add(n);
+                    if (n !== nodeId && this.hGraph.isProperlyBefore(n, nodeId)) result.add(n);
                 }
                 break;
             }
             case 'below': {
                 for (const n of realNodeIds) {
-                    if (n !== nodeId && this.vGraph.isStrictlyOrdered(nodeId, n)) result.add(n);
+                    if (n !== nodeId && this.vGraph.isProperlyBefore(nodeId, n)) result.add(n);
                 }
                 break;
             }
             case 'above': {
                 for (const n of realNodeIds) {
-                    if (n !== nodeId && this.vGraph.isStrictlyOrdered(n, nodeId)) result.add(n);
+                    if (n !== nodeId && this.vGraph.isProperlyBefore(n, nodeId)) result.add(n);
                 }
                 break;
             }

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -628,7 +628,8 @@ export type OracleProp =
     | { kind: 'coordGe'; axis: 'x' | 'y'; a: string; b: string }      // coord_a ≥ coord_b
     | { kind: 'properBefore'; axis: 'x' | 'y'; a: string; b: string } // coord_a + size_a ≤ coord_b
     | { kind: 'coordEq'; axis: 'x' | 'y'; a: string; b: string }      // coord_a = coord_b
-    | { kind: 'coordNeq'; axis: 'x' | 'y'; a: string; b: string };    // coord_a ≠ coord_b
+    | { kind: 'coordNeq'; axis: 'x' | 'y'; a: string; b: string }     // coord_a ≠ coord_b
+    | { kind: 'notProperBefore'; axis: 'x' | 'y'; a: string; b: string }; // coord_a + size_a ≥ coord_b
 
 function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool {
     const ctx = z3Ctx;
@@ -651,6 +652,8 @@ function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool 
         case 'properBefore': return coord(p.a).add(size(p.a)).le(coord(p.b));
         case 'coordEq': return coord(p.a).eq(coord(p.b));
         case 'coordNeq': return ctx.Not(coord(p.a).eq(coord(p.b)));
+        // Negation of properBefore — the refutation probe for a must-claim.
+        case 'notProperBefore': return coord(p.a).add(size(p.a)).ge(coord(p.b));
     }
 }
 

--- a/tests/z3-modal-equivalence.test.ts
+++ b/tests/z3-modal-equivalence.test.ts
@@ -13,8 +13,12 @@
  *   cannot P  ⟺  UNSAT(model ∧ P)
  *
  * Propositions:
- *   - must "Y left of X" is probed with its weakest sound reading,
- *     coord entailment: UNSAT(x_Y ≥ x_X).
+ *   - must "Y left of X" is probed at full strength, as proper placement:
+ *     UNSAT(x_Y + w_Y ≥ x_X). The weaker coord reading UNSAT(x_Y ≥ x_X) is
+ *     NOT enough — it accepts a Y that starts before X while still spanning
+ *     across it, which is not "left of" in any sense the query language means.
+ *     The two readings agree only when every node is the same size on the
+ *     axis, so a uniform-size fixture cannot tell them apart.
  *   - cannot/can "Y left of X" is probed as proper placement:
  *     x_Y + w_Y ≤ x_X. The system is pure difference bounds (no upper
  *     bounds), so a model with x_Y < x_X can always be stretched into one
@@ -114,10 +118,10 @@ async function checkModalAgainstOracle(
                 if (Y === X) continue;
 
                 if (must.has(Y)) {
-                    // Claim: Y strictly before X on this axis in ALL models.
-                    const refuted: OracleProp = { kind: 'coordGe', axis, a: Y, b: X };
+                    // Claim: Y sits entirely before X on this axis in ALL models.
+                    const refuted: OracleProp = { kind: 'notProperBefore', axis, a: Y, b: X };
                     if (await solveZ3With(layout, [refuted])) {
-                        fail(layout, `getMust(${X}, ${rel}) claims ${Y}, but Z3 found a model with ${axis}_${Y} ≥ ${axis}_${X}`);
+                        fail(layout, `getMust(${X}, ${rel}) claims ${Y}, but Z3 found a model where ${Y} does not clear ${X} on ${axis}`);
                     }
                 }
 
@@ -225,6 +229,29 @@ describe.runIf(available)('Modal query entailment vs Z3', () => {
     it('group bounding-box disjunctions leave modal claims exact', async () => {
         const layout = parseConstraintSpec('x <x a1, x <x a2, {A: a1, a2}');
         expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+    });
+
+    it('non-uniform sizes: sharing a column with a narrow node is not "left of"', async () => {
+        // W shares a column with the narrow N, and N is left of X. That forces
+        // only N's own width of separation, which says nothing about whether
+        // the far wider W clears X — and it does not: W spans right across it.
+        // getMust used to claim it, because reachability alone establishes only
+        // x_W < x_X. Sizes must differ to expose this: at equal widths any
+        // forced separation already exceeds a box, so the readings coincide.
+        const dims = {
+            W: [300, 60] as [number, number],
+            N: [20, 60] as [number, number],
+            X: [100, 60] as [number, number],
+        };
+        const layout = parseConstraintSpec('W =x N, N <x X', dims);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('X', 'leftOf').has('N')).toBe(true);  // N (20 wide) clears X
+        expect(v.getMust('X', 'leftOf').has('W')).toBe(false); // W (300 wide) does not
+        // The weaker reading still holds for W — that is exactly the gap.
+        expect(await solveZ3With(layout, [{ kind: 'coordGe', axis: 'x', a: 'W', b: 'X' }])).toBe(false);
     });
 
     // ─── Randomized (fixed seed → deterministic in CI) ──────────────────


### PR DESCRIPTION
## Problem

`getMust` and `getReachable` used `isStrictlyOrdered`. That test returns true when a path exists with at least one positive-weight edge. It establishes `coord_a < coord_b`. It does not establish that box `a` clears box `b`.

The query language means the second thing. `must.leftOf(X)` should return the boxes that end before X begins. The mechanized semantics defines it the same way: `leftOf b1 b2 := b1.x_tl + b1.width < b2.x_tl`.

The two readings are equal only when all boxes have the same size on the axis. In that case any forced separation is at least one box plus its padding. Box width comes from label text, so sizes differ in normal use.

Example. W is 300 wide. N is 20 wide. W and N are in the same column. N is left of X. The constraint "N is left of X" forces 35 units of separation, because N is narrow. W starts at the same coordinate as N, so W starts before X. W is 300 wide, so W spans across X. `getMust(X, 'leftOf')` returned W.

## Evidence

I added a probe that refutes a must-claim with `x_Y + w_Y >= x_X`, then ran the existing generator with no other changes. That generator already varies box sizes from 20 to 200.

| | count |
|---|---|
| must-claims examined | 395 |
| passed the shipped probe | 395 |
| false under the correct reading | 21 |

The shipped probe refuted with `coordGe`, that is `x_Y >= x_X`. This is the same weak reading the code implements. The cross-check therefore confirmed only that the code agreed with itself.

## Fix

New method `isProperlyBefore(a, b)`. It returns true when the constraints force `coord_a + size_a < coord_b`.

The separation two nodes are forced apart by is the maximum path weight, not the existence of a path. `maxWeightFrom` computes it:

1. Contract alignment classes. Members share a coordinate, so edges inside a class have weight zero and contribute nothing to a path.
2. What remains is a DAG, because positive-weight cycles are rejected at insertion.
3. Relax once in topological order.

Results are memoized per source. The contraction does not depend on the source, so it is built once per graph version.

`collectStrictPairs`, which feeds `getMust`, and `getReachable` now call `isProperlyBefore`.

`isStrictlyOrdered` is unchanged. It is still used by `addAlignmentEdges` and `getCannotAligned`. For those questions it is the correct test: separation of any size prevents two boxes from sharing a coordinate.

Feasibility is not affected. Edge weights already included box size, because `addEdge` adds `nodeSize` to the weight the caller passes. Cycle rejection is unchanged. `getCannot` was already sound, because it errs toward claiming less.

## Test changes

- New oracle proposition `notProperBefore`, that is `coord_a + size_a >= coord_b`.
- The must-claim refutation in `z3-modal-equivalence.test.ts` now uses it instead of `coordGe`. The header comment states why the weak reading is not sufficient.
- New regression case: a wide box sharing a column with a narrow box.

## Verification

- Modal suite at 300 generated systems with 5 nodes: no disagreements. The same configuration produced 21 disagreements before the fix.
- Z3 and validator suites: 173 tests pass.
- Full suite excluding Z3: 2121 tests across 148 files pass.
- Typecheck: 101 errors, identical to the base branch.

## Performance

Measured back-to-back, three runs each, on an unloaded machine.

| case | before | after | ratio |
|---|---|---|---|
| chain N=200, modal build + 600 queries | 23.9 ms | 32.3 ms | 1.35x |
| chain with alignments N=120, modal build + 360 queries | 6.7 ms | 11.1 ms | 1.6x |
| validation, chain N=200 | 6.2 ms | 6.2 ms | no change |

Validation is unchanged because modal state is built lazily and is not on the validation path. The benchmarks in #523 are therefore unaffected.

Hoisting the contraction out of the per-source loop reduced the cost from 2.7x-4.6x to the figures above. I also tried starting the relaxation at the source position in the topological order. That measured no change, so it was removed rather than kept.

## Not included

Modal queries still return degenerate answers after `enforceMaximalFeasibleSubset` runs. `Counterfactuals.lean` defines the semantics for that case as the realizations of the maximal feasible subset, which is never empty. Answering over that subset is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
