### PR TITLE
test(layout): widen Z3 oracle coverage and fix a non-strict oracle probe

### DIFF
--- a/tests/helpers/constraint-arbitraries.ts
+++ b/tests/helpers/constraint-arbitraries.ts
@@ -17,8 +17,8 @@ import { makeNode, leftOf, aboveOf, alignOnX, alignOnY, negativeLeftOf, negative
 
 // ─── Node pool ──────────────────────────────────────────────────────────────
 
-/** Generate a pool of N nodes with random dimensions. */
-export function arbNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
+/** Pool of N independently-sized nodes. */
+function arbVariedNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
     return fc.tuple(
         ...Array.from({ length: n }, (_, i) =>
             fc.record({
@@ -26,6 +26,33 @@ export function arbNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
                 h: fc.integer({ min: 20, max: 120 }),
             }).map(({ w, h }) => makeNode(`N${i}`, w, h))
         )
+    );
+}
+
+/** Pool of N nodes that all share one size. */
+function arbUniformNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
+    return fc.record({
+        w: fc.integer({ min: 20, max: 200 }),
+        h: fc.integer({ min: 20, max: 120 }),
+    }).map(({ w, h }) =>
+        Array.from({ length: n }, (_, i) => makeNode(`N${i}`, w, h))
+    );
+}
+
+/**
+ * Generate a pool of N nodes.
+ *
+ * Mostly varied sizes, which is what real diagrams have (box width comes from
+ * label text) and what separates the "starts before" and "clears" readings of
+ * an ordering. A minority are UNIFORM: drawing independently from 20..200 makes
+ * an all-equal pool vanishingly unlikely, yet that is the degenerate case where
+ * the two readings coincide, so it needs to be hit on purpose rather than left
+ * to chance.
+ */
+export function arbNodePool(n: number): fc.Arbitrary<LayoutNode[]> {
+    return fc.oneof(
+        { arbitrary: arbVariedNodePool(n), weight: 4 },
+        { arbitrary: arbUniformNodePool(n), weight: 1 },
     );
 }
 
@@ -43,15 +70,32 @@ export function arbPair(n: number): fc.Arbitrary<[number, number]> {
 
 // ─── Atomic constraint generators ───────────────────────────────────────────
 
+/**
+ * Random separation gap.
+ *
+ * The DSL builders default to 15 and `negativeLeftOf` hard-codes 0, so before
+ * this the whole generated suite used exactly two gap values. That matters most
+ * for the modal queries: `isProperlyBefore` compares a summed path weight
+ * against a single node size, so it is the gap-to-size ratio that decides the
+ * answer, and node sizes range over 20..200. 0 is included deliberately — it is
+ * the boundary where the forced separation is exactly one box, so the pair
+ * touches and is NOT "before" under the strict mechanized definition.
+ */
+export const arbGap: fc.Arbitrary<number> = fc.oneof(
+    { arbitrary: fc.constant(0), weight: 1 },   // touching: the strictness boundary
+    { arbitrary: fc.constant(15), weight: 2 },  // the historical default
+    { arbitrary: fc.integer({ min: 1, max: 40 }), weight: 3 },
+);
+
 /** Random ordering constraint: A <x B, B <x A, A <y B, or B <y A. */
 export function arbOrdering(nodes: LayoutNode[]): fc.Arbitrary<LayoutConstraint> {
-    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 0, max: 3 })).map(([[i, j], type]) => {
+    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 0, max: 3 }), arbGap).map(([[i, j], type, gap]) => {
         switch (type) {
-            case 0: return leftOf(nodes[i], nodes[j]);
-            case 1: return leftOf(nodes[j], nodes[i]);
-            case 2: return aboveOf(nodes[i], nodes[j]);
-            case 3: return aboveOf(nodes[j], nodes[i]);
-            default: return leftOf(nodes[i], nodes[j]);
+            case 0: return leftOf(nodes[i], nodes[j], gap);
+            case 1: return leftOf(nodes[j], nodes[i], gap);
+            case 2: return aboveOf(nodes[i], nodes[j], gap);
+            case 3: return aboveOf(nodes[j], nodes[i], gap);
+            default: return leftOf(nodes[i], nodes[j], gap);
         }
     });
 }
@@ -85,13 +129,13 @@ export function arbAlignment(nodes: LayoutNode[]): fc.Arbitrary<LayoutConstraint
 
 /** Random conjunctive constraint (ordering or alignment). */
 export function arbConjunctive(nodes: LayoutNode[]): fc.Arbitrary<LayoutConstraint> {
-    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 0, max: 3 })).map(([[i, j], type]) => {
+    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 0, max: 3 }), arbGap).map(([[i, j], type, gap]) => {
         switch (type) {
-            case 0: return leftOf(nodes[i], nodes[j]);
-            case 1: return aboveOf(nodes[i], nodes[j]);
+            case 0: return leftOf(nodes[i], nodes[j], gap);
+            case 1: return aboveOf(nodes[i], nodes[j], gap);
             case 2: return alignOnX(nodes[i], nodes[j]);
             case 3: return alignOnY(nodes[i], nodes[j]);
-            default: return leftOf(nodes[i], nodes[j]);
+            default: return leftOf(nodes[i], nodes[j], gap);
         }
     });
 }
@@ -100,12 +144,12 @@ export function arbConjunctive(nodes: LayoutNode[]): fc.Arbitrary<LayoutConstrai
 
 /** Random disjunction with 2–4 ordering alternatives between a pair. */
 export function arbDisjunction(nodes: LayoutNode[]): fc.Arbitrary<DisjunctiveConstraint> {
-    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 2, max: 4 })).map(([[i, j], numAlts]) => {
+    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 2, max: 4 }), arbGap).map(([[i, j], numAlts, gap]) => {
         const allAlts: LayoutConstraint[][] = [
-            [leftOf(nodes[i], nodes[j])],
-            [leftOf(nodes[j], nodes[i])],
-            [aboveOf(nodes[i], nodes[j])],
-            [aboveOf(nodes[j], nodes[i])],
+            [leftOf(nodes[i], nodes[j], gap)],
+            [leftOf(nodes[j], nodes[i], gap)],
+            [aboveOf(nodes[i], nodes[j], gap)],
+            [aboveOf(nodes[j], nodes[i], gap)],
         ];
         return new DisjunctiveConstraint(SRC, allAlts.slice(0, numAlts));
     });
@@ -113,13 +157,46 @@ export function arbDisjunction(nodes: LayoutNode[]): fc.Arbitrary<DisjunctiveCon
 
 /** Random disjunction that may include alignment alternatives. */
 export function arbRichDisjunction(nodes: LayoutNode[]): fc.Arbitrary<DisjunctiveConstraint> {
-    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 2, max: 5 })).map(([[i, j], numAlts]) => {
+    return fc.tuple(arbPair(nodes.length), fc.integer({ min: 2, max: 5 }), arbGap).map(([[i, j], numAlts, gap]) => {
         const allAlts: LayoutConstraint[][] = [
-            [leftOf(nodes[i], nodes[j])],
-            [leftOf(nodes[j], nodes[i])],
-            [aboveOf(nodes[i], nodes[j])],
-            [aboveOf(nodes[j], nodes[i])],
+            [leftOf(nodes[i], nodes[j], gap)],
+            [leftOf(nodes[j], nodes[i], gap)],
+            [aboveOf(nodes[i], nodes[j], gap)],
+            [aboveOf(nodes[j], nodes[i], gap)],
             [alignOnX(nodes[i], nodes[j])],
+        ];
+        return new DisjunctiveConstraint(SRC, allAlts.slice(0, numAlts));
+    });
+}
+
+/**
+ * Random disjunction whose alternatives are CONJUNCTIONS of two orderings over
+ * two different pairs.
+ *
+ * arbDisjunction and arbRichDisjunction both emit singleton alternatives over a
+ * single pair, so no generated disjunction could ever fail partway through an
+ * alternative: the first constraint either went in or it did not. Multi-
+ * constraint alternatives are what reach the partial-assignment undo path —
+ * add constraint 1, reject constraint 2, roll back constraint 1 — which is
+ * where #520's edge-deletion bug lived. Only a hand-written generator covered
+ * it before.
+ *
+ * Alternatives deliberately reuse the same pairs in different directions, so
+ * some rollbacks release an edge another alternative or the base set still
+ * claims.
+ */
+export function arbCompoundDisjunction(nodes: LayoutNode[]): fc.Arbitrary<DisjunctiveConstraint> {
+    return fc.tuple(
+        arbPair(nodes.length),
+        arbPair(nodes.length),
+        fc.integer({ min: 2, max: 3 }),
+        arbGap,
+        arbGap,
+    ).map(([[i, j], [k, l], numAlts, gap1, gap2]) => {
+        const allAlts: LayoutConstraint[][] = [
+            [leftOf(nodes[i], nodes[j], gap1), aboveOf(nodes[k], nodes[l], gap2)],
+            [leftOf(nodes[j], nodes[i], gap1), aboveOf(nodes[l], nodes[k], gap2)],
+            [aboveOf(nodes[i], nodes[j], gap2), leftOf(nodes[l], nodes[k], gap1)],
         ];
         return new DisjunctiveConstraint(SRC, allAlts.slice(0, numAlts));
     });

--- a/tests/helpers/constraint-dsl.ts
+++ b/tests/helpers/constraint-dsl.ts
@@ -52,12 +52,15 @@ function makeNode(id: string, width: number, height: number): LayoutNode {
     };
 }
 
-function leftOf(a: LayoutNode, b: LayoutNode): LeftConstraint {
-    return { left: a, right: b, minDistance: 15, sourceConstraint: SRC };
+/** Default gap. Kept as the default so existing fixtures are unchanged. */
+const DEFAULT_GAP = 15;
+
+function leftOf(a: LayoutNode, b: LayoutNode, minDistance = DEFAULT_GAP): LeftConstraint {
+    return { left: a, right: b, minDistance, sourceConstraint: SRC };
 }
 
-function aboveOf(a: LayoutNode, b: LayoutNode): TopConstraint {
-    return { top: a, bottom: b, minDistance: 15, sourceConstraint: SRC };
+function aboveOf(a: LayoutNode, b: LayoutNode, minDistance = DEFAULT_GAP): TopConstraint {
+    return { top: a, bottom: b, minDistance, sourceConstraint: SRC };
 }
 
 function alignOnX(a: LayoutNode, b: LayoutNode): AlignmentConstraint {

--- a/tests/helpers/z3-oracle.ts
+++ b/tests/helpers/z3-oracle.ts
@@ -626,7 +626,7 @@ async function checkedSolve(solver: any, what: string): Promise<boolean> {
 export type OracleProp =
     | { kind: 'coordLt'; axis: 'x' | 'y'; a: string; b: string }      // coord_a < coord_b
     | { kind: 'coordGe'; axis: 'x' | 'y'; a: string; b: string }      // coord_a ≥ coord_b
-    | { kind: 'properBefore'; axis: 'x' | 'y'; a: string; b: string } // coord_a + size_a ≤ coord_b
+    | { kind: 'properBefore'; axis: 'x' | 'y'; a: string; b: string } // coord_a + size_a < coord_b
     | { kind: 'coordEq'; axis: 'x' | 'y'; a: string; b: string }      // coord_a = coord_b
     | { kind: 'coordNeq'; axis: 'x' | 'y'; a: string; b: string }     // coord_a ≠ coord_b
     | { kind: 'notProperBefore'; axis: 'x' | 'y'; a: string; b: string }; // coord_a + size_a ≥ coord_b
@@ -649,7 +649,16 @@ function compileProp(p: OracleProp, layout: InstanceLayout, vars: VarMap): Bool 
     switch (p.kind) {
         case 'coordLt': return coord(p.a).lt(coord(p.b));
         case 'coordGe': return coord(p.a).ge(coord(p.b));
-        case 'properBefore': return coord(p.a).add(size(p.a)).le(coord(p.b));
+        // Strict, matching the mechanized definition
+        //   leftOf b₁ b₂ := b₁.x_tl + b₁.width < b₂.x_tl
+        // and making this the exact complement of notProperBefore below.
+        // A non-strict `le` here would let a TOUCHING pair (coord_a + size_a =
+        // coord_b) satisfy both props at once, so a cannot-claim could be
+        // "refuted" by a model that does not actually place a before b, and the
+        // can-side exactness check would test a weaker relation than it claims.
+        // Reachable only via zero-gap orderings, where the forced separation is
+        // exactly one box — see the negative-orientation modal tests.
+        case 'properBefore': return coord(p.a).add(size(p.a)).lt(coord(p.b));
         case 'coordEq': return coord(p.a).eq(coord(p.b));
         case 'coordNeq': return ctx.Not(coord(p.a).eq(coord(p.b)));
         // Negation of properBefore — the refutation probe for a must-claim.

--- a/tests/z3-equivalence.test.ts
+++ b/tests/z3-equivalence.test.ts
@@ -52,6 +52,7 @@ import {
     arbNegativeOrdering,
     arbMixedOrdering,
     arbGroup,
+    arbCompoundDisjunction,
 } from './helpers/constraint-arbitraries';
 import type { LayoutGroup, LayoutNode } from '../src/layout/interfaces';
 
@@ -375,6 +376,47 @@ describe.runIf(available)('Z3 Oracle Equivalence (Property-Based)', () => {
                         return new DisjunctiveConstraint(SRC, [altA, altB]);
                     });
                     const layout = buildLayout(nodes, base, disjs);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: 30, timeout: TIMEOUT });
+        });
+
+        // ── Multi-constraint alternatives (partial-assignment undo) ────
+        // Every other generator emits SINGLETON alternatives, so an
+        // alternative could never fail halfway: constraint 1 either went in or
+        // it did not. These carry two constraints over two pairs, so the
+        // solver regularly adds the first, rejects the second, and must roll
+        // the first back cleanly — the path #520's blind edge-delete corrupted.
+
+        it('random compound (2-constraint) alternatives on 4 nodes (Z3 cross-check)', async () => {
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(4).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 3 }),
+                        fc.array(arbCompoundDisjunction(nodes), { minLength: 1, maxLength: 3 }),
+                    )
+                ),
+                async ([nodes, constraints, disjs]) => {
+                    const layout = buildLayout(nodes, constraints, disjs);
+                    const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
+                    assertAgreement(layout, validatorSat, oracleSat);
+                }
+            ), { numRuns: NUM_RUNS, timeout: TIMEOUT });
+        });
+
+        it('random compound alternatives on 5 nodes, denser (Z3 cross-check)', async () => {
+            await fc.assert(fc.asyncProperty(
+                arbNodePool(5).chain(nodes =>
+                    fc.tuple(
+                        fc.constant(nodes),
+                        fc.array(arbOrdering(nodes), { minLength: 1, maxLength: 4 }),
+                        fc.array(arbCompoundDisjunction(nodes), { minLength: 2, maxLength: 4 }),
+                    )
+                ),
+                async ([nodes, constraints, disjs]) => {
+                    const layout = buildLayout(nodes, constraints, disjs);
                     const { validatorSat, oracleSat } = await checkAgainstOracle(layout);
                     assertAgreement(layout, validatorSat, oracleSat);
                 }

--- a/tests/z3-modal-equivalence.test.ts
+++ b/tests/z3-modal-equivalence.test.ts
@@ -20,10 +20,16 @@
  *     The two readings agree only when every node is the same size on the
  *     axis, so a uniform-size fixture cannot tell them apart.
  *   - cannot/can "Y left of X" is probed as proper placement:
- *     x_Y + w_Y ≤ x_X. The system is pure difference bounds (no upper
+ *     x_Y + w_Y < x_X. The system is pure difference bounds (no upper
  *     bounds), so a model with x_Y < x_X can always be stretched into one
  *     with proper separation — "can be strictly before" ⟺ "can be
  *     properly before" — which makes this probe exact, not conservative.
+ *     Both probes are STRICT, so properBefore and notProperBefore are exact
+ *     complements. A non-strict ≤ would admit a touching pair
+ *     (x_Y + w_Y = x_X) as "before" on the can-side while the must-side
+ *     refutation treats the same model as NOT before. Zero-gap orderings
+ *     force exactly that model, so the gap is reachable, not academic —
+ *     'oracle probes are exact complements' below pins it down.
  *
  * Soundness (claimed must/cannot facts hold per Z3) is always asserted.
  * Exactness of the can-side (no over-claimed "can") is asserted only where
@@ -36,10 +42,23 @@
 
 import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
 
-vi.setConfig({ testTimeout: 120_000 });
+/**
+ * Property size and seed. Defaults are the CI gate: deterministic, and sized
+ * so the whole file stays well inside the Z3 module's recycle budget. Raise
+ * both to search rather than to regression-test, e.g.
+ *   Z3_MODAL_RUNS=400 Z3_MODAL_SEED=$RANDOM npx vitest run tests/z3-modal-equivalence.test.ts
+ */
+const MODAL_RUNS = Number(process.env.Z3_MODAL_RUNS ?? 30);
+const MODAL_SEED = Number(process.env.Z3_MODAL_SEED ?? 20260727);
+
+// A modal case costs one Z3 solve per node pair per axis, so run time is
+// roughly linear in MODAL_RUNS. A fixed ceiling would turn any raise of
+// MODAL_RUNS into a timeout that reads like a hang, so scale with it and keep
+// 120s as the floor for the default size.
+vi.setConfig({ testTimeout: Math.max(120_000, MODAL_RUNS * 4_000) });
 import * as fc from 'fast-check';
 import { QualitativeConstraintValidator } from '../src/layout/qualitative-constraint-validator';
-import { InstanceLayout } from '../src/layout/interfaces';
+import { InstanceLayout, LayoutGroup } from '../src/layout/interfaces';
 import {
     isZ3Available,
     shutdownZ3,
@@ -51,6 +70,13 @@ import {
     cloneLayout,
     describeLayout,
     parseConstraintSpec,
+    makeNode,
+    leftOf,
+    aboveOf,
+    alignOnX,
+    alignOnY,
+    negativeLeftOf,
+    GBF,
 } from './helpers/constraint-dsl';
 import {
     arbNodePool,
@@ -104,6 +130,27 @@ async function checkModalAgainstOracle(
             expect(validator.getCannot(X, 'above').has(Y)).toBe(validator.getCannot(Y, 'below').has(X));
             expect(validator.getMustAligned(X, 'x').has(Y)).toBe(validator.getMustAligned(Y, 'x').has(X));
             expect(validator.getMustAligned(X, 'y').has(Y)).toBe(validator.getMustAligned(Y, 'y').has(X));
+        }
+    }
+
+    // ── getReachable (resolved model) vs getMust (all models) ──────────
+    // getReachable answers over the constraint set the CDCL committed to;
+    // getMust answers over the whole program. With no disjunctions and no
+    // groups there is nothing to commit, so the two sets are IDENTICAL — and
+    // since every getMust claim is Z3-checked below, this pins getReachable to
+    // Z3 too, for free. #524 rewrote all four of its cases and nothing else
+    // covers them.
+    // (With disjunctions the committed set is a strengthening, so getReachable
+    // is a superset and only ⊇ would hold — not asserted here.)
+    const resolvedIsFullProgram =
+        !layout.disjunctiveConstraints?.length && !layout.groups?.length;
+    if (resolvedIsFullProgram) {
+        for (const rel of ['leftOf', 'rightOf', 'above', 'below'] as const) {
+            for (const X of ids) {
+                const reach = validator.getReachable(X, rel);
+                const must = validator.getMust(X, rel);
+                expect([...reach].sort()).toEqual([...must].sort());
+            }
         }
     }
 
@@ -254,7 +301,116 @@ describe.runIf(available)('Modal query entailment vs Z3', () => {
         expect(await solveZ3With(layout, [{ kind: 'coordGe', axis: 'x', a: 'W', b: 'X' }])).toBe(false);
     });
 
-    // ─── Randomized (fixed seed → deterministic in CI) ──────────────────
+    // ─── The zero-gap (touching) boundary ───────────────────────────────
+    // A minDistance=0 ordering forces exactly one box of separation:
+    //   x_a + w_a ≤ x_b.
+    // So the pair may TOUCH, and a touching pair is not "left of" under the
+    // mechanized definition (leftOf b₁ b₂ := b₁.x_tl + b₁.width < b₂.x_tl).
+    // isProperlyBefore requires maxWeight > size, and here maxWeight = size
+    // exactly — the single point where the comparison's strictness decides the
+    // answer. No generator emitted zero gaps into the modal suite before this.
+
+    it('oracle probes are exact complements (properBefore / notProperBefore)', async () => {
+        // Guards the oracle itself, not the validator. A non-strict properBefore
+        // (≤) overlaps notProperBefore (≥) at coord_a + size_a = coord_b, which
+        // a zero-gap ordering makes reachable — so asserting both at once must
+        // be UNSAT. If this ever passes with a ≤ encoding, the can-side
+        // exactness check below is silently testing a weaker relation.
+        const a = makeNode('a', 100, 60), b = makeNode('b', 100, 60);
+        const layout = buildLayout([a, b], [negativeLeftOf(a, b)]);
+        expect(await solveZ3With(layout, [
+            { kind: 'properBefore', axis: 'x', a: 'a', b: 'b' },
+            { kind: 'notProperBefore', axis: 'x', a: 'a', b: 'b' },
+        ])).toBe(false);
+    });
+
+    it('zero-gap ordering permits touching, so it is not a must-leftOf', async () => {
+        const a = makeNode('a', 100, 60), b = makeNode('b', 100, 60);
+        const layout = buildLayout([a, b], [negativeLeftOf(a, b)]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        // Forced separation is exactly w_a, which does not CLEAR b.
+        expect(v.getMust('b', 'leftOf').has('a')).toBe(false);
+        // But nothing caps the separation, so it remains achievable.
+        expect(v.getCannot('b', 'leftOf').has('a')).toBe(false);
+        // The reverse is genuinely impossible, and the validator knows it.
+        expect(v.getCannot('a', 'leftOf').has('b')).toBe(true);
+
+        // Z3 confirms both halves.
+        expect(await solveZ3With(layout, [{ kind: 'notProperBefore', axis: 'x', a: 'a', b: 'b' }])).toBe(true);
+        expect(await solveZ3With(layout, [{ kind: 'properBefore', axis: 'x', a: 'a', b: 'b' }])).toBe(true);
+    });
+
+    it('one unit of gap crosses the boundary into a must-leftOf', async () => {
+        // Same shape as above with minDistance=1: separation is now w_a + 1,
+        // which clears b. The pair of tests brackets the comparison exactly.
+        const a = makeNode('a', 100, 60), b = makeNode('b', 100, 60);
+        const layout = buildLayout([a, b], [leftOf(a, b, 1)]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('b', 'leftOf').has('a')).toBe(true);
+    });
+
+    // ─── Separation accumulated along a chain ───────────────────────────
+    // The non-uniform case above has a path of length 1, so it only tests
+    // "one hop's weight vs one node's size". These walk a 3-hop path where the
+    // total is what decides, with the gap as the only difference between a
+    // false and a true answer.
+
+    it('accumulated separation below the wide node stays out of must-leftOf', async () => {
+        // W is x-aligned with N, so it inherits N's outgoing path: two hops of
+        // (20 + 15) = 70 total. W is 300 wide, so W still spans across X.
+        const W = makeNode('W', 300, 60), N = makeNode('N', 20, 60);
+        const M = makeNode('M', 20, 60), X = makeNode('X', 100, 60);
+        const layout = buildLayout([W, N, M, X], [
+            alignOnX(W, N), leftOf(N, M, 15), leftOf(M, X, 15),
+        ]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('X', 'leftOf').has('N')).toBe(true);  // 20 wide, 70 of run-up
+        expect(v.getMust('X', 'leftOf').has('W')).toBe(false); // 300 wide, same 70
+    });
+
+    it('accumulated separation above the wide node enters must-leftOf', async () => {
+        // Identical except the gap: two hops of (20 + 200) = 440 > 300, so the
+        // same W now does clear X. Only the arithmetic changed.
+        const W = makeNode('W', 300, 60), N = makeNode('N', 20, 60);
+        const M = makeNode('M', 20, 60), X = makeNode('X', 100, 60);
+        const layout = buildLayout([W, N, M, X], [
+            alignOnX(W, N), leftOf(N, M, 200), leftOf(M, X, 200),
+        ]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('X', 'leftOf').has('W')).toBe(true);
+    });
+
+    it('the same gap holds on the vertical axis through a y-alignment class', async () => {
+        // Mirror of the horizontal case: T is y-aligned with S (20 tall) and is
+        // itself 300 tall, so S clears C vertically and T does not. Exercises
+        // the vertical graph and height-based sizes.
+        const T = makeNode('T', 60, 300), S = makeNode('S', 60, 20), C = makeNode('C', 60, 60);
+        const layout = buildLayout([T, S, C], [alignOnY(T, S), aboveOf(S, C, 15)]);
+        expect(await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true })).toBe(true);
+
+        const v = new QualitativeConstraintValidator(cloneLayout(layout));
+        expect(v.validateConstraints()).toBeNull();
+        expect(v.getMust('C', 'above').has('S')).toBe(true);
+        expect(v.getMust('C', 'above').has('T')).toBe(false);
+    });
+
+    // ─── Randomized ─────────────────────────────────────────────────────
+    // Fixed seed by default so PR CI is a deterministic regression gate. A
+    // fixed-seed property explores the SAME systems on every run and can never
+    // find anything new, so both knobs are overridable: run with
+    // Z3_MODAL_SEED=$RANDOM (and a larger Z3_MODAL_RUNS) to actually search.
 
     it('random conjunctive systems: modal queries exactly match Z3', async () => {
         await fc.assert(fc.asyncProperty(
@@ -268,7 +424,24 @@ describe.runIf(available)('Modal query entailment vs Z3', () => {
                 const layout = buildLayout(nodes, constraints);
                 await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true });
             }
-        ), { numRuns: 8, seed: 20260727, timeout: 120_000 });
+        ), { numRuns: MODAL_RUNS, seed: MODAL_SEED, timeout: 120_000 });
+    });
+
+    it('random conjunctive systems on 5 nodes: modal queries exactly match Z3', async () => {
+        // Wider than the 4-node property: three-hop paths only exist from 5
+        // nodes up, and accumulated separation is what isProperlyBefore reads.
+        await fc.assert(fc.asyncProperty(
+            arbNodePool(5).chain(nodes =>
+                fc.tuple(
+                    fc.constant(nodes),
+                    fc.array(arbConjunctive(nodes), { minLength: 2, maxLength: 7 }),
+                )
+            ),
+            async ([nodes, constraints]) => {
+                const layout = buildLayout(nodes, constraints);
+                await checkModalAgainstOracle(layout, { canExactOrdering: true, canExactAlignment: true });
+            }
+        ), { numRuns: MODAL_RUNS, seed: MODAL_SEED, timeout: 120_000 });
     });
 
     it('random ordering + disjunction systems: modal claims are sound', async () => {
@@ -286,7 +459,32 @@ describe.runIf(available)('Modal query entailment vs Z3', () => {
                 // (see KNOWN INCOMPLETENESS below).
                 await checkModalAgainstOracle(layout, { canExactOrdering: false, canExactAlignment: false });
             }
-        ), { numRuns: 8, seed: 20260727, timeout: 120_000 });
+        ), { numRuns: MODAL_RUNS, seed: MODAL_SEED, timeout: 120_000 });
+    });
+
+    it('random systems with groups: modal claims are sound', async () => {
+        // Groups add bounding-box variables and Rule C member edges, so must
+        // paths can now run THROUGH a bbox. Nothing randomized covered that.
+        // Soundness only: the bbox inclusion disjunction has the same
+        // per-disjunction limit as any other (see KNOWN INCOMPLETENESS below).
+        await fc.assert(fc.asyncProperty(
+            arbNodePool(5).chain(nodes =>
+                fc.tuple(
+                    fc.constant(nodes),
+                    fc.array(arbOrdering(nodes), { minLength: 0, maxLength: 4 }),
+                    fc.integer({ min: 2, max: 3 }),
+                )
+            ),
+            async ([nodes, constraints, gSize]) => {
+                const memberIds = nodes.slice(0, gSize).map(n => n.id);
+                const group: LayoutGroup = {
+                    name: 'G0', nodeIds: memberIds, keyNodeId: memberIds[0],
+                    showLabel: true, sourceConstraint: GBF,
+                };
+                const layout = buildLayout(nodes, constraints, undefined, [group]);
+                await checkModalAgainstOracle(layout, { canExactOrdering: false, canExactAlignment: false });
+            }
+        ), { numRuns: MODAL_RUNS, seed: MODAL_SEED, timeout: 120_000 });
     });
 
     // ─── Known incompleteness ledger ────────────────────────────────────


### PR DESCRIPTION
This is test-only. No file under `src/` is changed.

## Why

The modal suite generated 16 systems per run. The feasibility suite generated 1250. The modal suite also ran on a fixed seed, so it examined the same 16 systems on every run and could never find anything new.

That is the wrong way round. The modal queries are the harder claim. Feasibility asks whether one valid layout exists. Modal queries state what is true across every valid layout, which is a statement about the whole solution set. A validator can be correct on the first and wrong on the second, and #524 was exactly that: feasibility verdicts were sound while `getMust` returned boxes that do not clear the target.

The modal API is also user-facing. It answers the `must`, `cannot` and `can` forms of the spatial query language (`src/evaluators/layout/layout-evaluator.ts`) and drives navigation in the explorer (`src/components/spytial-explorer/spytial-explorer.ts`). A wrong answer there is a wrong statement shown to a user. Nothing else catches it: the layout still renders and feasibility still says SAT.

Two of the four soundness bugs in the #523 campaign came from this suite, and they are the two that shipped (#517's `getCannotAligned`, #524's `getMust`).

## Oracle fix

`properBefore` compiled to `coord_a + size_a ≤ coord_b`. `notProperBefore` compiled to `≥`. The two overlapped at equality instead of being complements.

The mechanized definition is strict:

```
leftOf b₁ b₂ := b₁.x_tl + b₁.width < b₂.x_tl
```

So `notProperBefore` was right and `properBefore` was wrong. Two effects:

- A cannot-claim could be refuted by a model that only makes the pair touch, which is not "before" under the strict definition. That reports a disagreement that is not one.
- The can-side exactness check tested a weaker relation than it claimed, so it could miss an over-claim.

A zero-gap ordering forces exactly the touching model, so the overlap was reachable rather than academic. `properBefore` is now strict, and a new test asserts the two probes cannot both hold. I verified the test catches the defect: with `.le` restored it fails, with `.lt` it passes.

I did not find an input where this produced a wrong suite result. The system has only lower bounds, so a touching model can normally be stretched.

## Generator changes

**Gaps.** The DSL builders default to 15 and `negativeLeftOf` hard-codes 0, so the whole generated suite used exactly two gap values while node sizes ranged over 20 to 200. `isProperlyBefore` compares a summed path weight against one node size, so the gap-to-size ratio is what decides the answer, and it took two values. Gaps are now drawn from 0 to 40, with 0 weighted in because it is the touching boundary. `leftOf` and `aboveOf` take an optional `minDistance` and still default to 15, so existing fixtures are unchanged.

**Uniform node pools.** Sizes were drawn independently from 20 to 200, which makes an all-equal pool vanishingly unlikely. That is the degenerate case where the two readings of "before" coincide, and it is what many real diagrams look like. Pools are now uniform one time in five.

**Compound alternatives.** `arbDisjunction` and `arbRichDisjunction` both emit singleton alternatives over a single pair, so no generated alternative could fail partway through: the first constraint either went in or it did not. New `arbCompoundDisjunction` emits alternatives holding two constraints over two pairs, which reaches the partial-assignment undo path — add constraint 1, reject constraint 2, roll constraint 1 back. That is where #520's edge-deletion bug lived, and only a hand-written generator covered it before.

## Modal suite changes

Generated systems go from 16 to 120 per run.

- Default runs 8 to 30.
- New property for 5-node conjunctive systems. Three-hop paths only exist from 5 nodes up, and accumulated separation is what `isProperlyBefore` reads.
- New property for systems with groups. Groups add bounding-box variables and Rule C member edges, so a must path can run through a bbox. Nothing randomized covered that.
- `Z3_MODAL_RUNS` and `Z3_MODAL_SEED` override both knobs, so the same file can search instead of only regression-testing. The defaults stay fixed so PR CI remains a deterministic gate.
- The vitest timeout now scales with the run count. It was fixed at 120 s, and at 150 runs the 5-node property alone takes 72 s, so raising the run count used to surface as a timeout that reads like a hang.

New deterministic cases:

- The zero-gap touching boundary, and its one-unit-of-gap counterpart. These bracket the comparison exactly: at gap 0 the forced separation is exactly one box and the answer is false, at gap 1 it is true.
- Separation accumulated along a three-hop path, in two variants that differ only in the gap. At gap 15 the total is 70 and the 300-wide node still spans across the target. At gap 200 the total is 440 and it clears. Same shape, opposite answer, only the arithmetic changed.
- The same shape on the vertical axis through a y-alignment class.

## getReachable

It had no oracle coverage at all, despite #524 rewriting all four of its cases.

`getReachable` answers over the constraint set the CDCL committed to. `getMust` answers over the whole program. With no disjunctions and no groups there is nothing to commit, so the two sets are identical. The cross-check now asserts that, which pins `getReachable` to Z3 at no extra solver cost, because every `getMust` claim is already Z3-checked.

With disjunctions the committed set is a strengthening, so only a superset relation would hold. That is not asserted.

## Verification

| check | result |
|---|---|
| Modal, 3 seeds x 150 runs x 4 properties | 1800 generated systems, no disagreements |
| Feasibility, 5 consecutive full passes | clean; base also 5/5 |
| Full suite excluding Z3 | 2121 tests across 148 files pass |
| Typecheck | 73 errors, identical to base |

No validator bugs were found by the widened search.

Suite sizes:

| | tests | generated cases | wall time |
|---|---|---|---|
| feasibility, before | 50 | 1250 | 32 s |
| feasibility, after | 52 | 1550 | 32 s |
| modal, before | 11 | 16 | 5 s |
| modal, after | 19 | 120 | 32 s |

## One caveat

An early feasibility pass died with the documented single-monster-solve heap mode: heap at 2048 MB, the oracle marked itself `RUNTIME DEAD`, no disagreement reported. This is the failure mode the oracle's own comments describe, not a validator disagreement.

I suspected uniform pools were producing symmetric instances that are hard for Z3, so I forced uniform-only and varied-only and ran the negated-group tests three times each. Six of six clean. The hypothesis is not supported.

One occurrence in nine branch passes against zero in five base passes is not enough to attribute it to these changes, and not enough to rule it out. `solver-oracle` runs with `--bail=1`, so this pre-existing mode would fail that job if it hit.

## Not included

**Model harvesting.** The way to make modal cases cheap is to take one model, read the coordinates, and resolve many pairs at once, instead of one full solve per pair. Most of the current cost is the can-side exactness check, which fires one solve for every ordered pair. Harvesting would remove almost all of it and allow 250 or more runs in CI. At 30 runs the suite is 32 s, so this is not yet blocking.

**CI placement.** `tests/z3-modal-equivalence.test.ts` is not in the `solver-oracle` job. It runs in the main `test` job, which has no path filter and no `--bail=1`. These changes add about 26 s there. The `solver-oracle` path filter (`tests/.*z3`) already matches the modal file, so moving it is a one-line change, but it also means modal checks would be skipped when the filter does not fire. Left alone deliberately.

**Modal queries after `enforceMaximalFeasibleSubset`.** Still degenerate. `Counterfactuals.lean` defines that case as the realizations of the maximal feasible subset, which is never empty. Unchanged from #523's ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
