### PR TITLE
Move icons into atomStyle as an iconStyle block

### DIFF
--- a/docs/SPEC_EDITOR.md
+++ b/docs/SPEC_EDITOR.md
@@ -153,6 +153,17 @@ With a domain present you get:
 - **Relation / type dropdowns**: fields of kind `relationName` and `typeName`
   render as combo boxes (free text plus a dropdown of known names) instead of
   plain text inputs.
+
+Domain-independent, so available with or without a `domain`:
+
+- **Icon browser**: `atomStyle`'s `iconStyle.path` (kind `iconPath`) renders a
+  text input plus a button that opens a searchable grid of the icons bundled
+  with the package, previewed from their inlined data URIs. Picking one writes
+  the bundled *name* (`person`), not the resolved data URI, so the spec stays
+  readable. Typing stays authoritative — URLs, relative paths, and `pack:name`
+  references are unaffected. CDN packs are listed as guidance (prefix, name,
+  example) rather than thumbnails, since previewing them would need a network
+  round-trip.
 - **Soft warnings**: `relationName`/`typeName` values not present in the
   instance, and selector identifiers that match no domain type/relation/atom,
   surface as `source: 'domain'` diagnostics. **All domain diagnostics are
@@ -560,8 +571,14 @@ An `ItemDefinition` has:
 - `label`, optional `description`: shown in the add menu.
 - optional `deprecated`: parse/render but hide from the add menu.
 - `fields: FieldSpec[]`: the form. Each `FieldSpec` is
-  `{ key, kind, label, required?, options?, multiple?, default?, placeholder?, help?, selectorArity? }`.
-  `kind` is one of `selector | relationName | typeName | enum | number | color | text | boolean`.
+  `{ key, kind, label, required?, options?, multiple?, default?, placeholder?, help?, selectorArity?, children? }`.
+  `kind` is one of
+  `selector | relationName | typeName | enum | number | color | text | iconPath | boolean | group`.
+  `group` renders its `children` recursively as a nested block (`lineStyle`,
+  `textStyle`, `iconStyle`, …); `iconPath` renders a text input plus a browser
+  for the bundled icons. Fields inside a style block must not declare a
+  `default` — a seeded value would emit as authored YAML and break the style
+  resolver's compose / collision rules.
 - `summary(params)`: the one-line collapsed-row text.
 - optional `validate(params)`: extra structural diagnostics beyond required-field
   checks.

--- a/docs/YAML_SPECIFICATION.md
+++ b/docs/YAML_SPECIFICATION.md
@@ -396,7 +396,7 @@ Directives control visual styling and presentation without affecting layout stru
 
 ### Atom Style Directive (atomStyle)
 
-Styles the atoms (nodes) matching a selector. An atom is a composite of an interior **fill**, an outline **border**, and its **label**, so styling uses the shared `fillStyle`, `borderStyle`, and `textStyle` blocks (the same block vocabulary as `edgeStyle`'s `lineStyle`/`textStyle`).
+Styles the atoms (nodes) matching a selector. An atom is a composite of an interior **fill**, an outline **border**, an **icon**, and its **label**, so styling uses the shared `fillStyle`, `borderStyle`, `iconStyle`, and `textStyle` blocks (the same block vocabulary as `edgeStyle`'s `lineStyle`/`textStyle`).
 
 ```yaml
 - atomStyle:
@@ -406,23 +406,42 @@ Styles the atoms (nodes) matching a selector. An atom is a composite of an inter
     borderStyle:                 # Optional: the outline
       color: <color>
       width: <number>
+    iconStyle:                   # Optional: an icon drawn on the atom
+      path: <icon-path>
+      placement: <full|badge>
+      opacity: <0..1>
     textStyle:                   # Optional: the atom's own (name) label
       size: <small|normal|large>
       color: <color>
+    showLabel: <boolean>         # Optional: whether the atom's label is drawn
 ```
 
 **Fields:**
 
-| Field | Required | Type | Description |
-|-------|----------|------|-------------|
-| `selector` | ❌ No | string | Unary selector for target atoms; absent styles every atom |
-| `fillStyle.color` | ❌ No | string | CSS color of the node's interior fill (opt-in; the default is an unfilled Tufte look where only stroke + label mark the node) |
-| `borderStyle.color` | ❌ No | string | CSS color of the node's outline |
-| `borderStyle.width` | ❌ No | number | Outline thickness in pixels (must be > 0) |
-| `textStyle.size` | ❌ No | enum | `small`, `normal`, or `large` — *reserved; not yet applied to the node's own label* |
-| `textStyle.color` | ❌ No | string | CSS color of the atom's label |
+| Field | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `selector` | ❌ No | string | all atoms | Unary selector for target atoms |
+| `fillStyle.color` | ❌ No | string | — | CSS color of the node's interior fill (opt-in; the default is an unfilled Tufte look where only stroke + label mark the node) |
+| `borderStyle.color` | ❌ No | string | — | CSS color of the node's outline |
+| `borderStyle.width` | ❌ No | number | — | Outline thickness in pixels (must be > 0) |
+| `iconStyle.path` | ❌ No | string | — | Icon path, URL, bundled name (`person`), or icon-pack reference (`bi:person-fill`) |
+| `iconStyle.placement` | ❌ No | enum | `full` | `full` — the icon occupies the box; `badge` — a small top-right marker |
+| `iconStyle.opacity` | ❌ No | number | `1` | Icon alpha in `[0,1]`; out-of-range values are ignored |
+| `textStyle.size` | ❌ No | enum | `normal` | `small`, `normal`, or `large` — *reserved; not yet applied to the node's own label* |
+| `textStyle.color` | ❌ No | string | — | CSS color of the atom's label |
+| `showLabel` | ❌ No | boolean | `true` | Whether the atom's label is drawn |
 
-**Inheritance & conflicts:** rules match atoms through their selector, and a supertype selector already returns subtype atoms — so a `Node` rule and a `RedNode` rule both apply to a `RedNode` atom, their set properties **composing** (gap-fill inheritance up the type hierarchy). Two rules that set the *same* property to *different* values is an error: styles never silently override.
+**Inheritance & conflicts:** rules match atoms through their selector, and a supertype selector already returns subtype atoms — so a `Node` rule and a `RedNode` rule both apply to a `RedNode` atom, their set properties **composing** (gap-fill inheritance up the type hierarchy). Two rules that set the *same* property to *different* values is an error: styles never silently override. This applies to `iconStyle` like any other block, so a supertype can supply the `path` and a subtype tune only its `opacity`.
+
+**Icons and labels are independent.** `placement` controls the icon's geometry; `showLabel` controls whether the label draws. The three useful combinations:
+
+| Idiom | Spec | Result |
+|---|---|---|
+| **Glyph** | `placement: full`, `showLabel: false` | The icon *is* the node — the box goes transparent, no label |
+| **Badge** | `placement: badge`, `showLabel: true` | Small corner marker beside a normal labelled node |
+| **Watermark** | `placement: full`, `opacity: 0.15`, `showLabel: true` | Faded full-size icon behind the label |
+
+A `full` icon leaves the node's box transparent (so a group hull shows through) unless you ask for a `fillStyle.color`, which wins.
 
 **Examples:**
 
@@ -438,6 +457,25 @@ Styles the atoms (nodes) matching a selector. An atom is a composite of an inter
 - atomStyle:
     selector: Error
     borderStyle: { color: red }
+
+# Glyph: the icon replaces the node entirely
+- atomStyle:
+    selector: XCell
+    showLabel: false
+    iconStyle: { path: tic-x }
+
+# Badge: a lock marker alongside the label
+- atomStyle:
+    selector: Locked
+    iconStyle: { path: 'bi:lock-fill', placement: badge }
+
+# Watermark: every Person faded behind its label, Admins more strongly
+- atomStyle:
+    selector: Person
+    iconStyle: { path: person, opacity: 0.12 }
+- atomStyle:
+    selector: Admin
+    iconStyle: { opacity: 0.35 }   # inherits `path` from the Person rule
 ```
 
 **Migrating from `atomColor`:** `atomColor` (below) is the legacy flat form and still works; its `value` maps onto `borderStyle.color` (so existing diagrams keep their outlines exactly), and you can add a `fillStyle` for a real interior fill:
@@ -446,6 +484,15 @@ Styles the atoms (nodes) matching a selector. An atom is a composite of an inter
 |---|---|
 | `value` | `borderStyle.color` |
 | `selector` | `selector` |
+
+**Migrating from `icon`:** the legacy `icon` directive's single `showLabels` boolean drove label visibility *and* icon geometry at once. It splits into the two independent knobs:
+
+| `icon` | `atomStyle` |
+|---|---|
+| `path` | `iconStyle.path` |
+| `selector` | `selector` |
+| `showLabels: false` (default) | `showLabel: false` + `iconStyle.placement: full` |
+| `showLabels: true` | `showLabel: true` + `iconStyle.placement: badge` |
 
 ---
 
@@ -618,7 +665,9 @@ Customizes the appearance of edges for a specific field/relation.
 
 ---
 
-### Icon Directive
+### Icon Directive — *legacy*
+
+> **Deprecated:** prefer [`atomStyle`](#atom-style-directive-atomstyle) with an `iconStyle` block. `icon` still works and desugars onto `atomStyle` with a deprecation warning. See [Migrating from `icon`](#atom-style-directive-atomstyle) for the exact mapping — the one `showLabels` boolean becomes `showLabel` plus `iconStyle.placement`, which is what lets you fade an icon, or hide a label with no icon at all.
 
 Assigns an icon to atoms matching a selector.
 
@@ -636,6 +685,8 @@ Assigns an icon to atoms matching a selector.
 | `selector` | ✅ Yes | string | - | Unary selector for target atoms |
 | `path` | ✅ Yes | string | - | Icon path, URL, or registered icon name |
 | `showLabels` | ❌ No | boolean | `false` | Display text labels with the icon |
+
+A directive missing either required field draws nothing, and is dropped rather than desugared.
 
 **Examples:**
 
@@ -1025,25 +1076,29 @@ constraints:
 
 directives:
   # Visual styling
-  - atomColor:
+  - atomStyle:
       selector: Person
-      value: "#4a90d9"
+      borderStyle:
+        color: "#4a90d9"
   
-  - atomColor:
+  - atomStyle:
       selector: Error
-      value: red
+      borderStyle:
+        color: red
   
-  - icon:
+  - atomStyle:
       selector: File
-      path: "file-icon"
-      showLabels: true
+      iconStyle:
+        path: "file-icon"
+        placement: badge
   
   # Edge styling
-  - edgeColor:
+  - edgeStyle:
       field: error
-      value: red
-      style: dashed
-      weight: 2
+      lineStyle:
+        color: red
+        pattern: dashed
+        weight: 2
   
   # Convert to attributes
   - attribute:

--- a/docs/field-selectors.md
+++ b/docs/field-selectors.md
@@ -23,18 +23,16 @@ Field-based directives now support an optional `selector` parameter that specifi
 ```yaml
 directives:
   # Color name relations red, but only for Person atoms
-  - edgeColor:
+  - edgeStyle:
       field: 'name'
-      value: 'red'
       selector: 'Person'
-      style: 'dashed'
-      weight: 2
+      lineStyle: { color: 'red', pattern: 'dashed', weight: 2 }
       
   # Color name relations blue, but only for Car atoms
-  - edgeColor:
+  - edgeStyle:
       field: 'name'
-      value: 'blue'
       selector: 'Car'
+      lineStyle: { color: 'blue' }
       
   # Company name relations will remain default color (black)
 ```
@@ -111,21 +109,21 @@ directives:
 
 ### Edge Color with Value Filters
 
-The `filter` parameter works on edge color directives too:
+The `filter` parameter works on edge style directives too:
 
 ```yaml
 directives:
   # Color 'active' edges green only where value is True
-  - edgeColor:
+  - edgeStyle:
       field: 'active'
-      value: 'green'
       filter: 'active & (univ -> True)'
+      lineStyle: { color: 'green' }
   
   # Color 'active' edges red only where value is False  
-  - edgeColor:
+  - edgeStyle:
       field: 'active'
-      value: 'red'
       filter: 'active & (univ -> False)'
+      lineStyle: { color: 'red' }
 ```
 
 ### Group By Field with Selectors
@@ -147,9 +145,9 @@ Directives without selectors continue to work as before:
 ```yaml
 directives:
   # This still applies to ALL name relations (legacy behavior)
-  - edgeColor:
+  - edgeStyle:
       field: 'name'
-      value: 'green'
+      lineStyle: { color: 'green' }
 ```
 
 ## How It Works

--- a/site/directives.md
+++ b/site/directives.md
@@ -6,30 +6,48 @@ Directives control the **visual presentation** of your graph — colors, icons, 
 
 ## Atom Styling
 
-Styles the atoms (nodes) matching a selector. An atom has an interior **fill**, an outline **border**, and a **label**, styled with the shared `fillStyle`, `borderStyle`, and `textStyle` blocks — the same block vocabulary `edgeStyle` uses for lines and labels. Use `atomStyle` in the directives section.
+Styles the atoms (nodes) matching a selector. An atom has an interior **fill**, an outline **border**, an **icon**, and a **label**, styled with the shared `fillStyle`, `borderStyle`, `iconStyle`, and `textStyle` blocks — the same block vocabulary `edgeStyle` uses for lines and labels. Use `atomStyle` in the directives section.
 
 ```yaml
 - atomStyle:
     selector: <unary-selector>                        # Optional (absent = all atoms)
     fillStyle:   { color: <color> }                   # the interior fill (opt-in)
     borderStyle: { color: <color>, width: <number> }  # the outline
+    iconStyle:   { path: <icon-path>, placement: <full|badge>, opacity: <0..1> }
     textStyle:   { size: <small|normal|large>, color: <color> }  # the atom's label
+    showLabel:   <boolean>                            # Optional (default: true)
 ```
 
-| Field | Required | Type | Description |
-|-------|----------|------|-------------|
-| `selector` | No | string | Unary selector for target atoms; absent styles every atom |
-| `fillStyle.color` | No | string | Interior fill color (opt-in; the default is unfilled) |
-| `borderStyle.color` | No | string | Outline color |
-| `borderStyle.width` | No | number | Outline thickness in px (must be > 0) |
-| `textStyle.color` | No | string | Label color |
-| `textStyle.size` | No | enum | `small`/`normal`/`large` — *reserved; not yet applied to the node's own label* |
+| Field | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `selector` | No | string | all atoms | Unary selector for target atoms |
+| `fillStyle.color` | No | string | — | Interior fill color (opt-in; the default is unfilled) |
+| `borderStyle.color` | No | string | — | Outline color |
+| `borderStyle.width` | No | number | — | Outline thickness in px (must be > 0) |
+| `iconStyle.path` | No | string | — | Icon path, URL, or registered name — see [Icons](#icons) |
+| `iconStyle.placement` | No | enum | `full` | `full` (the icon occupies the box) or `badge` (small top-right marker) |
+| `iconStyle.opacity` | No | number | `1` | Icon alpha in `[0,1]` |
+| `textStyle.color` | No | string | — | Label color |
+| `textStyle.size` | No | enum | `normal` | `small`/`normal`/`large` — *reserved; not yet applied to the node's own label* |
+| `showLabel` | No | boolean | `true` | Whether the atom's label is drawn |
 
 You can use hex codes, named colors, `rgb()`, `hsl()`, etc.
 
-When several `atomStyle` rules match one atom their set properties **compose**; because a supertype selector already returns subtype atoms, a rule on a supertype and a rule on a subtype both apply (inheritance up the type hierarchy). Setting the *same* property two different ways is an error — no silent override.
+When several `atomStyle` rules match one atom their set properties **compose**; because a supertype selector already returns subtype atoms, a rule on a supertype and a rule on a subtype both apply (inheritance up the type hierarchy). Setting the *same* property two different ways is an error — no silent override. `iconStyle` composes like any other block, so a supertype can supply the icon and a subtype tune only its opacity.
+
+**Icons and labels are separate knobs.** `placement` sets the icon's geometry, `showLabel` decides whether the label draws — combine them freely:
+
+| Idiom | Spec | Result |
+|---|---|---|
+| **Glyph** | `placement: full`, `showLabel: false` | The icon *is* the node — transparent box, no label |
+| **Badge** | `placement: badge` | Small corner marker beside a normal labelled node |
+| **Watermark** | `placement: full`, low `opacity` | Faded full-size icon behind the label |
+
+A `full` icon leaves the box transparent (a group hull shows through it) unless you ask for a `fillStyle.color`, which wins.
 
 > **`atomColor` is the legacy form** and still works: `value`→`borderStyle.color`, so a node keeps its outline exactly as before. It desugars to `atomStyle` with a deprecation warning. Add a `fillStyle` to give a node a real interior fill.
+>
+> **`icon` is likewise legacy.** Its one `showLabels` boolean drove both label visibility and icon geometry: `showLabels: false` → `showLabel: false` + `placement: full`; `showLabels: true` → `showLabel: true` + `placement: badge`. It desugars with a deprecation warning.
 
 ### Examples
 
@@ -114,7 +132,7 @@ Customizes the appearance of edges for a specific field (relation). Use `edgeSty
 
 When several `edgeStyle` rules match one edge their set properties **compose**; setting the *same* property two different ways is an error — no silent override.
 
-> **`edgeColor` is the legacy form** and still works: `value`→`lineStyle.color`, `style`→`lineStyle.pattern`, `weight`→`lineStyle.weight`, `highlight`→`lineStyle.highlight`. It will desugar to `edgeStyle` with a deprecation warning. The scoping and example snippets below use `edgeColor`; swap the flat keys for the blocks above to get the `edgeStyle` form.
+> **`edgeColor` is the legacy form** and still works: `value`→`lineStyle.color`, `style`→`lineStyle.pattern`, `weight`→`lineStyle.weight`, `highlight`→`lineStyle.highlight`. It will desugar to `edgeStyle` with a deprecation warning.
 
 ### Scoping with `selector` and `filter`
 
@@ -122,54 +140,51 @@ When multiple types share the same field name (e.g., both `Person` and `Car` hav
 
 ```yaml
 # Color Person.name edges red
-- edgeColor:
+- edgeStyle:
     field: name
-    value: red
     selector: Person
+    lineStyle: { color: red }
 
 # Color Car.name edges blue
-- edgeColor:
+- edgeStyle:
     field: name
-    value: blue
     selector: Car
+    lineStyle: { color: blue }
 ```
 
 Use `filter` for finer control over which tuples are affected:
 
 ```yaml
 # Only style edges where the target is Active
-- edgeColor:
+- edgeStyle:
     field: status
-    value: green
     filter: "status & (univ -> Active)"
+    lineStyle: { color: green }
 ```
 
 ### Examples
 
 ```yaml
 # Color all 'parent' edges blue
-- edgeColor:
+- edgeStyle:
     field: parent
-    value: blue
+    lineStyle: { color: blue }
 
 # Dashed red edges with thicker lines
-- edgeColor:
+- edgeStyle:
     field: references
-    value: red
     selector: Document
-    style: dashed
-    weight: 2
+    lineStyle: { color: red, pattern: dashed, weight: 2 }
 
 # Hide edges but keep the relationship in the data
-- edgeColor:
+- edgeStyle:
     field: internal
-    value: gray
     hidden: true
 
 # Remove edge labels for cleaner look
-- edgeColor:
+- edgeStyle:
     field: owns
-    value: "#666"
+    lineStyle: { color: "#666" }
     showLabel: false
 ```
 
@@ -198,8 +213,8 @@ Use `filter` for finer control over which tuples are affected:
 constraints:
   - orientation: { selector: parent, directions: [above] }
 directives:
-  - edgeColor: { field: parent,     value: "blue" }
-  - edgeColor: { field: references, value: "red", selector: Document, style: dashed, weight: 2 }
+  - edgeStyle: { field: parent,     lineStyle: { color: "blue" } }
+  - edgeStyle: { field: references, selector: Document, lineStyle: { color: "red", pattern: dashed, weight: 2 } }
 </template>
 </div>
 
@@ -207,20 +222,19 @@ directives:
 
 ## Icons
 
-Assigns an icon to nodes matching a selector. Replaces the default rectangular node appearance.
+Icons are part of [atom styling](#atom-styling) — set them with an `iconStyle` block:
 
 ```yaml
-- icon:
-    selector: <unary-selector>   # Required
-    path: <icon-path>            # Required
-    showLabels: <boolean>        # Optional (default: false)
+- atomStyle:
+    selector: <unary-selector>
+    iconStyle:
+      path: <icon-path>            # bundled name, pack reference, URL, or path
+      placement: <full|badge>      # Optional (default: full)
+      opacity: <0..1>              # Optional (default: 1)
+    showLabel: <boolean>           # Optional (default: true)
 ```
 
-| Field | Required | Type | Default | Description |
-|-------|----------|------|---------|-------------|
-| `selector` | Yes | string | — | Unary selector for target atoms |
-| `path` | Yes | string | — | Icon path, URL, or registered icon name |
-| `showLabels` | No | boolean | `false` | Show text labels alongside the icon |
+> The standalone `- icon:` directive is deprecated but still works. See the [atom styling](#atom-styling) section for how its `showLabels` flag maps onto `showLabel` + `placement`.
 
 ### Icon Sources
 
@@ -272,35 +286,38 @@ Use a prefix to pull icons from popular icon libraries:
 ### Examples
 
 ```yaml
-# Bundled icon
-- icon:
+# Bundled icon as a corner badge, label kept
+- atomStyle:
     selector: Person
-    path: "person"
-    showLabels: true
+    iconStyle: { path: "person", placement: badge }
 
 # Bootstrap Icons pack
-- icon:
+- atomStyle:
     selector: Folder
-    path: "bi:folder2-open"
-    showLabels: true
-
-# Lucide pack
-- icon:
-    selector: Settings
-    path: "lucide:settings"
+    iconStyle: { path: "bi:folder2-open", placement: badge }
 
 # External URL
-- icon:
+- atomStyle:
     selector: File
-    path: "https://example.com/icons/file.svg"
+    iconStyle: { path: "https://example.com/icons/file.svg" }
 
-# Shapes for game boards
-- icon:
+# Shapes for game boards — the icon replaces the node entirely
+- atomStyle:
     selector: XPlayer
-    path: "tic-x"
-- icon:
+    showLabel: false
+    iconStyle: { path: "tic-x" }
+- atomStyle:
     selector: OPlayer
-    path: "tic-o"
+    showLabel: false
+    iconStyle: { path: "tic-o" }
+
+# Watermark: a faded icon behind the label, stronger for admins
+- atomStyle:
+    selector: Person
+    iconStyle: { path: "person", opacity: 0.12 }
+- atomStyle:
+    selector: Admin
+    iconStyle: { opacity: 0.35 }   # path inherited from the Person rule
 ```
 
 <div class="spytial-diagram" data-height="340" data-caption="Live: bundled icons replace the default rectangles — Person uses person, Folder uses folder.">
@@ -322,8 +339,8 @@ Use a prefix to pull icons from popular icon libraries:
 </template>
 <template class="spec">
 directives:
-  - icon: { selector: Person, path: "person", showLabels: true }
-  - icon: { selector: Folder, path: "folder", showLabels: true }
+  - atomStyle: { selector: Person, iconStyle: { path: "person", placement: badge } }
+  - atomStyle: { selector: Folder, iconStyle: { path: "folder", placement: badge } }
 </template>
 </div>
 

--- a/site/examples/ttt/layout.cnd
+++ b/site/examples/ttt/layout.cnd
@@ -3,8 +3,8 @@ constraints:
   - orientation: {selector: right, directions: [directlyRight]}
 
 directives:
-  - icon: {showLabels: false, selector: '{ x : Cell | (some x.mark) and x.mark in O}', path: tic-o}
-  - icon: {showLabels: false, selector: '{ x : Cell | (some x.mark) and x.mark in X}', path: tic-x}
+  - atomStyle: {showLabel: false, selector: '{ x : Cell | (some x.mark) and x.mark in O}', iconStyle: {path: tic-o}}
+  - atomStyle: {showLabel: false, selector: '{ x : Cell | (some x.mark) and x.mark in X}', iconStyle: {path: tic-x}}
   - hideAtom: {selector: O + X}
   - hideField: {field: down}
   - hideField: {field: right}

--- a/site/selectors.md
+++ b/site/selectors.md
@@ -32,7 +32,7 @@ The key concept to understand is **arity** — how many "columns" a selector ret
 
 A **unary selector** returns a *set of atoms*. It answers the question: **"which nodes?"**
 
-Used by: `atomStyle`, `align`, `hideAtom`, `icon`, `size`, `group` (by selector)
+Used by: `atomStyle`, `align`, `hideAtom`, `size`, `group` (by selector)
 
 ```yaml
 # All Node atoms

--- a/site/yaml-reference.md
+++ b/site/yaml-reference.md
@@ -52,7 +52,7 @@ Both sections are optional. An empty specification is valid.
 
 Selectors use [Forge](https://forge-fm.org/docs/building-models/constraints/formulas-and-expressions/) relational syntax. [AlaSQL](https://alasql.org/) is also supported as an alternative. See the full [Selector Syntax](selectors.md) guide.
 
-**Unary selectors** return a set of atoms — used by `atomStyle`, `align`, `hideAtom`, `icon`, `group`, `size`:
+**Unary selectors** return a set of atoms — used by `atomStyle`, `align`, `hideAtom`, `group`, `size`:
 
 ```yaml
 selector: Node                        # All Node atoms
@@ -115,10 +115,11 @@ directives:
       value: currentGrade
       textStyle: { size: small, color: "#2980b9" }
 
-  - icon:
+  - atomStyle:
       selector: File
-      path: "file-icon"
-      showLabels: true
+      iconStyle:
+        path: "file-icon"
+        placement: badge
 
   - hideField:
       field: internal

--- a/src/components/NoCodeView/types.ts
+++ b/src/components/NoCodeView/types.ts
@@ -9,7 +9,28 @@ export type ConstraintType = 'orientation' | 'cyclic' | 'align' | 'groupfield' |
 /**
  * Directive types supported by the CND layout system
  * Following cnd-core TypeScript strict typing guidelines
- * 
+ *
+ * `atomStyle` and `edgeStyle` are the current styling forms — composite,
+ * selector-matched, and resolved through the shared style resolver. The three
+ * legacy members below them (`atomColor`, `edgeColor`, `icon`) are still parsed
+ * and rendered, each desugaring onto one of those two behind a deprecation
+ * warning, so they stay in the union; prefer the style forms in new specs.
+ *
  * @public
  */
-export type DirectiveType = 'attribute' | 'hideField' | 'icon' | 'atomColor' | 'edgeColor' | 'size' | 'flag' | 'inferredEdge' | 'hideAtom' | 'tag';
+export type DirectiveType =
+    | 'attribute'
+    | 'hideField'
+    | 'atomStyle'
+    | 'edgeStyle'
+    | 'size'
+    | 'flag'
+    | 'inferredEdge'
+    | 'hideAtom'
+    | 'tag'
+    /** @deprecated Use `atomStyle` with a `borderStyle` block. */
+    | 'atomColor'
+    /** @deprecated Use `edgeStyle` with a `lineStyle` block. */
+    | 'edgeColor'
+    /** @deprecated Use `atomStyle` with an `iconStyle` block. */
+    | 'icon';

--- a/src/layout/icon-registry.ts
+++ b/src/layout/icon-registry.ts
@@ -75,6 +75,19 @@ const BUNDLED_ICONS: Record<string, string> = {
   'key': `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M0 8a4 4 0 0 1 7.465-2H14a.5.5 0 0 1 .354.146l1.5 1.5a.5.5 0 0 1 0 .708l-1.5 1.5a.5.5 0 0 1-.708 0L13 9.207l-.646.647a.5.5 0 0 1-.708 0L11 9.207l-.646.647a.5.5 0 0 1-.708 0L9 9.207l-.646.647A.5.5 0 0 1 8 10h-.535A4 4 0 0 1 0 8m4-3a3 3 0 1 0 2.712 4.285A.5.5 0 0 1 7.163 9h.63l.853-.854a.5.5 0 0 1 .708 0l.646.647.646-.647a.5.5 0 0 1 .708 0l.646.647.646-.647a.5.5 0 0 1 .708 0l.646.647.793-.793-1-1h-6.63a.5.5 0 0 1-.451-.285A3 3 0 0 0 4 5m-1.5 3a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0"/></svg>')}`,
 };
 
+/**
+ * Drawn in place of an icon whose URL fails to load — a broken-image glyph,
+ * inlined as a data URI.
+ *
+ * Deliberately not a packaged asset path: a relative URL would resolve against
+ * the *host application*, not this package, so it would 404 for every library
+ * consumer and could fire another error event. A data URI needs no network and
+ * no bundling, so it renders identically everywhere — which matters most for an
+ * icon-only (`placement: full`) atom, where losing the icon would otherwise
+ * leave an empty transparent box with no label to explain it.
+ */
+export const FALLBACK_ICON: string = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5"/><line x1="2" y1="13" x2="14" y2="3" stroke-dasharray="2 1.5"/></svg>')}`;
+
 // CDN-based icon packs (requires internet access)
 // These resolve icon names to CDN URLs
 const ICON_PACK_CDNS: Record<string, (name: string) => string> = {

--- a/src/layout/icon-registry.ts
+++ b/src/layout/icon-registry.ts
@@ -177,10 +177,77 @@ export function getIconPackPrefixes(): string[] {
 }
 
 /**
+ * Human-readable name for each pack prefix, for UI that offers packs as a
+ * choice. Kept beside {@link ICON_PACK_CDNS} rather than folded into it so the
+ * resolver stays a plain prefix→URL map; a test asserts every prefix has a
+ * label, so the two cannot drift.
+ */
+const ICON_PACK_LABELS: Record<string, string> = {
+  'bi': 'Bootstrap Icons',
+  'fa': 'FontAwesome (solid)',
+  'fa-solid': 'FontAwesome (solid)',
+  'fa-regular': 'FontAwesome (regular)',
+  'fa-brands': 'FontAwesome (brands)',
+  'lucide': 'Lucide',
+  'heroicons': 'Heroicons (outline)',
+  'heroicons-solid': 'Heroicons (solid)',
+  'tabler': 'Tabler Icons',
+  'simple': 'Simple Icons (brands)',
+};
+
+/** A CDN icon pack, described for display. */
+export interface IconPackInfo {
+  /** The prefix an author writes, e.g. `bi`. */
+  prefix: string;
+  /** Human-readable pack name, e.g. `Bootstrap Icons`. */
+  label: string;
+  /** A representative reference an author could paste, e.g. `bi:person-fill`. */
+  example: string;
+}
+
+/**
+ * The icon packs, described for a picker or docs. These resolve to CDN URLs at
+ * render time, so unlike the bundled set they cannot be previewed offline —
+ * consumers should present them as guidance (prefix + name) rather than
+ * thumbnails.
+ */
+export function getIconPacks(): IconPackInfo[] {
+  return Object.keys(ICON_PACK_CDNS).map((prefix) => ({
+    prefix,
+    label: ICON_PACK_LABELS[prefix] ?? prefix,
+    example: `${prefix}:${prefix.startsWith('fa') || prefix === 'bi' ? 'person' : 'home'}`,
+  }));
+}
+
+/**
  * Check if an icon name is a bundled icon.
  */
 export function isBundledIcon(iconPath: string): boolean {
   return iconPath in BUNDLED_ICONS;
+}
+
+const BUNDLED_PREFIX = 'data:image/svg+xml,';
+
+/**
+ * The raw SVG markup of a bundled icon, or `undefined` for anything not in the
+ * bundled set (a URL, a relative path, a `pack:name` reference).
+ *
+ * Why this exists: the bundled glyphs are drawn with `fill="currentColor"`, and
+ * `currentColor` inside an SVG loaded through `<img>` resolves against the SVG
+ * *document* — whose initial `color` is black — not the host page. So an `<img>`
+ * thumbnail is always black no matter what the surrounding theme is, which is
+ * invisible on a dark surface. Inlining the markup instead lets `color` cascade
+ * in normally.
+ *
+ * Returning `undefined` for everything else is the safety property, not an
+ * omission: only markup this module authored at compile time is ever eligible
+ * for inlining, so a caller cannot be tricked into injecting a user-supplied
+ * string by passing it here.
+ */
+export function getBundledIconSvg(name: string): string | undefined {
+  const uri = BUNDLED_ICONS[name];
+  if (!uri) return undefined;
+  return decodeURIComponent(uri.slice(BUNDLED_PREFIX.length));
 }
 
 /**

--- a/src/layout/interfaces.ts
+++ b/src/layout/interfaces.ts
@@ -2,6 +2,7 @@ import { Group } from "webcola";
 import { RelativeOrientationConstraint, CyclicOrientationConstraint, AlignConstraint, GroupByField, GroupBySelector, RelativeDirection } from "./layoutspec";
 import { EdgeStyle } from "./edge-style";
 import type { TextStyle } from "./style/text-style";
+import type { IconPlacement } from "./style/atom-style-spec";
 import type { LayoutWarning } from "./error-state";
 
 export interface LayoutGroup {
@@ -110,11 +111,25 @@ export interface LayoutNode {
      * metadata in the data instance.
      */
     labels?: Record<string, string[]>;
+    /** Resolved icon URL / data URI from `atomStyle.iconStyle.path`. Empty = no icon. */
     icon? : string;
+    /**
+     * How {@link icon} draws: `full` (occupies the box, which stays transparent
+     * unless an explicit fill was asked for) or `badge` (small top-right marker).
+     * Defaults to `full`. Meaningless without an {@link icon}.
+     */
+    iconPlacement? : IconPlacement;
+    /** Icon alpha in [0,1] from `atomStyle.iconStyle.opacity`. Undefined = opaque. */
+    iconOpacity? : number;
     width : number;
     height : number;
     mostSpecificType : string;
     types : string[];
+    /**
+     * Whether the atom's label is drawn, from `atomStyle.showLabel` (default true).
+     * Named plural for back-compat with the render contract; the spec-level key is
+     * the singular `showLabel`, matching `edgeStyle`.
+     */
     showLabels : boolean;
     /** True when the node has no edges connecting it to the rest of the graph. */
     disconnected?: boolean;

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -2,7 +2,6 @@ import { Graph, Edge } from 'graphlib';
 import { IAtom, IDataInstance } from '../data-instance/interfaces';
 import { type PositionalConstraintError, type GroupOverlapError, type HiddenNodeConflictError, type IConstraintValidator, isPositionalConstraintError, isGroupOverlapError, isHiddenNodeConflictError } from './constraint-types';
 import { EdgeStyle, normalizeEdgeStyle } from './edge-style';
-import { resolveIconPath } from './icon-registry';
 import type { SelectorErrorDetail, LayoutWarning } from './error-state';
 
 
@@ -1615,10 +1614,8 @@ export class LayoutInstance {
 
         this.ensureNoExtraNodes(g, a, groups);
 
-        // Recompute visual maps after graph mutations (inferred edges / node removal)
-        let nodeIconMap = this.getNodeIconMap(g);
-        // Resolve atomStyle once: it feeds both the border color (via the color
-        // map) and the node's fill / border-width / label styling below.
+        // Resolve atomStyle once: it feeds the border color (via the color map)
+        // and the node's fill / border-width / label / icon styling below.
         let atomStyleMap = this.getAtomStyleMap(g, ai);
         let { colorMap: nodeColorMap, explicitlyColored } = this.getNodeColorMap(g, ai, atomStyleMap);
 
@@ -1647,10 +1644,6 @@ export class LayoutInstance {
             let colorSource = explicitlyColored.has(nodeId)
                 ? ColorSource.Directive
                 : ColorSource.DefaultPalette;
-            let iconDetails = nodeIconMap[nodeId];
-            let iconPath = iconDetails.path;
-            let showLabels = iconDetails.showLabels;
-
             let { height, width } = nodeSizeMap[nodeId];
 
             const mostSpecificType = this.getMostSpecificType(nodeId, a);
@@ -1670,9 +1663,17 @@ export class LayoutInstance {
                 nodeLabels = atom.labels;
             }
 
-            // Fill / border-width / label styling from the resolved atomStyle
-            // (border *color* already flowed through nodeColorMap → color above).
+            // Fill / border-width / label / icon styling from the resolved
+            // atomStyle (border *color* already flowed through nodeColorMap →
+            // color above).
             const atomStyle = atomStyleMap[nodeId];
+            const iconStyle = atomStyle?.iconStyle;
+            // An atom shows its label unless a rule says otherwise; the legacy
+            // `icon` directive desugars an explicit false for its icon-only default.
+            const showLabels = atomStyle?.showLabel ?? true;
+            // Placement only matters once there is a path to draw; `full` is the
+            // default so a bare `iconStyle: { path }` reads as "this icon IS the atom".
+            const iconPlacement = iconStyle?.placement ?? 'full';
 
             return {
                 id: nodeId,
@@ -1687,7 +1688,9 @@ export class LayoutInstance {
                 attributes: nodeAttributes,
                 attributeTextStyles: nodeAttributeTextStyles,
                 labels: nodeLabels,
-                icon: iconPath,
+                icon: iconStyle?.path ?? this.DEFAULT_NODE_ICON_PATH,
+                iconPlacement: iconPlacement,
+                iconOpacity: iconStyle?.opacity,
                 height: height,
                 width: width,
                 mostSpecificType: mostSpecificType,
@@ -3229,52 +3232,6 @@ export class LayoutInstance {
         });
 
         return { colorMap: nodeColorMap, explicitlyColored };
-    }
-
-    private getNodeIconMap(g: Graph): Record<string, { path: string, showLabels: boolean }> {
-        let nodeIconMap: Record<string, { path: string, showLabels: boolean }> = {};
-        const DEFAULT_ICON = this.DEFAULT_NODE_ICON_PATH;
-
-        // Apply icon directives first
-        let iconDirectives = this._layoutSpec.directives.icons;
-        iconDirectives.forEach((iconDirective, specIndex) => {
-            let selected: string[];
-            try {
-                const selectorRes = this.evaluator.evaluate(iconDirective.selector, { instanceIndex: this.instanceNum });
-                if (!this.acceptSelectorResult(selectorRes, iconDirective.selector, 'icon selector', 'unary', 'icon', specIndex)) {
-                    return; // Skip this directive only
-                }
-                selected = selectorRes.selectedAtoms();
-            } catch (error) {
-                this.recordSelectorError(iconDirective.selector, 'icon selector', error);
-                return; // Skip this icon directive
-            }
-            let iconPath = iconDirective.path;
-
-            selected.forEach((nodeId) => {
-                // Resolve icon path (handles bundled icons, icon packs, and URLs)
-                const resolvedPath = resolveIconPath(iconPath);
-                if (nodeIconMap[nodeId]) {
-                    const existingIcon = nodeIconMap[nodeId];
-                    if (existingIcon.path !== resolvedPath || existingIcon.showLabels !== iconDirective.showLabels) {
-                        throw new Error(
-                            `Icon Conflict: "${nodeId}" cannot have multiple icons: ${JSON.stringify(existingIcon)}, ${JSON.stringify({ path: resolvedPath, showLabels: iconDirective.showLabels })}.`
-                        );
-                    }
-                }
-                nodeIconMap[nodeId] = { path: resolvedPath, showLabels: iconDirective.showLabels };
-            });
-        });
-
-        // Set default icons for nodes that do not have an icon set
-        let graphNodes = [...g.nodes()];
-        graphNodes.forEach((nodeId) => {
-            if (!nodeIconMap[nodeId]) {
-                nodeIconMap[nodeId] = { path: DEFAULT_ICON, showLabels: true };
-            }
-        });
-
-        return nodeIconMap;
     }
 
     /**

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -22,7 +22,7 @@ import {
 } from './layoutspec';
 import { resolveEdgeStyle } from './style/edge-style-spec';
 import type { EdgeStyleSpec, LineStyle } from './style/edge-style-spec';
-import { resolveAtomStyle } from './style/atom-style-spec';
+import { resolveAtomStyle, iconToAtomStyleRule } from './style/atom-style-spec';
 import type { AtomStyleRule, AtomStyleSpec } from './style/atom-style-spec';
 import type { TextStyle } from './style/text-style';
 
@@ -288,6 +288,58 @@ class LayoutNodePath {
     static areEquivalent(p1: LayoutNodePath, p2: LayoutNodePath): boolean {
         return p1.isSubpathOf(p2) && p2.isSubpathOf(p1);
     }
+}
+
+
+/**
+ * Desugar any legacy directives still sitting on a {@link LayoutSpec} into the
+ * `atomStyle` rules the layout actually reads.
+ *
+ * `parseLayoutSpec` already does this for YAML, leaving `icons`/`atomColors`
+ * empty — but a `LayoutSpec` can also arrive as an object, via the
+ * `setupLayout(spec: LayoutSpec, ...)` overload or `new LayoutInstance(spec)`
+ * directly. Those paths never touch the parser, so a programmatically-built
+ * spec would populate `directives.icons` and have it silently ignored: nothing
+ * reads those arrays any more.
+ *
+ * `atomColors` carries the same latent hole — nothing has read it since the
+ * legacy color desugar landed — so it is normalized here too. Note these arrays
+ * hold *parsed* directives, not raw YAML: an {@link AtomColorDirective} spells
+ * its color `color`, where the YAML form (which `atomColorToAtomStyleRule`
+ * consumes) spells it `value`. Hence the mapping below rather than a reuse of
+ * that parser-side helper. {@link AtomIconDirective} happens to match the YAML
+ * shape exactly, so it can go through {@link iconToAtomStyleRule} directly.
+ *
+ * Idempotent by construction — a parsed spec has empty legacy arrays, so this
+ * is a no-op and returns the spec untouched. Only a spec that actually carries
+ * legacy directives is copied (shallowly, so the caller's object isn't
+ * mutated). Selectorless/pathless entries drop, matching the parser exactly.
+ */
+export function normalizeLegacyDirectives(spec: LayoutSpec): LayoutSpec {
+    const legacyIcons = spec.directives?.icons ?? [];
+    const legacyAtomColors = spec.directives?.atomColors ?? [];
+    if (legacyIcons.length === 0 && legacyAtomColors.length === 0) return spec;
+
+    const fromAtomColors: (AtomStyleRule | null)[] = legacyAtomColors.map((d) => {
+        if (!d.selector || d.selector.trim().length === 0) return null;
+        if (typeof d.color !== 'string' || d.color.length === 0) return null;
+        return { selector: d.selector, style: { borderStyle: { color: d.color } } };
+    });
+
+    const desugared: AtomStyleRule[] = [
+        ...fromAtomColors,
+        ...legacyIcons.map(iconToAtomStyleRule),
+    ].filter((rule): rule is AtomStyleRule => rule !== null);
+
+    return {
+        ...spec,
+        directives: {
+            ...spec.directives,
+            atomStyles: [...spec.directives.atomStyles, ...desugared],
+            icons: [],
+            atomColors: [],
+        },
+    };
 }
 
 
@@ -661,7 +713,7 @@ export class LayoutInstance {
     ) {
         this.instanceNum = instNum;
         this.evaluator = evaluator;
-        this._layoutSpec = layoutSpec;
+        this._layoutSpec = normalizeLegacyDirectives(layoutSpec);
 
         // Handle backward compatibility: if alignmentEdgeStrategy is provided, use it
         // Otherwise, convert boolean addAlignmentEdges to strategy

--- a/src/layout/layoutspec.ts
+++ b/src/layout/layoutspec.ts
@@ -2,7 +2,7 @@ import * as yaml from 'js-yaml';
 import { EdgeStyle } from './edge-style';
 import { EdgeStyleRule, parseEdgeStyleSpec, edgeColorToEdgeStyleRule } from './style/edge-style-spec';
 import type { LineStyle } from './style/edge-style-spec';
-import { AtomStyleRule, parseAtomStyleSpec, atomColorToAtomStyleRule } from './style/atom-style-spec';
+import { AtomStyleRule, parseAtomStyleSpec, atomColorToAtomStyleRule, iconToAtomStyleRule } from './style/atom-style-spec';
 import { parseTextStyle } from './style/text-style';
 import type { TextStyle } from './style/text-style';
 
@@ -990,15 +990,29 @@ function parseDirectives(directives: unknown[], warnings: ParseWarning[] = []): 
 
     // CURRENTLY NO SUGAR HERE!
 
-    let icons : AtomIconDirective[] = typedDirectives.filter(d => d.icon)
-                .map(d => {
-
-                    return {
-                        path: d.icon.path,
-                        selector: d.icon.selector,
-                        showLabels: d.icon.showLabels || false 
-                    }
-                });
+    // icon is the deprecated flat form of atomStyle's `iconStyle` block. Its one
+    // `showLabels` boolean conflated label visibility with icon geometry; the
+    // desugar splits it into `showLabel` + `iconStyle.placement` (see
+    // iconToAtomStyleRule for the exact, behavior-preserving mapping) so icons
+    // resolve through the single atomStyle path — composing, inheriting, and
+    // colliding by the same rules as every other atom style.
+    // `icons` is kept empty only to satisfy the DirectivesBlock shape.
+    const rawIcons = typedDirectives.filter(d => d.icon);
+    if (rawIcons.length > 0) {
+        deprecate(
+            'icon',
+            "[spytial] 'icon' is deprecated and will be removed in a future major; " +
+            "use 'atomStyle' with an 'iconStyle' block ({ path, placement: full | badge, opacity }), " +
+            "and atomStyle's own 'showLabel' to control the atom's label."
+        );
+    }
+    // A selectorless or pathless icon desugars to null and is dropped — it drew
+    // nothing before, and must not become a graph-wide icon now that an absent
+    // atomStyle selector means "every atom".
+    const desugaredIcons: AtomStyleRule[] = rawIcons
+        .map(d => iconToAtomStyleRule(d.icon))
+        .filter((rule): rule is AtomStyleRule => rule !== null);
+    let icons : AtomIconDirective[] = [];
     // atomColor is the deprecated flat form of atomStyle. Desugar each into an
     // AtomStyleRule (border-preserving: value→borderStyle.color, so existing
     // diagrams stay outlined exactly as before) and resolve through the one
@@ -1125,16 +1139,17 @@ function parseDirectives(directives: unknown[], warnings: ParseWarning[] = []): 
     // Desugared legacy edgeColor rules join the native ones — one resolution path.
     edgeStyles = [...edgeStyles, ...desugaredEdgeColors];
 
-    // atomStyle (composite: fillStyle + borderStyle + textStyle), keyed by an
-    // optional unary selector. Native rules plus desugared legacy atomColor rules
-    // resolve through the one atomStyle path.
+    // atomStyle (composite: fillStyle + borderStyle + textStyle + iconStyle, plus
+    // the showLabel behavior flag), keyed by an optional unary selector. Native
+    // rules plus desugared legacy atomColor / icon rules resolve through the one
+    // atomStyle path.
     let atomStyles : AtomStyleRule[] = typedDirectives.filter(d => d.atomStyle).map(d => {
         return {
             selector: d.atomStyle.selector,
             style: parseAtomStyleSpec(d.atomStyle)
         }
     });
-    atomStyles = [...atomStyles, ...desugaredAtomColors];
+    atomStyles = [...atomStyles, ...desugaredAtomColors, ...desugaredIcons];
 
     return {
         atomColors,

--- a/src/layout/style/atom-style-spec.ts
+++ b/src/layout/style/atom-style-spec.ts
@@ -16,6 +16,7 @@ import { parseTextStyle } from './text-style';
 import type { TextStyle } from './text-style';
 import { resolveStyle } from './style-resolver';
 import type { StyleContribution } from './style-resolver';
+import { resolveIconPath } from '../icon-registry';
 
 /** Sparse fill styling of an atom's rectangle. `type`, so it stays assignable to SparseStyle. */
 export type FillStyle = {
@@ -28,11 +29,53 @@ export type BorderStyle = {
     width?: number;
 };
 
+/**
+ * Where an atom's icon draws relative to its box:
+ *  - `full`  — the icon occupies the whole box (the box itself stays transparent
+ *              unless a `fillStyle.color` was asked for). With the label hidden
+ *              this is the glyph idiom; with the label shown and a low
+ *              {@link IconStyle.opacity} it is the watermark idiom.
+ *  - `badge` — a small marker in the top-right corner, secondary to the label.
+ */
+export const ICON_PLACEMENTS = ['full', 'badge'] as const;
+export type IconPlacement = typeof ICON_PLACEMENTS[number];
+
+function isIconPlacement(v: unknown): v is IconPlacement {
+    return typeof v === 'string' && (ICON_PLACEMENTS as readonly string[]).includes(v);
+}
+
+/**
+ * Sparse icon styling of an atom. `type`, so it stays assignable to SparseStyle.
+ *
+ * `path` is stored already resolved (bundled name / pack reference / URL →
+ * concrete URL or data URI) so the style resolver compares canonical values:
+ * two rules naming the same icon different ways compose instead of colliding.
+ *
+ * Every leaf is optional — including `path` — so a supertype rule can supply the
+ * icon and a subtype rule tune only its `opacity`, which is the gap-fill
+ * inheritance the shared resolver provides. An `iconStyle` that resolves without
+ * a `path` draws nothing.
+ */
+export type IconStyle = {
+    path?: string;
+    placement?: IconPlacement;
+    /** Alpha in [0,1]. Absent = fully opaque. */
+    opacity?: number;
+};
+
 /** The full sparse payload of an `atomStyle` directive. `type`, so it stays assignable to SparseStyle. */
 export type AtomStyleSpec = {
     fillStyle?: FillStyle;
     borderStyle?: BorderStyle;
     textStyle?: TextStyle;
+    iconStyle?: IconStyle;
+    /**
+     * Whether the atom's label is drawn (behavior, not appearance — the same
+     * split `edgeStyle` makes with its own `showLabel`). Defaults to `true` at
+     * consumption; the deprecated `icon` directive desugars an explicit `false`
+     * to preserve its icon-only default.
+     */
+    showLabel?: boolean;
 };
 
 /** A parsed `atomStyle` directive: how it matches atoms, plus its style. */
@@ -61,6 +104,20 @@ function parseBorderStyle(raw: unknown): BorderStyle | undefined {
     return Object.keys(borderStyle).length > 0 ? borderStyle : undefined;
 }
 
+function parseIconStyle(raw: unknown): IconStyle | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const r = raw as Record<string, unknown>;
+    const iconStyle: IconStyle = {};
+    // Resolved here so the resolver's equality check sees canonical paths.
+    if (typeof r.path === 'string' && r.path.length > 0) iconStyle.path = resolveIconPath(r.path);
+    if (isIconPlacement(r.placement)) iconStyle.placement = r.placement;
+    // Alpha only; out-of-range is dropped rather than clamped (mirrors border width).
+    if (typeof r.opacity === 'number' && Number.isFinite(r.opacity) && r.opacity >= 0 && r.opacity <= 1) {
+        iconStyle.opacity = r.opacity;
+    }
+    return Object.keys(iconStyle).length > 0 ? iconStyle : undefined;
+}
+
 /**
  * Build a sparse {@link AtomStyleSpec} from a raw `atomStyle` directive object,
  * keeping only present, valid leaves. Matching keys (selector) are ignored here.
@@ -78,6 +135,11 @@ export function parseAtomStyleSpec(raw: unknown): AtomStyleSpec {
 
     const textStyle = parseTextStyle(r.textStyle);
     if (textStyle) spec.textStyle = textStyle;
+
+    const iconStyle = parseIconStyle(r.iconStyle);
+    if (iconStyle) spec.iconStyle = iconStyle;
+
+    if (typeof r.showLabel === 'boolean') spec.showLabel = r.showLabel;
 
     return spec;
 }
@@ -101,6 +163,49 @@ export function atomColorToAtomStyleRule(raw: unknown): AtomStyleRule | null {
     const style: AtomStyleSpec = {};
     if (typeof r.value === 'string') style.borderStyle = { color: r.value };
     return { selector, style };
+}
+
+/**
+ * Desugar a legacy `icon` directive into an {@link AtomStyleRule}.
+ *
+ * The flat directive's single `showLabels` boolean drove four separate things:
+ * label visibility, icon size, icon position, and whether the box went
+ * transparent. The atomStyle model splits those into two orthogonal knobs, and
+ * the mapping is total — every legacy spec lands on an exact equivalent:
+ *
+ * | legacy                        | becomes                                          |
+ * |-------------------------------|--------------------------------------------------|
+ * | `showLabels: false` (default) | `showLabel: false` + `iconStyle.placement: full`  |
+ * | `showLabels: true`            | `showLabel: true`  + `iconStyle.placement: badge` |
+ *
+ * Writing `showLabel` explicitly (rather than leaning on a default) is what lets
+ * the new surface default `showLabel` to `true` like any other atom, without
+ * changing what an existing `icon` directive draws.
+ *
+ * Returns `null` — caller drops the rule — when the directive could never have
+ * drawn anything: `selector` was required (a blank one already failed selector
+ * evaluation, and must not become a graph-wide icon now that an absent selector
+ * means "every atom"), and so was `path`.
+ */
+export function iconToAtomStyleRule(raw: unknown): AtomStyleRule | null {
+    const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+    const selector = typeof r.selector === 'string' ? r.selector : '';
+    if (selector.trim().length === 0) return null;
+
+    const path = typeof r.path === 'string' ? r.path : '';
+    if (path.length === 0) return null;
+
+    const showLabels = r.showLabels === true;
+    return {
+        selector,
+        style: {
+            showLabel: showLabels,
+            iconStyle: {
+                path: resolveIconPath(path),
+                placement: showLabels ? 'badge' : 'full',
+            },
+        },
+    };
 }
 
 function atomRuleSource(rule: AtomStyleRule): string {

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -721,7 +721,7 @@ const BORDER_STYLE_FIELDS: readonly FieldSpec[] = [
  * resolver's compose / collision rules.
  */
 const ICON_STYLE_FIELDS: readonly FieldSpec[] = [
-  { key: 'path', kind: 'text', label: 'Path / URL', placeholder: 'e.g. bi:person-fill, person, https://…' },
+  { key: 'path', kind: 'iconPath', label: 'Icon', placeholder: 'e.g. person, bi:person-fill, https://…' },
   { key: 'placement', kind: 'enum', options: ICON_PLACEMENTS, label: 'Placement' },
   { key: 'opacity', kind: 'number', label: 'Opacity', help: '0–1. Fade a full-bleed icon to use it as a watermark behind the label.' },
 ];

--- a/src/spec-editor/core/registry.ts
+++ b/src/spec-editor/core/registry.ts
@@ -23,8 +23,8 @@
  *     - flag: <scalar string>
  *     - attribute:    { field, selector?, filter?, textStyle?:{size,color} }
  *     - hideField:    { field, selector?, filter? }
- *     - icon:         { path, selector?, showLabels? }
- *     - atomStyle:    { selector?, fillStyle?:{color}, borderStyle?:{color,width}, textStyle?:{size,color} }
+ *     - icon:         { path, selector?, showLabels? }  (deprecated → atomStyle)
+ *     - atomStyle:    { selector?, fillStyle?:{color}, borderStyle?:{color,width}, iconStyle?:{path,placement,opacity}, textStyle?:{size,color}, showLabel? }
  *     - atomColor:    { value, selector? }  (deprecated → atomStyle)
  *     - edgeStyle:    { field, selector?, filter?, lineStyle?:{color,pattern,weight,highlight}, textStyle?:{size,color}, showLabel?, hidden? }
  *     - edgeColor:    { value, field, selector?, filter?, style?, weight?, showLabel?, hidden?, highlight? }  (deprecated → edgeStyle)
@@ -95,6 +95,13 @@ export const ORIENTATION_DIRECTIONS = [
 export const CYCLIC_DIRECTIONS = ['clockwise', 'counterclockwise'] as const;
 export const ALIGN_DIRECTIONS = ['horizontal', 'vertical'] as const;
 export const EDGE_STYLES = ['solid', 'dashed', 'dotted'] as const;
+
+/**
+ * Where an atom's icon draws: `full` occupies the box (which goes transparent
+ * unless a fill was asked for), `badge` is a small top-right marker beside the
+ * label. Mirrors `IconPlacement` in `layout/style/atom-style-spec.ts`.
+ */
+export const ICON_PLACEMENTS = ['full', 'badge'] as const;
 
 /**
  * Text-size tiers for a label line, relative to the node label. `large` renders
@@ -621,7 +628,9 @@ const icon: ItemDefinition = {
   kind: 'directive',
   type: 'icon',
   label: 'Icon',
-  description: 'Render matching atoms with an icon.',
+  description: "Deprecated — use Atom style (atomStyle) with an 'iconStyle' block. Still parsed/rendered for back-compat (showLabels splits into showLabel + iconStyle.placement).",
+  deprecated: true,
+  deprecatedInFavorOf: 'atomStyle',
   fields: [
     {
       key: 'path',
@@ -705,6 +714,18 @@ const BORDER_STYLE_FIELDS: readonly FieldSpec[] = [
   { key: 'width', kind: 'number', label: 'Width' },
 ];
 
+/**
+ * Shared `iconStyle` block children — an atom's icon, its geometry, and its
+ * alpha. No defaults (sparse): the engine treats an absent `placement` as
+ * `full`, and seeding it here would emit it as an authored value and break the
+ * resolver's compose / collision rules.
+ */
+const ICON_STYLE_FIELDS: readonly FieldSpec[] = [
+  { key: 'path', kind: 'text', label: 'Path / URL', placeholder: 'e.g. bi:person-fill, person, https://…' },
+  { key: 'placement', kind: 'enum', options: ICON_PLACEMENTS, label: 'Placement' },
+  { key: 'opacity', kind: 'number', label: 'Opacity', help: '0–1. Fade a full-bleed icon to use it as a watermark behind the label.' },
+];
+
 const edgeStyle: ItemDefinition = {
   kind: 'directive',
   type: 'edgeStyle',
@@ -733,12 +754,14 @@ const atomStyle: ItemDefinition = {
   kind: 'directive',
   type: 'atomStyle',
   label: 'Atom style',
-  description: 'Style matching atoms — fill, border, and label.',
+  description: 'Style matching atoms — fill, border, icon, and label.',
   fields: [
     { key: 'selector', kind: 'selector', label: 'Selector', selectorArity: 'unary' },
     { key: 'fillStyle', kind: 'group', label: 'Fill style', children: FILL_STYLE_FIELDS },
     { key: 'borderStyle', kind: 'group', label: 'Border style', children: BORDER_STYLE_FIELDS },
+    { key: 'iconStyle', kind: 'group', label: 'Icon style', children: ICON_STYLE_FIELDS },
     { key: 'textStyle', kind: 'group', label: 'Text style', children: TEXT_STYLE_FIELDS },
+    { key: 'showLabel', kind: 'boolean', label: 'Show label' },
   ],
   summary(params) {
     const fill = (params.fillStyle ?? {}) as Record<string, unknown>;

--- a/src/spec-editor/core/types.ts
+++ b/src/spec-editor/core/types.ts
@@ -41,6 +41,7 @@ export type FieldKind =
   | 'number'
   | 'color'
   | 'text'
+  | 'iconPath' // free text (URL / path / pack ref) plus a browser for the bundled icons
   | 'boolean'
   | 'group'; // a nested block (lineStyle / textStyle / …); renders its `children` recursively
 

--- a/src/spec-editor/ui/FieldRenderer.tsx
+++ b/src/spec-editor/ui/FieldRenderer.tsx
@@ -11,6 +11,7 @@
  * - `color`           → color swatch input
  * - `boolean`         → switch
  * - `text`            → text input
+ * - `iconPath`        → {@link IconField} (text input + built-in icon browser)
  *
  * The renderer is domain-agnostic. Domain names for `relationName`/`typeName`
  * combo boxes come from the `options` prop; per-field selector props (the
@@ -22,6 +23,7 @@ import React, { useId } from 'react';
 import type { Diagnostic, FieldSpec } from '../core/types';
 import { SelectorField } from './SelectorField';
 import type { SelectorFieldProps } from './SelectorField';
+import { IconField } from './IconField';
 
 /** Domain names available for the combo-box field kinds. */
 export interface FieldRendererOptions {
@@ -496,6 +498,20 @@ function renderControl(
         >
           <span className="spytial-ed-switch-thumb" aria-hidden="true" />
         </button>
+      );
+    }
+
+    case 'iconPath': {
+      return (
+        <IconField
+          id={fieldId}
+          value={asString(value)}
+          onChange={(v) => onChange(field.key, v)}
+          placeholder={field.placeholder}
+          disabled={disabled}
+          aria-describedby={describedBy}
+          aria-invalid={diagnostics.some((d) => d.severity === 'error')}
+        />
       );
     }
 

--- a/src/spec-editor/ui/IconField.tsx
+++ b/src/spec-editor/ui/IconField.tsx
@@ -1,0 +1,227 @@
+/**
+ * {@link IconField} — the `iconPath` field kind: a free-text input plus a
+ * browser for the icons that ship with the package.
+ *
+ * The text input stays authoritative, because `path` accepts four different
+ * things (a bundled name, a `pack:name` reference, an absolute URL, a relative
+ * asset path) and only the first is enumerable. The browser is an assist for
+ * the discoverable case, not a replacement for typing: nothing it offers is
+ * unavailable by hand, and anything typed by hand still works.
+ *
+ * Bundled icons are inlined data URIs, so they preview truthfully with no
+ * network. Pack references resolve to a CDN at render time and therefore
+ * *cannot* be previewed here — they are listed as guidance (prefix, name, a
+ * copyable example) rather than shown as thumbnails, which is honest about the
+ * fact that they need a connection to draw.
+ */
+
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import {
+  getBundledIconNames,
+  getBundledIconSvg,
+  getIconPacks,
+} from '../../layout/icon-registry';
+import { useAnchoredPopup } from './use-anchored-popup';
+
+/**
+ * Draw a bundled icon by inlining its markup, so `fill="currentColor"` picks up
+ * the surrounding theme. An `<img>` cannot do this: `currentColor` there
+ * resolves against the SVG document (initial `color`: black), which is
+ * invisible on the dark theme's surface.
+ *
+ * `dangerouslySetInnerHTML` is safe here *by construction*: `getBundledIconSvg`
+ * only ever returns markup this package authored at compile time, and returns
+ * `undefined` for anything else — so an author-supplied path can never reach
+ * it. Callers must keep that invariant; never pass a typed value through.
+ */
+const BundledGlyph: React.FC<{ name: string; className?: string }> = ({
+  name,
+  className,
+}) => {
+  const svg = getBundledIconSvg(name);
+  if (!svg) return null;
+  return (
+    <span
+      className={className}
+      aria-hidden="true"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+};
+
+export interface IconFieldProps {
+  /** controlled value — whatever the author typed or picked */
+  value: string;
+  onChange(value: string): void;
+  placeholder?: string;
+  disabled?: boolean;
+  id?: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean;
+}
+
+export const IconField: React.FC<IconFieldProps> = ({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  id,
+  'aria-describedby': describedBy,
+  'aria-invalid': invalid,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const btnRef = useRef<HTMLButtonElement | null>(null);
+  const popupId = useId();
+
+  const popupStyle = useAnchoredPopup(open, btnRef, {
+    align: 'end',
+    estimatedHeight: 340,
+  });
+
+  const bundled = useMemo(() => getBundledIconNames(), []);
+  const packs = useMemo(() => getIconPacks(), []);
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return q ? bundled.filter((n) => n.includes(q)) : bundled;
+  }, [bundled, query]);
+
+  // Close on click-outside, matching the overflow menu's behaviour.
+  useEffect(() => {
+    if (!open) return;
+    const onDocMouseDown = (e: MouseEvent): void => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocMouseDown);
+    return () => document.removeEventListener('mousedown', onDocMouseDown);
+  }, [open]);
+
+  const pick = (name: string): void => {
+    onChange(name);
+    setOpen(false);
+  };
+
+  // Preview the current value only when it is a bundled icon: those inline with
+  // no network and inherit the theme colour. A CDN or remote URL would need a
+  // round-trip, and a broken one would render a browser error glyph inside the
+  // form.
+  const previewable = !!value && !!getBundledIconSvg(value);
+
+  return (
+    <div className="spytial-ed-icon" ref={wrapRef}>
+      <div className="spytial-ed-icon-row">
+        {previewable ? (
+          <BundledGlyph name={value} className="spytial-ed-icon-preview" />
+        ) : null}
+        <input
+          id={id}
+          type="text"
+          className="spytial-ed-input"
+          value={value}
+          placeholder={placeholder}
+          disabled={disabled}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          aria-describedby={describedBy}
+          aria-invalid={invalid || undefined}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        <button
+          ref={btnRef}
+          type="button"
+          className="spytial-ed-icon-btn"
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-controls={open ? popupId : undefined}
+          aria-label="Browse built-in icons"
+          title="Browse built-in icons"
+          disabled={disabled}
+          onClick={() => setOpen((o) => !o)}
+        >
+          <span aria-hidden="true">☆</span>
+        </button>
+      </div>
+
+      {open ? (
+        <div
+          id={popupId}
+          className="spytial-ed-icon-pop"
+          style={popupStyle}
+          role="dialog"
+          aria-label="Built-in icons"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.stopPropagation();
+              setOpen(false);
+              btnRef.current?.focus();
+            }
+          }}
+        >
+          <input
+            type="text"
+            className="spytial-ed-input spytial-ed-icon-search"
+            placeholder={`Filter ${bundled.length} bundled icons…`}
+            value={query}
+            spellCheck={false}
+            aria-label="Filter bundled icons"
+            onChange={(e) => setQuery(e.target.value)}
+          />
+
+          <p className="spytial-ed-icon-note">
+            Bundled icons need no network. You can also type any image URL or
+            path.
+          </p>
+
+          {matches.length > 0 ? (
+            <div className="spytial-ed-icon-grid" role="listbox" aria-label="Bundled icons">
+              {matches.map((name) => (
+                <button
+                  key={name}
+                  type="button"
+                  role="option"
+                  aria-selected={value === name}
+                  className={`spytial-ed-icon-cell${
+                    value === name ? ' spytial-ed-icon-cell--active' : ''
+                  }`}
+                  title={name}
+                  onClick={() => pick(name)}
+                >
+                  <BundledGlyph name={name} className="spytial-ed-icon-cell-glyph" />
+                  <span className="spytial-ed-icon-cell-name">{name}</span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="spytial-ed-icon-empty">
+              No bundled icon matches “{query.trim()}”. Try an icon pack below,
+              or paste a URL.
+            </p>
+          )}
+
+          <div className="spytial-ed-icon-packs">
+            <p className="spytial-ed-icon-note">
+              Icon packs — write <code>prefix:name</code>. These load from a CDN
+              at render time, so they need a connection and aren’t previewed
+              here.
+            </p>
+            <ul>
+              {packs.map((p) => (
+                <li key={p.prefix}>
+                  <code>{p.prefix}:</code> {p.label}{' '}
+                  <span className="spytial-ed-icon-pack-eg">
+                    e.g. <code>{p.example}</code>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/src/spec-editor/ui/spec-editor.css
+++ b/src/spec-editor/ui/spec-editor.css
@@ -1641,3 +1641,133 @@
 .spytial-ed-group-add:hover {
   background: var(--spytial-ed-hover, #f6f8fa);
 }
+
+/* ── iconPath field: text input + built-in icon browser ──────────────────── */
+
+.spytial-ed-icon {
+  position: relative;
+  width: 100%;
+}
+
+.spytial-ed-icon-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+/* Only shown for bundled values — see IconField for why. The glyph is inlined
+   SVG, not an <img>, so `fill="currentColor"` inherits this color and the icon
+   stays legible in both the light and dark themes. */
+.spytial-ed-icon-preview,
+.spytial-ed-icon-cell-glyph {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--spytial-ed-text, #221d14);
+}
+.spytial-ed-icon-preview svg {
+  inline-size: 1.15rem;
+  block-size: 1.15rem;
+}
+.spytial-ed-icon-cell-glyph svg {
+  inline-size: 1.35rem;
+  block-size: 1.35rem;
+}
+
+.spytial-ed-icon-btn {
+  flex: 0 0 auto;
+  cursor: pointer;
+  padding: 0.3em 0.5em;
+  line-height: 1;
+  color: var(--spytial-ed-text-muted, #6e6553);
+  background: var(--spytial-ed-surface, #faf8f2);
+  border: 1px solid var(--spytial-ed-border, #d9d2c0);
+  border-radius: var(--spytial-ed-radius-sm, 2px);
+}
+.spytial-ed-icon-btn:hover:not(:disabled) {
+  color: var(--spytial-ed-text, #221d14);
+  background: var(--spytial-ed-hover, #f6f8fa);
+}
+.spytial-ed-icon-btn:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.spytial-ed-icon-pop {
+  position: fixed;
+  z-index: 1000;
+  inline-size: 20rem;
+  max-inline-size: calc(100vw - 1rem);
+  overflow-y: auto;
+  padding: 0.5rem;
+  background: var(--spytial-ed-surface, #faf8f2);
+  border: 1px solid var(--spytial-ed-border, #d9d2c0);
+  border-radius: var(--spytial-ed-radius, 2px);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--spytial-ed-text, #221d14) 8%, transparent),
+    0 8px 24px color-mix(in srgb, var(--spytial-ed-text, #221d14) 18%, transparent);
+  animation: spytial-ed-pop 0.12s ease-out;
+}
+
+.spytial-ed-icon-search {
+  margin-block-end: 0.4rem;
+}
+
+.spytial-ed-icon-note,
+.spytial-ed-icon-empty {
+  margin: 0 0 0.45rem;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: var(--spytial-ed-text-muted, #6e6553);
+}
+
+.spytial-ed-icon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(4.25rem, 1fr));
+  gap: 0.25rem;
+}
+
+.spytial-ed-icon-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  cursor: pointer;
+  padding: 0.4rem 0.2rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--spytial-ed-radius-sm, 2px);
+  color: var(--spytial-ed-text, #221d14);
+}
+.spytial-ed-icon-cell:hover {
+  background: var(--spytial-ed-hover, #f6f8fa);
+  border-color: var(--spytial-ed-border, #d9d2c0);
+}
+.spytial-ed-icon-cell--active {
+  border-color: var(--spytial-ed-accent, #0969da);
+  background: color-mix(in srgb, var(--spytial-ed-accent, #0969da) 10%, transparent);
+}
+.spytial-ed-icon-cell-name {
+  max-inline-size: 100%;
+  overflow: hidden;
+  font-size: 0.65rem;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--spytial-ed-text-muted, #6e6553);
+}
+
+.spytial-ed-icon-packs {
+  margin-block-start: 0.6rem;
+  padding-block-start: 0.5rem;
+  border-block-start: 1px solid var(--spytial-ed-border, #d9d2c0);
+}
+.spytial-ed-icon-packs ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.72rem;
+  line-height: 1.6;
+  color: var(--spytial-ed-text, #221d14);
+}
+.spytial-ed-icon-pack-eg {
+  color: var(--spytial-ed-text-muted, #6e6553);
+}

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -424,17 +424,57 @@ export class WebColaCnDGraph extends HTMLElementBase {
   }
 
   /**
-   * Node rectangle fill. Hidden and icon-only nodes stay transparent. An
-   * explicit `atomStyle.fillStyle.color` (d.fillColor) is an opt-in real fill,
-   * preserved exactly as chosen. Otherwise Tufte: the fill matches the canvas so
-   * only stroke + label distinguish a node.
+   * Node rectangle fill. Hidden nodes, and nodes whose icon occupies the box
+   * (`placement: full`), stay transparent — real `transparent`, not the canvas
+   * color, so a group hull shows through behind the icon. An explicit
+   * `atomStyle.fillStyle.color` (d.fillColor) is an opt-in real fill and wins
+   * even under a full-bleed icon. Otherwise Tufte: the fill matches the canvas
+   * so only stroke + label distinguish a node.
+   *
+   * Note this keys off placement, not label visibility — a labelled atom with a
+   * faded full-bleed icon (the watermark idiom) gets the same see-through box as
+   * an unlabelled glyph.
    */
   private nodeFillColor(d: any): string {
-    const isHidden = this.isHiddenNode(d);
-    const hasIcon = !!d.icon;
-    const showLabels = d.showLabels;
-    if (isHidden || (hasIcon && !showLabels)) return 'transparent';
-    return d.fillColor ?? this.getCanvasBackground();
+    if (this.isHiddenNode(d)) return 'transparent';
+    if (d.fillColor) return d.fillColor;
+    if (d.icon && !this.isBadgeIcon(d)) return 'transparent';
+    return this.getCanvasBackground();
+  }
+
+  /** True when the node's icon draws as a small corner marker rather than filling the box. */
+  private isBadgeIcon(d: any): boolean {
+    return d.iconPlacement === 'badge';
+  }
+
+  /** Icon width: the full box, or a fraction of it for a badge. */
+  private iconWidth(d: any): number {
+    const vw = d.visualWidth ?? d.width;
+    return this.isBadgeIcon(d) ? vw * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR : vw;
+  }
+
+  /** Icon height: the full box, or a fraction of it for a badge. */
+  private iconHeight(d: any): number {
+    const vh = d.visualHeight ?? d.height;
+    return this.isBadgeIcon(d) ? vh * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR : vh;
+  }
+
+  /**
+   * Icon left edge. A badge sits against the box's top-right corner; a full icon
+   * spans the box from `fullX` (defaulting to the box's own left edge — callers
+   * that track WebCola bounds pass those instead).
+   */
+  private iconX(d: any, fullX?: number): number {
+    const vw = d.visualWidth ?? d.width;
+    if (this.isBadgeIcon(d)) return d.x + vw / 2 - (vw * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR);
+    return fullX ?? d.x - vw / 2;
+  }
+
+  /** Icon top edge — the box's top edge in both placements (see {@link iconX} for `fullY`). */
+  private iconY(d: any, fullY?: number): number {
+    const vh = d.visualHeight ?? d.height;
+    if (this.isBadgeIcon(d)) return d.y - vh / 2;
+    return fullY ?? d.y - vh / 2;
   }
 
   /** Edge stroke (themed): preserves chosen colors, themes the implicit default. */
@@ -4123,51 +4163,35 @@ export class WebColaCnDGraph extends HTMLElementBase {
 
   /**
    * Adds icon images to nodes that have icon properties.
-   * Handles scaling and positioning based on label visibility.
-   * Includes error handling for failed icon loads.
-   * 
+   * Geometry comes from `atomStyle.iconStyle.placement` (full vs badge) and alpha
+   * from its `opacity`. Includes error handling for failed icon loads.
+   *
    * @param nodeSelection - D3 selection of node groups
    */
   private setupNodeIcons(nodeSelection: d3.Selection<SVGGElement, any, any, unknown>): void {
-    
-    
-    nodeSelection
+    const images = nodeSelection
       .filter((d: any) => d.icon) // Only nodes with icons
       .append("image")
       .attr("xlink:href", (d: any) => d.icon)
-      .attr("width", (d: any) => {
-        const vw = d.visualWidth ?? d.width;
-        return d.showLabels
-          ? vw * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR
-          : vw;
-      })
-      .attr("height", (d: any) => {
-        const vh = d.visualHeight ?? d.height;
-        return d.showLabels
-          ? vh * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR
-          : vh;
-      })
-      .attr("x", (d: any) => {
-        const width = d.visualWidth ?? d.width;
-        if (d.showLabels) {
-          // Position in top-right corner when labels are shown
-          return d.x + width - (width * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR);
-        }
-        // Center horizontally when no labels
-        return d.x - width / 2;
-      })
-      .attr("y", (d: any) => {
-        const height = d.visualHeight ?? d.height;
-        // Always align with top edge
-        return d.y - height / 2;
-      })
-      .append("title")
-      .text((d: any) => d.label || d.name || d.id || "Node")
-      .on("error", function(this: any, event: any, d: any) {
+      .attr("width", (d: any) => this.iconWidth(d))
+      .attr("height", (d: any) => this.iconHeight(d))
+      .attr("x", (d: any) => this.iconX(d))
+      .attr("y", (d: any) => this.iconY(d))
+      // Set on the <image> itself, so the morph animation's group-level opacity
+      // composes with it rather than being overwritten.
+      .attr("opacity", (d: any) => d.iconOpacity ?? null);
 
-        d3.select(this).attr("xlink:href", "img/default.png");
-        console.error(`Failed to load icon for node ${d.id}: ${d.icon}`);
-      });
+    // Bound to the <image>, not to the <title> appended below: chaining `.on`
+    // after `.append("title")` would attach the handler to the title element,
+    // which never emits `error`, leaving broken icons silently blank.
+    images.on("error", function (this: SVGImageElement, _event: Event, d: any) {
+      d3.select(this).attr("xlink:href", "img/default.png");
+      console.error(`Failed to load icon for node ${d.id}: ${d.icon}`);
+    });
+
+    images
+      .append("title")
+      .text((d: any) => d.label || d.name || d.id || "Node");
   }
 
   /**
@@ -4459,16 +4483,8 @@ export class WebColaCnDGraph extends HTMLElementBase {
       .attr('height', (d: any) => d.visualHeight ?? d.height);
 
     this.svgNodes.select('image')
-      .attr('x', (d: any) => {
-        if (d.x == null) return 0;
-        const vw = d.visualWidth ?? d.width;
-        return d.showLabels ? d.x + vw / 2 - (vw * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR) : d.x - vw / 2;
-      })
-      .attr('y', (d: any) => {
-        if (d.y == null) return 0;
-        const vh = d.visualHeight ?? d.height;
-        return d.y - vh / 2;
-      });
+      .attr('x', (d: any) => d.x == null ? 0 : this.iconX(d))
+      .attr('y', (d: any) => d.y == null ? 0 : this.iconY(d));
 
     this.svgNodes.select('.mostSpecificTypeLabel')
       .attr('x', (d: any) => d.x != null ? d.x - ((d as any).visualWidth ?? d.width ?? 0) / 2 + 5 : 0)
@@ -4518,26 +4534,8 @@ export class WebColaCnDGraph extends HTMLElementBase {
 
     // Update node icons with proper positioning
     this.svgNodes.select('image')
-      .attr('x', (d: any) => {
-        const vw = d.visualWidth ?? d.width;
-        if (d.showLabels) {
-          // Move to the top-right corner
-          return d.x + vw / 2 - (vw * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR);
-        } else {
-          // Align with visual left edge
-          return d.x - vw / 2;
-        }
-      })
-      .attr('y', (d: any) => {
-        const vh = d.visualHeight ?? d.height;
-        if (d.showLabels) {
-          // Align with the top edge
-          return d.y - vh / 2;
-        } else {
-          // Align with visual top edge
-          return d.y - vh / 2;
-        }
-      });
+      .attr('x', (d: any) => this.iconX(d))
+      .attr('y', (d: any) => this.iconY(d));
 
     // Update most specific type labels — positioned at top-left of the node
     this.svgNodes.select('.mostSpecificTypeLabel')
@@ -4768,27 +4766,11 @@ export class WebColaCnDGraph extends HTMLElementBase {
         .attr("height", function (d: any) { return d.bounds.height(); });
     
 
+    // A full-bleed icon tracks the WebCola bounds here (rather than the visual
+    // box) so it stays registered with the rect drawn from those same bounds.
     node.select("image")
-        .attr("x", function (d: any) {
-            const vw = d.visualWidth ?? d.width;
-            if (d.showLabels) {
-                // Move to the top-right corner
-                return d.x + (vw / 2) - (vw * WebColaCnDGraph.SMALL_IMG_SCALE_FACTOR);
-            } else {
-                // Align with d.bounds.x
-                return d.bounds.x;
-            }
-        })
-        .attr("y", function (d: any) {
-            const vh = d.visualHeight ?? d.height;
-            if (d.showLabels) {
-                // Align with the top edge
-                return d.y - vh / 2;
-            } else {
-                // Align with d.bounds.y
-                return d.bounds.y;
-            }
-        })
+        .attr("x", (d: any) => this.iconX(d, d.bounds.x))
+        .attr("y", (d: any) => this.iconY(d, d.bounds.y))
 
     mostSpecificTypeLabel
         .attr("x", function (d: any) { return d.bounds.x + 5; })

--- a/src/translators/webcola/webcola-cnd-graph.ts
+++ b/src/translators/webcola/webcola-cnd-graph.ts
@@ -5,6 +5,7 @@ import type { LayoutWarning } from '../../layout/error-state';
 import type { GridRouter, Group, Layout, Node, Link } from 'webcola';
 import { IInputDataInstance, ITuple, IAtom } from '../../data-instance/interfaces';
 import { MAIN_LABEL_FONT_SIZE, SECONDARY_FONT_SIZE, LABEL_LINE_HEIGHT_RATIO, resolveAttrFontSize } from '../../layout/text-extent';
+import { FALLBACK_ICON } from '../../layout/icon-registry';
 import { setLabLightness, type NodeColorParams } from '../../layout/colorpicker';
 
 // Guarded: this module is reachable from the npm entries' static import graph
@@ -4184,8 +4185,14 @@ export class WebColaCnDGraph extends HTMLElementBase {
     // Bound to the <image>, not to the <title> appended below: chaining `.on`
     // after `.append("title")` would attach the handler to the title element,
     // which never emits `error`, leaving broken icons silently blank.
+    //
+    // The fallback is an inlined data URI (not a packaged asset path, which
+    // would resolve against the host app and 404), and the guard stops a
+    // fallback that somehow also failed from looping on its own error event.
     images.on("error", function (this: SVGImageElement, _event: Event, d: any) {
-      d3.select(this).attr("xlink:href", "img/default.png");
+      const img = d3.select(this);
+      if (img.attr("xlink:href") === FALLBACK_ICON) return;
+      img.attr("xlink:href", FALLBACK_ICON);
       console.error(`Failed to load icon for node ${d.id}: ${d.icon}`);
     });
 

--- a/src/translators/webcola/webcolatranslator.ts
+++ b/src/translators/webcola/webcolatranslator.ts
@@ -2,6 +2,7 @@ import { Node, Group, Link, Rectangle } from 'webcola';
 import { InstanceLayout, LayoutNode, LayoutEdge, LayoutConstraint, LayoutGroup, LeftConstraint, TopConstraint, AlignmentConstraint, isLeftConstraint, isTopConstraint, isAlignmentConstraint, isBoundingBoxConstraint, isGroupBoundaryConstraint, ColorSource } from '../../layout/interfaces';
 import { EdgeStyle } from '../../layout/edge-style';
 import type { TextStyle } from '../../layout/style/text-style';
+import type { IconPlacement } from '../../layout/style/atom-style-spec';
 import { LayoutInstance } from '../../layout/layoutinstance';
 import type { IDataInstance } from '../../data-instance/interfaces';
 import type { SequencePolicy } from './sequence-policy';
@@ -58,6 +59,10 @@ type NodeWithMetadata = Node & {
   /** Main-label styling from `atomStyle.textStyle` (only `color` consumed today; see LayoutNode). */
   textStyle?: TextStyle,
   icon: string,
+  /** Icon geometry from `atomStyle.iconStyle.placement`: 'full' | 'badge'. */
+  iconPlacement?: IconPlacement,
+  /** Icon alpha from `atomStyle.iconStyle.opacity`; absent = opaque. */
+  iconOpacity?: number,
   mostSpecificType: string,
   showLabels: boolean,
   /** Original visual width of the node (without layout padding). Use this for rendering. */
@@ -736,6 +741,8 @@ export class WebColaLayout {
       x: x,
       y: y,
       icon: node.icon || '',
+      iconPlacement: node.iconPlacement,
+      iconOpacity: node.iconOpacity,
       fixed: fixed,
       mostSpecificType: node.mostSpecificType,
       showLabels: node.showLabels,

--- a/tests/atom-icon-style.test.ts
+++ b/tests/atom-icon-style.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Integration tests for icons as part of `atomStyle`: parse → match (selector) →
+ * resolve (compose / collide / inherit) → LayoutNode fields (`icon`,
+ * `iconPlacement`, `iconOpacity`, `showLabels`).
+ *
+ * The point of the move is that `showLabels` — one boolean that used to drive
+ * label visibility, icon size, icon position AND box transparency — splits into
+ * two orthogonal knobs: atomStyle's own `showLabel`, and `iconStyle.placement`.
+ * The legacy `icon` directive desugars onto that pair losslessly, which is what
+ * the desugar block below pins.
+ *
+ * `RedNode` is a subtype of `Node`, so a `Node` selector already returns the
+ * `RedNode` atom — the basis of the inheritance test.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
+import { parseLayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance } from '../src/layout/layoutinstance';
+import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
+import { StyleCollisionError } from '../src/layout/style/style-resolver';
+import { resolveIconPath } from '../src/layout/icon-registry';
+
+const data: IJsonDataInstance = {
+    atoms: [
+        { id: 'n1', type: 'Node', label: 'n1' },
+        { id: 'r1', type: 'RedNode', label: 'r1' },
+    ],
+    relations: [
+        {
+            id: 'link',
+            name: 'link',
+            types: ['Node', 'Node'],
+            tuples: [{ atoms: ['n1', 'r1'], types: ['Node', 'RedNode'] }],
+        },
+    ],
+    types: [
+        { id: 'Node', types: ['Node'], atoms: [{ id: 'n1', type: 'Node', label: 'n1' }], isBuiltin: false },
+        { id: 'RedNode', types: ['RedNode', 'Node'], atoms: [{ id: 'r1', type: 'RedNode', label: 'r1' }], isBuiltin: false },
+    ],
+};
+
+function layoutFor(specStr: string) {
+    const layoutSpec = parseLayoutSpec(specStr);
+    const instance = new JSONDataInstance(data);
+    const evaluator = new SGraphQueryEvaluator();
+    evaluator.initialize({ sourceData: instance });
+    const layoutInstance = new LayoutInstance(layoutSpec, evaluator, 0, true);
+    return () => layoutInstance.generateLayout(instance);
+}
+
+const nodeById = (layout: any, id: string) => layout.nodes.find((n: any) => n.id === id);
+
+const PERSON_ICON = resolveIconPath('person');
+
+describe('atomStyle iconStyle — end to end', () => {
+    it('carries a resolved path, placement, and opacity onto the LayoutNode', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: n1
+      iconStyle:
+        path: person
+        placement: badge
+        opacity: 0.5
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.icon).toBe(PERSON_ICON); // bundled name resolved at parse time
+        expect(n.icon).toMatch(/^data:image\/svg\+xml/);
+        expect(n.iconPlacement).toBe('badge');
+        expect(n.iconOpacity).toBe(0.5);
+    });
+
+    it('defaults placement to full and leaves opacity unset', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: n1
+      iconStyle:
+        path: person
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.iconPlacement).toBe('full');
+        expect(n.iconOpacity).toBeUndefined();
+    });
+
+    it('shows the label by default, even with a full-bleed icon (the watermark idiom)', () => {
+        // The old `icon` directive defaulted to hiding the label; on the atomStyle
+        // surface an atom keeps its label unless a rule says otherwise.
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: n1
+      iconStyle:
+        path: person
+        opacity: 0.15
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.showLabels).toBe(true);
+        expect(n.iconPlacement).toBe('full');
+    });
+
+    it('hides the label via showLabel, independently of any icon', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: n1
+      showLabel: false
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.showLabels).toBe(false);
+        expect(n.icon).toBe(''); // label hidden with no icon at all — impossible before
+    });
+
+    it('leaves atoms with no icon rule unstyled and labelled', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: n1
+      iconStyle:
+        path: person
+`)();
+        const r = nodeById(layout, 'r1');
+        expect(r.icon).toBe('');
+        expect(r.iconOpacity).toBeUndefined();
+        expect(r.showLabels).toBe(true);
+    });
+
+    it('drops an out-of-range or non-finite opacity rather than clamping it', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - atomStyle:
+      selector: n1
+      iconStyle:
+        path: person
+        opacity: 1.5
+`);
+        expect(spec.directives.atomStyles[0].style.iconStyle).toEqual({ path: PERSON_ICON });
+    });
+
+    it('accepts the 0 and 1 endpoints', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - atomStyle: { selector: n1, iconStyle: { path: person, opacity: 0 } }
+  - atomStyle: { selector: r1, iconStyle: { path: person, opacity: 1 } }
+`);
+        expect(spec.directives.atomStyles[0].style.iconStyle?.opacity).toBe(0);
+        expect(spec.directives.atomStyles[1].style.iconStyle?.opacity).toBe(1);
+    });
+
+    it('ignores an unknown placement instead of inventing geometry', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - atomStyle: { selector: n1, iconStyle: { path: person, placement: sideways } }
+`);
+        expect(spec.directives.atomStyles[0].style.iconStyle).toEqual({ path: PERSON_ICON });
+    });
+
+    it('inherits an icon from a supertype rule and tunes only its opacity in a subtype rule', () => {
+        // The capability the flat directive could not express: `Node` supplies the
+        // path, `RedNode` fades it. Gap-fill falls out of ordinary selector matching.
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: Node
+      iconStyle:
+        path: person
+  - atomStyle:
+      selector: RedNode
+      iconStyle:
+        opacity: 0.2
+`)();
+        const r = nodeById(layout, 'r1');
+        expect(r.icon).toBe(PERSON_ICON);
+        expect(r.iconOpacity).toBe(0.2);
+
+        const n = nodeById(layout, 'n1'); // Node only — inherits nothing from RedNode
+        expect(n.icon).toBe(PERSON_ICON);
+        expect(n.iconOpacity).toBeUndefined();
+    });
+
+    it('HARD ERRORS when two rules disagree on the icon path', () => {
+        // Replaces the bespoke "Icon Conflict" throw with the shared resolver's
+        // no-override rule.
+        const run = layoutFor(`
+directives:
+  - atomStyle:
+      selector: Node
+      iconStyle:
+        path: person
+  - atomStyle:
+      selector: RedNode
+      iconStyle:
+        path: star
+`);
+        expect(run).toThrow(StyleCollisionError);
+    });
+
+    it('composes agreeing rules rather than colliding', () => {
+        const { layout } = layoutFor(`
+directives:
+  - atomStyle:
+      selector: Node
+      iconStyle:
+        path: person
+  - atomStyle:
+      selector: RedNode
+      iconStyle:
+        path: person
+        placement: badge
+`)();
+        const r = nodeById(layout, 'r1');
+        expect(r.icon).toBe(PERSON_ICON);
+        expect(r.iconPlacement).toBe('badge');
+    });
+});
+
+describe('icon → atomStyle desugar (parse level)', () => {
+    it('maps the icon-only default onto showLabel:false + placement:full', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - icon:
+      selector: Node
+      path: person
+`);
+        expect(spec.directives.icons).toEqual([]);
+        expect(spec.directives.atomStyles).toHaveLength(1);
+        expect(spec.directives.atomStyles[0]).toEqual({
+            selector: 'Node',
+            style: {
+                showLabel: false,
+                iconStyle: { path: PERSON_ICON, placement: 'full' },
+            },
+        });
+    });
+
+    it('maps showLabels:true onto showLabel:true + placement:badge', () => {
+        const spec = parseLayoutSpec(`
+directives:
+  - icon:
+      selector: Node
+      path: person
+      showLabels: true
+`);
+        expect(spec.directives.atomStyles[0]).toEqual({
+            selector: 'Node',
+            style: {
+                showLabel: true,
+                iconStyle: { path: PERSON_ICON, placement: 'badge' },
+            },
+        });
+    });
+
+    it('preserves what each legacy form drew, end to end', () => {
+        const { layout } = layoutFor(`
+directives:
+  - icon: { selector: n1, path: person }
+  - icon: { selector: r1, path: star, showLabels: true }
+`)();
+        const glyph = nodeById(layout, 'n1');
+        expect(glyph.icon).toBe(PERSON_ICON);
+        expect(glyph.showLabels).toBe(false);
+        expect(glyph.iconPlacement).toBe('full');
+
+        const badged = nodeById(layout, 'r1');
+        expect(badged.icon).toBe(resolveIconPath('star'));
+        expect(badged.showLabels).toBe(true);
+        expect(badged.iconPlacement).toBe('badge');
+    });
+
+    it('warns that icon is deprecated', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        parseLayoutSpec('directives:\n  - icon: { selector: Node, path: person }');
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("'icon' is deprecated"));
+        warn.mockRestore();
+    });
+
+    it('warns once per spec, not once per use', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        parseLayoutSpec(`
+directives:
+  - icon: { selector: n1, path: person }
+  - icon: { selector: r1, path: star }
+`);
+        const iconWarnings = warn.mock.calls.filter(c => String(c[0]).includes("'icon' is deprecated"));
+        expect(iconWarnings).toHaveLength(1);
+        warn.mockRestore();
+    });
+
+    it('drops a selectorless icon instead of iconifying every atom', () => {
+        // icon's selector was required; a blank one already failed evaluation, and
+        // must not become an atomStyle rule that matches every atom.
+        const spec = parseLayoutSpec('directives:\n  - icon: { path: person }');
+        expect(spec.directives.atomStyles).toEqual([]);
+    });
+
+    it('a selectorless icon leaves every node icon-free and labelled (end to end)', () => {
+        const { layout } = layoutFor('directives:\n  - icon: { path: person }')();
+        for (const id of ['n1', 'r1']) {
+            expect(nodeById(layout, id).icon).toBe('');
+            expect(nodeById(layout, id).showLabels).toBe(true);
+        }
+    });
+
+    it('drops a pathless icon', () => {
+        const spec = parseLayoutSpec('directives:\n  - icon: { selector: Node }');
+        expect(spec.directives.atomStyles).toEqual([]);
+    });
+
+    it('composes a legacy icon with a native atomStyle on other leaves', () => {
+        const { layout } = layoutFor(`
+directives:
+  - icon: { selector: n1, path: person }
+  - atomStyle:
+      selector: n1
+      borderStyle:
+        color: '#33c'
+`)();
+        const n = nodeById(layout, 'n1');
+        expect(n.icon).toBe(PERSON_ICON);
+        expect(n.showLabels).toBe(false);
+        expect(n.color).toBe('#33c');
+    });
+
+    it('HARD ERRORS when a legacy icon and an atomStyle disagree on placement', () => {
+        const run = layoutFor(`
+directives:
+  - icon: { selector: n1, path: person, showLabels: true }
+  - atomStyle: { selector: n1, iconStyle: { placement: full } }
+`);
+        expect(run).toThrow(StyleCollisionError);
+    });
+});

--- a/tests/atom-icon-style.test.ts
+++ b/tests/atom-icon-style.test.ts
@@ -14,8 +14,8 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { JSONDataInstance, IJsonDataInstance } from '../src/data-instance/json-data-instance';
-import { parseLayoutSpec } from '../src/layout/layoutspec';
-import { LayoutInstance } from '../src/layout/layoutinstance';
+import { parseLayoutSpec, type LayoutSpec } from '../src/layout/layoutspec';
+import { LayoutInstance, normalizeLegacyDirectives } from '../src/layout/layoutinstance';
 import { SGraphQueryEvaluator } from '../src/evaluators/data/sgq-evaluator';
 import { StyleCollisionError } from '../src/layout/style/style-resolver';
 import { resolveIconPath } from '../src/layout/icon-registry';
@@ -328,5 +328,89 @@ directives:
   - atomStyle: { selector: n1, iconStyle: { placement: full } }
 `);
         expect(run).toThrow(StyleCollisionError);
+    });
+});
+
+/**
+ * A LayoutSpec can reach the layout as an *object* — via the
+ * `setupLayout(spec: LayoutSpec, ...)` overload or `new LayoutInstance(spec)` —
+ * which never touches `parseLayoutSpec`, so nothing desugars its legacy
+ * directives. Since the layout now reads only `atomStyles`, such a spec would
+ * silently lose its icons without the normalization these pin.
+ */
+describe('programmatic LayoutSpec — legacy directives are normalized', () => {
+    function layoutForSpec(spec: LayoutSpec) {
+        const instance = new JSONDataInstance(data);
+        const evaluator = new SGraphQueryEvaluator();
+        evaluator.initialize({ sourceData: instance });
+        return new LayoutInstance(spec, evaluator, 0, true).generateLayout(instance);
+    }
+
+    /** A spec built by hand, as an integration or a test harness would. */
+    function specWithLegacy(overrides: Partial<LayoutSpec['directives']>): LayoutSpec {
+        const base = parseLayoutSpec('directives: []');
+        return { ...base, directives: { ...base.directives, ...overrides } };
+    }
+
+    it('honours icons set directly on directives.icons', () => {
+        const { layout } = layoutForSpec(specWithLegacy({
+            icons: [{ selector: 'n1', path: 'person', showLabels: false }],
+        }));
+        const n = nodeById(layout, 'n1');
+        expect(n.icon).toBe(PERSON_ICON);
+        expect(n.showLabels).toBe(false);
+        expect(n.iconPlacement).toBe('full');
+    });
+
+    it('maps a programmatic showLabels:true onto a badge, like the YAML desugar', () => {
+        const { layout } = layoutForSpec(specWithLegacy({
+            icons: [{ selector: 'n1', path: 'person', showLabels: true }],
+        }));
+        const n = nodeById(layout, 'n1');
+        expect(n.showLabels).toBe(true);
+        expect(n.iconPlacement).toBe('badge');
+    });
+
+    it('honours a programmatic atomColor, which spells its color `color` not `value`', () => {
+        const { layout } = layoutForSpec(specWithLegacy({
+            atomColors: [{ selector: 'n1', color: '#f80' }],
+        }));
+        expect(nodeById(layout, 'n1').color).toBe('#f80');
+    });
+
+    it('composes programmatic legacy directives with native atomStyle rules', () => {
+        const { layout } = layoutForSpec(specWithLegacy({
+            icons: [{ selector: 'n1', path: 'person', showLabels: false }],
+            atomStyles: [{ selector: 'n1', style: { fillStyle: { color: '#eef' } } }],
+        }));
+        const n = nodeById(layout, 'n1');
+        expect(n.icon).toBe(PERSON_ICON);
+        expect(n.fillColor).toBe('#eef');
+    });
+
+    it('drops selectorless / pathless entries rather than applying them globally', () => {
+        const { layout } = layoutForSpec(specWithLegacy({
+            icons: [
+                { selector: '', path: 'person', showLabels: false },
+                { selector: 'n1', path: '', showLabels: false },
+            ],
+            atomColors: [{ selector: '', color: '#f00' }],
+        }));
+        for (const id of ['n1', 'r1']) {
+            expect(nodeById(layout, id).icon).toBe('');
+            expect(nodeById(layout, id).color).not.toBe('#f00');
+        }
+    });
+
+    it('leaves a parsed spec untouched — normalization is a no-op and does not copy', () => {
+        const parsed = parseLayoutSpec('directives:\n  - atomStyle: { selector: n1, fillStyle: { color: "#eef" } }');
+        expect(normalizeLegacyDirectives(parsed)).toBe(parsed);
+    });
+
+    it('does not mutate the caller\'s spec object', () => {
+        const spec = specWithLegacy({ icons: [{ selector: 'n1', path: 'person', showLabels: false }] });
+        normalizeLegacyDirectives(spec);
+        expect(spec.directives.icons).toHaveLength(1); // caller's copy still intact
+        expect(spec.directives.atomStyles).toHaveLength(0);
     });
 });

--- a/tests/atom-style-render.test.ts
+++ b/tests/atom-style-render.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import { WebColaCnDGraph } from '../src/translators/webcola/webcola-cnd-graph';
 import { WebColaLayout } from '../src/translators/webcola/webcolatranslator';
+import { FALLBACK_ICON, resolveIconPath } from '../src/layout/icon-registry';
 
 const proto = WebColaCnDGraph.prototype as any;
 
@@ -64,6 +65,29 @@ describe('webcola-cnd-graph — node fill color', () => {
     it('stays transparent for a hidden node whatever its icon or fill', () => {
         const hidden = { ...base, isHiddenNode: () => true };
         expect(fill(hidden, { fillColor: '#eef', icon: 'x', iconPlacement: 'full' })).toBe('transparent');
+    });
+});
+
+describe('icon load failure fallback', () => {
+    it('is self-contained, not a path resolved against the host application', () => {
+        // A relative asset path (the old `img/default.png`) resolves against the
+        // consuming app, not this package, so it 404s for every library consumer
+        // and can fire a second error event. The fallback must need no network
+        // and no bundling.
+        expect(FALLBACK_ICON.startsWith('data:image/svg+xml')).toBe(true);
+        expect(FALLBACK_ICON).not.toMatch(/^(https?:)?\/\//);
+        expect(FALLBACK_ICON).not.toContain('img/default.png');
+    });
+
+    it('decodes to a drawable SVG', () => {
+        const decoded = decodeURIComponent(FALLBACK_ICON.replace(/^data:image\/svg\+xml,/, ''));
+        expect(decoded).toMatch(/^<svg[\s>]/);
+        expect(decoded).toContain('</svg>');
+    });
+
+    it('is not something resolveIconPath would rewrite', () => {
+        // It travels the same path as an authored icon, so it has to survive it.
+        expect(resolveIconPath(FALLBACK_ICON)).toBe(FALLBACK_ICON);
     });
 });
 

--- a/tests/atom-style-render.test.ts
+++ b/tests/atom-style-render.test.ts
@@ -18,7 +18,13 @@ const proto = WebColaCnDGraph.prototype as any;
 
 describe('webcola-cnd-graph — node fill color', () => {
     // A themed default canvas; nodeFillColor falls back to it when no fill is set.
-    const base = { isHiddenNode: () => false, getCanvasBackground: () => '#fafafa' };
+    // `isBadgeIcon` is the real predicate — the fill rule keys off icon placement,
+    // so stubbing it would test the stub rather than the precedence.
+    const base = {
+        isHiddenNode: () => false,
+        getCanvasBackground: () => '#fafafa',
+        isBadgeIcon: proto.isBadgeIcon,
+    };
     const fill = (thisArg: any, d: any) => proto.nodeFillColor.call(thisArg, d);
 
     it('uses an explicit atomStyle fill color', () => {
@@ -34,8 +40,68 @@ describe('webcola-cnd-graph — node fill color', () => {
         expect(fill(hidden, { fillColor: '#eef', showLabels: true })).toBe('transparent');
     });
 
-    it('stays transparent for an icon-only node (icon, labels hidden)', () => {
-        expect(fill(base, { fillColor: '#eef', icon: 'x', showLabels: false })).toBe('transparent');
+    it('stays transparent under a full-bleed icon, so a group hull shows through', () => {
+        expect(fill(base, { icon: 'x', iconPlacement: 'full', showLabels: false })).toBe('transparent');
+    });
+
+    it('treats a missing placement as full (the engine default)', () => {
+        expect(fill(base, { icon: 'x', showLabels: false })).toBe('transparent');
+    });
+
+    it('keeps a normal fill under a badge icon — only the box-filling placement goes transparent', () => {
+        expect(fill(base, { icon: 'x', iconPlacement: 'badge', showLabels: true })).toBe('#fafafa');
+        expect(fill(base, { fillColor: '#eef', icon: 'x', iconPlacement: 'badge', showLabels: true })).toBe('#eef');
+    });
+
+    it('lets an explicit fill win over a full-bleed icon', () => {
+        // Deliberate precedence change from the icon → atomStyle move: asking for a
+        // fill and a full-bleed icon together is now a coherent request (an icon on
+        // a tinted card) rather than a silently-discarded fill. Transparency is the
+        // *default* for that placement, not an override of an explicit choice.
+        expect(fill(base, { fillColor: '#eef', icon: 'x', iconPlacement: 'full', showLabels: false })).toBe('#eef');
+    });
+
+    it('stays transparent for a hidden node whatever its icon or fill', () => {
+        const hidden = { ...base, isHiddenNode: () => true };
+        expect(fill(hidden, { fillColor: '#eef', icon: 'x', iconPlacement: 'full' })).toBe('transparent');
+    });
+});
+
+describe('webcola-cnd-graph — icon geometry', () => {
+    // A 100×60 node centred at (200, 100); SMALL_IMG_SCALE_FACTOR is 0.3.
+    const d = (extra: Record<string, unknown> = {}) => ({
+        x: 200, y: 100, visualWidth: 100, visualHeight: 60, icon: 'x', ...extra,
+    });
+    const call = (fn: string, node: unknown, ...rest: unknown[]) =>
+        proto[fn].call(proto, node, ...rest);
+
+    it('sizes a full icon to the whole box and a badge to a fraction of it', () => {
+        expect(call('iconWidth', d({ iconPlacement: 'full' }))).toBe(100);
+        expect(call('iconHeight', d({ iconPlacement: 'full' }))).toBe(60);
+        expect(call('iconWidth', d({ iconPlacement: 'badge' }))).toBeCloseTo(30);
+        expect(call('iconHeight', d({ iconPlacement: 'badge' }))).toBeCloseTo(18);
+    });
+
+    it('anchors a full icon to the box origin and a badge to the top-right corner', () => {
+        expect(call('iconX', d({ iconPlacement: 'full' }))).toBe(150); // 200 - 100/2
+        expect(call('iconY', d({ iconPlacement: 'full' }))).toBe(70);  // 100 - 60/2
+        expect(call('iconX', d({ iconPlacement: 'badge' }))).toBeCloseTo(220); // 200 + 50 - 30
+        expect(call('iconY', d({ iconPlacement: 'badge' }))).toBe(70);  // both hug the top edge
+    });
+
+    it('honours a caller-supplied origin for a full icon but not for a badge', () => {
+        // The WebCola tick path passes bounds (which include layout padding) so the
+        // icon stays registered with the rect drawn from those same bounds.
+        expect(call('iconX', d({ iconPlacement: 'full' }), 111)).toBe(111);
+        expect(call('iconY', d({ iconPlacement: 'full' }), 222)).toBe(222);
+        expect(call('iconX', d({ iconPlacement: 'badge' }), 111)).toBeCloseTo(220);
+        expect(call('iconY', d({ iconPlacement: 'badge' }), 222)).toBe(70);
+    });
+
+    it('falls back to width/height when no visual size was recorded', () => {
+        const noVisual = { x: 0, y: 0, width: 80, height: 40, icon: 'x', iconPlacement: 'full' };
+        expect(call('iconWidth', noVisual)).toBe(80);
+        expect(call('iconHeight', noVisual)).toBe(40);
     });
 });
 

--- a/tests/deprecation-warnings.test.ts
+++ b/tests/deprecation-warnings.test.ts
@@ -68,6 +68,7 @@ describe('Deprecation warnings', () => {
         const cases: Array<[string, string]> = [
             ['atomColor', "directives:\n  - atomColor: { selector: Node, value: '#ff0000' }"],
             ['edgeColor', "directives:\n  - edgeColor: { field: next, value: '#111111' }"],
+            ['icon', 'directives:\n  - icon: { selector: Node, path: person }'],
             [
                 'inferredEdge',
                 "directives:\n  - inferredEdge: { name: n, selector: next, color: '#00ff00' }",

--- a/tests/icon-field.test.tsx
+++ b/tests/icon-field.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Coverage for the `iconPath` field kind — the built-in icon browser in the
+ * No Code builder.
+ *
+ * The contract the tests defend: the text input stays authoritative (an author
+ * can always type a URL, path, or pack reference, and picking never takes that
+ * away), the browser only ever offers icons that need no network, and CDN packs
+ * are presented as guidance rather than as unpreviewable thumbnails.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { FieldRenderer } from '../src/spec-editor/ui/FieldRenderer';
+import type { FieldSpec } from '../src/spec-editor/core/types';
+import { getDefinitions } from '../src/spec-editor';
+import {
+    getBundledIconNames,
+    getBundledIconSvg,
+    getIconPacks,
+    getIconPackPrefixes,
+    resolveIconPath,
+} from '../src/layout/icon-registry';
+
+const iconField: FieldSpec = {
+    key: 'path',
+    kind: 'iconPath',
+    label: 'Icon',
+    placeholder: 'e.g. person, bi:person-fill, https://…',
+};
+
+const openBrowser = (): void => {
+    fireEvent.click(screen.getByRole('button', { name: /browse built-in icons/i }));
+};
+
+describe('registry — atomStyle exposes the icon browser', () => {
+    it('registers iconStyle.path as an iconPath field, not plain text', () => {
+        const atomStyle = getDefinitions('directive').find((d) => d.type === 'atomStyle');
+        const iconStyle = atomStyle?.fields.find((f) => f.key === 'iconStyle');
+        const path = iconStyle?.children?.find((c) => c.key === 'path');
+        expect(path?.kind).toBe('iconPath');
+    });
+
+    it('keeps the block sparse — no seeded default on the icon path', () => {
+        const atomStyle = getDefinitions('directive').find((d) => d.type === 'atomStyle');
+        const iconStyle = atomStyle?.fields.find((f) => f.key === 'iconStyle');
+        for (const child of iconStyle?.children ?? []) {
+            expect(child.default).toBeUndefined();
+        }
+    });
+});
+
+describe('IconField — typing stays authoritative', () => {
+    it('edits freely, so URLs and pack references are unaffected by the picker', () => {
+        const onChange = vi.fn();
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={onChange} />);
+        const input = screen.getByRole('textbox');
+        fireEvent.change(input, { target: { value: 'https://example.com/x.svg' } });
+        expect(onChange).toHaveBeenCalledWith('path', 'https://example.com/x.svg');
+    });
+
+    it('does not open the browser unless asked', () => {
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={vi.fn()} />);
+        expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    it('previews a bundled value inline but not a remote one', () => {
+        const { rerender } = render(
+            <FieldRenderer fields={[iconField]} values={{ path: 'person' }} onChange={vi.fn()} />,
+        );
+        // Bundled icons inline as real SVG — no network, and the theme colour
+        // reaches them (see the currentColor test below).
+        const preview = document.querySelector('.spytial-ed-icon-preview');
+        expect(preview?.querySelector('svg')).toBeTruthy();
+
+        // A remote URL would need a round-trip (and would show a broken-image
+        // glyph inside the form if it failed), so it is deliberately not drawn.
+        rerender(
+            <FieldRenderer
+                fields={[iconField]}
+                values={{ path: 'https://example.com/x.svg' }}
+                onChange={vi.fn()}
+            />,
+        );
+        expect(document.querySelector('.spytial-ed-icon-preview')).toBeNull();
+    });
+});
+
+/**
+ * Regression guard for a bug found by sampling rendered pixels in a real
+ * browser: bundled glyphs are drawn with `fill="currentColor"`, and inside an
+ * `<img>` that resolves against the SVG document (initial colour black), not
+ * the page — so thumbnails came out pure black on the dark theme's near-black
+ * surface. Inlining the markup is what makes the colour cascade in.
+ */
+describe('IconField — bundled glyphs inherit the theme colour', () => {
+    it('inlines bundled markup rather than using <img>, so currentColor applies', () => {
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={vi.fn()} />);
+        openBrowser();
+        const cells = document.querySelectorAll('.spytial-ed-icon-cell');
+        expect(cells.length).toBeGreaterThan(0);
+        for (const cell of Array.from(cells)) {
+            expect(cell.querySelector('svg')).toBeTruthy();
+            // An <img> here would be the bug: it cannot inherit the theme colour.
+            expect(cell.querySelector('img')).toBeNull();
+        }
+    });
+
+    it('keeps currentColor in the inlined markup for the theme to drive', () => {
+        const svg = getBundledIconSvg('person');
+        expect(svg).toBeTruthy();
+        expect(svg).toContain('currentColor');
+        expect(svg!.startsWith('<svg')).toBe(true);
+    });
+
+    it('refuses to inline anything it did not author, which is what keeps it safe', () => {
+        // The component feeds only this function's output to dangerouslySetInnerHTML,
+        // so a value an author typed can never be inlined.
+        expect(getBundledIconSvg('https://evil.example/x.svg')).toBeUndefined();
+        expect(getBundledIconSvg('<script>alert(1)</script>')).toBeUndefined();
+        expect(getBundledIconSvg('bi:person-fill')).toBeUndefined();
+    });
+
+    it('round-trips: the inlined markup encodes back to the resolved data URI', () => {
+        for (const name of getBundledIconNames()) {
+            const svg = getBundledIconSvg(name)!;
+            expect(`data:image/svg+xml,${encodeURIComponent(svg)}`).toBe(resolveIconPath(name));
+        }
+    });
+});
+
+describe('IconField — the browser', () => {
+    it('offers every bundled icon', () => {
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={vi.fn()} />);
+        openBrowser();
+        const options = screen.getAllByRole('option');
+        expect(options).toHaveLength(getBundledIconNames().length);
+    });
+
+    it('writes the bundled NAME, not the resolved data URI, so the spec stays readable', () => {
+        const onChange = vi.fn();
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={onChange} />);
+        openBrowser();
+        fireEvent.click(screen.getByRole('option', { name: /(^|\s)person(\s|$)/i }));
+        expect(onChange).toHaveBeenCalledWith('path', 'person');
+    });
+
+    it('closes after a pick', () => {
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={vi.fn()} />);
+        openBrowser();
+        fireEvent.click(screen.getAllByRole('option')[0]);
+        expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    it('filters by name and explains an empty result instead of going blank', () => {
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={vi.fn()} />);
+        openBrowser();
+        const search = screen.getByLabelText(/filter bundled icons/i);
+
+        fireEvent.change(search, { target: { value: 'star' } });
+        const names = screen.getAllByRole('option').map((o) => o.getAttribute('title'));
+        expect(names.length).toBeGreaterThan(0);
+        expect(names.every((n) => n!.includes('star'))).toBe(true);
+
+        fireEvent.change(search, { target: { value: 'zzzznope' } });
+        expect(screen.queryAllByRole('option')).toHaveLength(0);
+        expect(screen.getByText(/no bundled icon matches/i)).toBeTruthy();
+    });
+
+    it('marks the current value as the selected option', () => {
+        render(<FieldRenderer fields={[iconField]} values={{ path: 'gear' }} onChange={vi.fn()} />);
+        openBrowser();
+        const selected = screen.getAllByRole('option').filter(
+            (o) => o.getAttribute('aria-selected') === 'true',
+        );
+        expect(selected).toHaveLength(1);
+        expect(selected[0].getAttribute('title')).toBe('gear');
+    });
+
+    it('lists CDN packs as guidance, without pretending to preview them', () => {
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={vi.fn()} />);
+        openBrowser();
+        const packs = document.querySelector('.spytial-ed-icon-packs') as HTMLElement;
+        expect(packs).toBeTruthy();
+        for (const p of getIconPacks()) {
+            expect(within(packs).getByText(`${p.prefix}:`)).toBeTruthy();
+        }
+        // No thumbnails in the pack section — they'd need a network round-trip.
+        expect(packs.querySelectorAll('img')).toHaveLength(0);
+    });
+
+    it('closes on Escape', () => {
+        render(<FieldRenderer fields={[iconField]} values={{}} onChange={vi.fn()} />);
+        openBrowser();
+        fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+        expect(screen.queryByRole('dialog')).toBeNull();
+    });
+});
+
+describe('icon-registry — pack metadata', () => {
+    it('labels every pack the resolver knows, so the two cannot drift', () => {
+        const described = getIconPacks().map((p) => p.prefix);
+        expect(described.sort()).toEqual(getIconPackPrefixes().sort());
+        for (const p of getIconPacks()) {
+            expect(p.label.length).toBeGreaterThan(0);
+            expect(p.label).not.toBe(p.prefix); // a real name, not the fallback
+        }
+    });
+
+    it('gives each pack an example that resolves to that pack’s CDN', () => {
+        for (const p of getIconPacks()) {
+            expect(p.example.startsWith(`${p.prefix}:`)).toBe(true);
+            expect(resolveIconPath(p.example)).toMatch(/^https:\/\//);
+        }
+    });
+});


### PR DESCRIPTION
## Why

The `icon` directive stood outside the style system. That cost three things:

1. **A bespoke conflict check.** `getNodeIconMap` hand-rolled an "Icon Conflict" throw comparing `path`/`showLabels` pairs — duplicating what the shared resolver's no-override rule already does, with worse messages.
2. **No inheritance.** An icon was all-or-nothing per directive. There was no way to say "every `Person` gets this icon, but `Admin`s show it more strongly."
3. **A duplicate selector path.** It re-ran the same evaluate → `acceptSelectorResult` → `recordSelectorError` sequence `getAtomStyleMap` already performs.

Underneath all of it, `showLabels` was one boolean driving four unrelated things: whether the label drew, the icon's size, the icon's position, and whether the node's box went transparent. Consolidating without splitting that would just have relocated the tangle.

## What changed

Icons resolve through `atomStyle` as an `iconStyle` block, and the conflated boolean becomes two orthogonal knobs:

- **`atomStyle.showLabel`** — a top-level behavior flag, mirroring the split `edgeStyle` already makes with its own `showLabel`. It applies with or without an icon, so an atom's label can now be hidden on its own.
- **`iconStyle.placement`** — `full` (the icon occupies the box) or `badge` (a small top-right marker).

`opacity` is new, and is what collapses what would otherwise be a third placement — a faded `full` icon behind a shown label is the watermark idiom.

```yaml
- atomStyle:
    selector: Person
    iconStyle: { path: person, opacity: 0.12 }
- atomStyle:
    selector: Admin
    iconStyle: { opacity: 0.35 }   # path inherited from the Person rule
```

That last rule is the capability the flat directive could not express: `path` is optional in the block and resolved at parse time, so the resolver compares canonical values and gap-fill inheritance falls out of ordinary selector matching.

The three idioms the grid now spells out — all documented:

| Idiom | Spec | Result |
|---|---|---|
| Glyph | `placement: full`, `showLabel: false` | The icon *is* the node |
| Badge | `placement: badge` | Small corner marker beside a normal labelled node |
| Watermark | `placement: full`, low `opacity` | Faded full-size icon behind the label |

## Back-compat

`icon` is deprecated — still parsed and rendered, one warning per spec — and desugars losslessly:

| legacy | becomes |
|---|---|
| `showLabels: false` (default) | `showLabel: false` + `placement: full` |
| `showLabels: true` | `showLabel: true` + `placement: badge` |

Desugaring `showLabel` **explicitly** is what lets the atomStyle surface default it to `true` like any other atom without changing what existing specs draw. A selectorless or pathless `icon` drew nothing before and is dropped rather than desugared — it must not become a graph-wide icon now that an absent `atomStyle` selector means "every atom".

## Legacy directives on programmatic specs

Caught in review. A `LayoutSpec` can reach the layout as an *object* — the `setupLayout(spec: LayoutSpec, ...)` overload, or `new LayoutInstance(spec)` — neither of which touches `parseLayoutSpec`. Because this PR removed the last reader of `directives.icons`, such a spec silently lost its icons.

Legacy directives are now desugared in the `LayoutInstance` constructor, so every entry point resolves identically; it is idempotent, returning a parsed spec untouched and uncopied. Two notes for reviewers:

- **`directives.atomColors` has the same hole and it pre-dates this PR** — nothing has read it since the legacy colour desugar landed in the 3.0 style work, so a programmatic `atomColor` has been silently ignored since then. Both are handled here rather than leaving the new helper ignoring half of what it names.
- **These arrays hold _parsed_ directives, not raw YAML.** `AtomColorDirective` spells its colour `color`; the YAML form that `atomColorToAtomStyleRule` consumes spells it `value`. Reusing that helper would have compiled cleanly and silently produced no border colour, so the mapping is written out, with a test naming the trap.

## One deliberate behavior change

An explicit `fillStyle.color` now **wins** over a full-bleed icon instead of being silently discarded. Asking for a fill and a full-bleed icon together is a coherent request (an icon on a tinted card); transparency is the *default* for that placement, not an override of an explicit choice. This broke one existing test, rewritten here to pin both halves.

## Incidental

- **Fixes a dead error handler, and the asset it pointed at.** In `setupNodeIcons`, `.on("error")` was chained after `.append("title")`, binding it to the `<title>` element — which never emits `error` — so the fallback for broken icon URLs never fired. Found while rewriting that function. Activating it exposed a second problem (caught in review): it pointed at `img/default.png`, which exists in neither the repo nor the published file list, and as a relative URL would have resolved against the consuming application rather than this package. The fallback is now an inlined data URI, with a guard against a fallback that somehow also failed looping on its own error event.
- **Migrates remaining pre-3.0 styling vocabulary in public surfaces.** The `@public` `DirectiveType` union gains `atomStyle`/`edgeStyle` with per-member `@deprecated` tags on all three legacy forms; the `atomColor`/`edgeColor` examples in the docs are migrated, including a live docs-site diagram that was rendering with deprecation warnings. Occurrences inside the sections documenting the deprecated directives themselves are left alone.

## Net

Deletions outweigh additions in the engine despite adding a feature: `getNodeIconMap` and its conflict check are gone, and the renderer's four-way duplicated icon geometry collapses into `iconWidth`/`iconHeight`/`iconX`/`iconY`.

## Testing

- **2154 tests pass** (148 files), including 28 new icon tests covering resolution, defaults, inheritance, collisions, the desugar mapping, end-to-end preservation of what each legacy form drew, and legacy directives arriving on a programmatic spec.
- The programmatic-spec tests were confirmed to fail without the constructor normalization, rather than assumed meaningful.
- Render tests extended to cover placement geometry, the fill-precedence rule, and that the icon fallback is self-contained.
- Typecheck at 73 errors — unchanged from the pre-existing baseline, none in touched files.
- The tic-tac-toe docs example (migrated to the new form) parses clean with no deprecation warning.

## Not included

`borderStyle.width` still rejects non-positive values, so a `placement: full` glyph always draws a box around itself. Not a regression — it's current behavior — but allowing `width: 0` or a `pattern: none` is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
